### PR TITLE
perf: rewrite auto close login with ~4x performance improve

### DIFF
--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -110,8 +110,10 @@ Comark is ideal for:
 | Vue support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
 | React support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
 | No build step | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
+| Parse to AST | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
 | Compact AST | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
 | Auto-close for streams | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
+
 
 ## Key Features
 

--- a/packages/comark/benchmark.ts
+++ b/packages/comark/benchmark.ts
@@ -73,6 +73,7 @@ const markdownExit = new MarkdownExit({
   .use(pluginMdc)
 
 const comark = createParse()
+const comarkNoClose = createParse({ autoClose: false })
 
 // Benchmark: markdown-it parsing
 bench('markdown-it parse', () => {
@@ -86,6 +87,10 @@ bench('markdown-exit parse', () => {
 
 bench('comark parse', async () => {
   await comark(sampleMarkdown)
+})
+
+bench('comark parse no close', async () => {
+  await comarkNoClose(sampleMarkdown)
 })
 
 // Benchmark: markdown-it render

--- a/packages/comark/src/internal/parse/auto-close/index.ts
+++ b/packages/comark/src/internal/parse/auto-close/index.ts
@@ -129,7 +129,10 @@ export function autoCloseMarkdown(markdown: string): string {
     let lastOpenBrace = -1
     for (let i = finalLine.length - 1; i >= 0; i--) {
       if (finalLine[i] === '}') break
-      if (finalLine[i] === '{') { lastOpenBrace = i; break }
+      if (finalLine[i] === '{') {
+        lastOpenBrace = i
+        break
+      }
     }
     if (lastOpenBrace >= 0) {
       const propsContent = finalLine.slice(lastOpenBrace + 1)


### PR DESCRIPTION
Rewrite auto close logic to improve performance, the new linear loop is nearly 4 times performant than previous implementaion.

```
benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
new                         909.37 ns/iter 921.07 ns          █▆▃         
                      (850.57 ns … 1.08 µs) 977.08 ns        █████▇        
                    (210.68  b …   1.88 kb)   1.86 kb ▂▁▃▄█▆████████▆▃▂▁▁▁▃

old                            4.86 µs/iter   4.90 µs    █  ▄              
                        (4.64 µs … 5.54 µs)   5.29 µs   ▅██ █ █            
                    (588.10  b …   4.58 kb) 727.40  b ▅▁███▅█▅█▅▅▁▁▁▁▁█▁▁▁▅
```

&nbsp;