### PR TITLE
feat: add nuxt devtools integration

### DIFF
--- a/packages/comark/src/nuxt/devtools.ts
+++ b/packages/comark/src/nuxt/devtools.ts
@@ -1,0 +1,20 @@
+import type { Nuxt } from 'nuxt/schema'
+
+const DEVTOOLS_URL = 'https://comark.dev/embed/devtools'
+
+export function setupDevTools(nuxt: Nuxt): void {
+  if (!nuxt.options.dev) return
+
+  // @ts-expect-error - hook exists
+  nuxt.hook('devtools:customTabs', (tabs) => {
+    tabs.push({
+      name: 'comark',
+      title: 'Comark',
+      icon: 'https://comark.dev/favicon.svg',
+      view: {
+        type: 'iframe',
+        src: DEVTOOLS_URL,
+      },
+    })
+  })
+}

--- a/packages/comark/src/nuxt/module.ts
+++ b/packages/comark/src/nuxt/module.ts
@@ -1,5 +1,6 @@
 import { defineNuxtModule, createResolver, addComponent, hasNuxtModule } from '@nuxt/kit'
 import type { Nuxt, NuxtModule } from 'nuxt/schema'
+import { setupDevTools } from './devtools'
 import fs from 'node:fs/promises'
 
 // Module options TypeScript interface definition
@@ -31,6 +32,9 @@ const module: NuxtModule<ComarkModuleOptions> = defineNuxtModule<ComarkModuleOpt
     if (hasNuxtModule('@nuxt/ui')) {
       setupNuxtUI(nuxt)
     }
+
+    // Set up Nuxt DevTools integration
+    setupDevTools(nuxt)
 
     // Register user global components
     const _layers = [...nuxt.options._layers].reverse()


### PR DESCRIPTION
closes #9 

this PR adds nuxt devtools integration by using the embeded page from docs. depends on #22 