### PR TITLE
docs: update installation examples link

### DIFF
--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -48,7 +48,7 @@ Now that you have Comark installed, explore the documentation:
 - [Vue Rendering](/rendering/vue) - Render Comark in Vue
 - [React Rendering](/rendering/react) - Render Comark in React
 - [Parse API](/api/parse) - Detailed parsing options
-- [Examples](/getting-started/examples) - Real-world usage patterns
+- [Examples](/examples) - Real-world usage patterns
 
 ## Getting Help
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -7,7 +7,7 @@ seo:
 
 ::landing-hero
 #title
-Comark  
+Comark
 
 #description
 A high-performance markdown parser and renderer with Vue & React components support.


### PR DESCRIPTION
# Description

small PR to fix the broken link to `examples` in `installation`