### PR TITLE
docs(landing): make it editable by studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ logs
 !.env.example
 
 .vscode
+.history

--- a/docs/app/components/landing/LandingCard.vue
+++ b/docs/app/components/landing/LandingCard.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+const props = defineProps<{
+  icon?: string
+  color?: 'primary' | 'purple' | 'green' | 'neutral' | 'red' | 'yellow' | 'blue' | 'orange' | 'pink' | 'teal' | 'cyan'
+}>()
+
+const colorMap = {
+  primary: { bg: 'bg-primary-500/10', text: 'text-primary-500' },
+  purple: { bg: 'bg-purple-500/10', text: 'text-purple-500' },
+  green: { bg: 'bg-green-500/10', text: 'text-green-500' },
+  neutral: { bg: 'bg-neutral-500/10', text: 'text-neutral-500' },
+  red: { bg: 'bg-red-500/10', text: 'text-red-500' },
+  yellow: { bg: 'bg-yellow-500/10', text: 'text-yellow-500' },
+  blue: { bg: 'bg-blue-500/10', text: 'text-blue-500' },
+  orange: { bg: 'bg-orange-500/10', text: 'text-orange-500' },
+  pink: { bg: 'bg-pink-500/10', text: 'text-pink-500' },
+  teal: { bg: 'bg-teal-500/10', text: 'text-teal-500' },
+  cyan: { bg: 'bg-cyan-500/10', text: 'text-cyan-500' },
+}
+
+const colors = computed(() => colorMap[props.color ?? 'primary'])
+</script>
+
+<template>
+  <UCard class="text-center">
+    <div
+      v-if="icon"
+      class="mb-3 flex justify-center"
+    >
+      <div
+        class="flex h-12 w-12 items-center justify-center rounded-lg"
+        :class="colors.bg"
+      >
+        <UIcon
+          :name="icon"
+          class="h-6 w-6"
+          :class="colors.text"
+        />
+      </div>
+    </div>
+    <h3 class="mb-2 font-semibold text-neutral-900 dark:text-white">
+      <slot
+        name="title"
+        mdc-unwrap="p"
+      />
+    </h3>
+    <p class="text-sm text-neutral-600 dark:text-neutral-400">
+      <slot
+        name="description"
+        mdc-unwrap="p"
+      />
+    </p>
+  </UCard>
+</template>

--- a/docs/app/components/landing/LandingCards.vue
+++ b/docs/app/components/landing/LandingCards.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="mt-12 grid gap-6 sm:grid-cols-3">
+    <slot />
+  </div>
+</template>

--- a/docs/app/components/landing/LandingCodeExample.vue
+++ b/docs/app/components/landing/LandingCodeExample.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+const activeTab = ref('vue')
+
+const tabs = [
+  { id: 'vue', label: 'Vue', icon: 'i-logos-vue' },
+  { id: 'react', label: 'React', icon: 'i-logos-react' },
+]
+</script>
+
+<template>
+  <div>
+    <div class="flex flex-wrap gap-2 mb-6 justify-center">
+      <UButton
+        v-for="tab in tabs"
+        :key="tab.id"
+        :variant="activeTab === tab.id ? 'solid' : 'soft'"
+        color="neutral"
+        :icon="tab.icon"
+        @click="activeTab = tab.id"
+      >
+        {{ tab.label }}
+      </UButton>
+    </div>
+    <div v-show="activeTab === 'vue'">
+      <slot name="vue" />
+    </div>
+    <div v-show="activeTab === 'react'">
+      <slot name="react" />
+    </div>
+  </div>
+</template>

--- a/docs/app/components/landing/LandingSubHero.vue
+++ b/docs/app/components/landing/LandingSubHero.vue
@@ -1,0 +1,51 @@
+<template>
+  <UPageHero
+    :ui="{
+      container: 'py-24',
+      title: 'text-3xl sm:text-4xl font-bold tracking-tight text-highlighted',
+      description: 'text-lg text-muted',
+      body: 'mx-auto max-w-4xl text-left',
+      footer: 'mx-auto max-w-4xl text-left',
+    }"
+  >
+    <template
+      v-if="$slots.headline"
+      #headline
+    >
+      <UBadge
+        variant="subtle"
+        size="lg"
+        class="mb-4"
+      >
+        <template #leading>
+          <UIcon
+            name="i-lucide-zap"
+            class="h-4 w-4"
+          />
+        </template>
+        <slot
+          name="headline"
+          mdc-unwrap="p"
+        />
+      </UBadge>
+    </template>
+    <template #title>
+      <slot
+        name="title"
+        mdc-unwrap="p"
+      />
+    </template>
+    <template #description>
+      <slot
+        name="description"
+        mdc-unwrap="p"
+      />
+    </template>
+    <template #body>
+      <slot name="body" />
+    </template>
+    <template #footer>
+      <slot name="footer" />
+    </template>
+  </UPageHero>
+</template>

--- a/docs/app/utils/components-manifest.ts
+++ b/docs/app/utils/components-manifest.ts
@@ -5,7 +5,9 @@ import { localComponents } from '#content/components'
 const components = {
   // Landing components
   LandingHero: () => import('@/components/landing/LandingHero.vue'),
-  LandingGetStarted: () => import('@/components/landing/LandingGetStarted.vue'),
+  LandingSubHero: () => import('@/components/landing/LandingSubHero.vue'),
+  LandingCards: () => import('@/components/landing/LandingCards.vue'),
+  LandingCard: () => import('@/components/landing/LandingCard.vue'),
   LandingTypography: () => import('@/components/landing/LandingTypography.vue'),
   LandingCodeBlock: () => import('@/components/landing/LandingCodeBlock.vue'),
   LandingCjk: () => import('@/components/landing/LandingCjk.vue'),

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -2,7 +2,7 @@
 seo:
   title: Markdown with Components
   description: Fast, streaming-ready markdown parser with Vue and React component support. Parse Comark content from strings or streams with TypeScript support.
-  ogImage: '/social-card.png'
+  ogImage: /social-card.png
 ---
 
 ::landing-hero
@@ -35,7 +35,91 @@ A high-performance markdown parser and renderer with Vue & React components supp
   :::
 ::
 
-:landing-get-started
+::landing-sub-hero
+#headline
+Get Started in Seconds
+
+#title
+Simple to use, powerful features
+
+#description
+Install with npm and start parsing markdown in seconds
+
+#body
+  :::landing-code-example
+  #vue
+  ```vue [src/App.vue]
+  <script setup lang="ts">
+  import { Comark } from 'comark/vue'
+  import Alert from './components/Alert.vue'
+
+  const md = `
+  # [Hello *World*]{.text-5xl}
+
+  ::alert{type="info"}
+  This is an alert!
+  ::
+  `
+  </script>
+
+  <template>
+    <Suspense>
+      <Comark :components="{ Alert }">{{ md }}</Comark>
+    </Suspense>
+  </template>
+  ```
+
+  #react
+  ```tsx [src/App.tsx]
+  import { Comark } from 'comark/react'
+
+  export default function App() {
+    const markdown = `# Hello **World**`
+
+    return <Comark>{markdown}</Comark>
+  }
+  ```
+  :::
+
+#footer
+  :::landing-cards
+    ::::landing-card
+    ---
+    color: primary
+    icon: i-lucide-zap
+    ---
+    #title
+    Zero Config
+
+    #description
+    Works out of the box with sensible defaults
+    ::::
+
+    ::::landing-card
+    ---
+    color: purple
+    icon: i-simple-icons-typescript
+    ---
+    #title
+    Type Safe
+
+    #description
+    Full TypeScript support with type definitions
+    ::::
+
+    ::::landing-card
+    ---
+    color: green
+    icon: i-lucide-shield-check
+    ---
+    #title
+    Framework Agnostic
+
+    #description
+    Use with React, Vue, or vanilla JavaScript
+    ::::
+  :::
+::
 
 ::u-page-section
 #title


### PR DESCRIPTION
Replace hard coded content in vue page into mdc syntax to make it editable by Studio.

https://github.com/user-attachments/assets/a853e981-ccd2-4292-9ce0-310309be8278

The main idea was to create a new skill on Studio: https://github.com/nuxt-content/nuxt-studio/pull/364 to help users make their content editable with Nuxt Studio. 

@HugoRCD 

