### PR TITLE
fix(parse): ensure task-list and alert are enabled by default

### DIFF
--- a/packages/comark/SPEC/GFM/alert.md
+++ b/packages/comark/SPEC/GFM/alert.md
@@ -1,6 +1,6 @@
 ---
 timeout:
-  parse: 6ms
+  parse: 15ms
   html: 5ms
   markdown: 5ms
 ---

--- a/packages/comark/src/index.ts
+++ b/packages/comark/src/index.ts
@@ -55,7 +55,7 @@ export function createParse(options: ParseOptions = {}): ComarkParseFn {
     .enable(['table', 'strikethrough'])
     .use(pluginMdc)
 
-  for (const plugin of options.plugins || []) {
+  for (const plugin of plugins) {
     for (const markdownItPlugin of (plugin.markdownItPlugins || [])) {
       parser.use(markdownItPlugin)
     }

--- a/packages/comark/test/roundtrip.test.ts
+++ b/packages/comark/test/roundtrip.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { parse } from '../src/index'
+import { renderMarkdown } from '../src/string'
+
+describe('MDC roundtrip', () => {
+  const roundtrip = async (input: string) => {
+    const ast = await parse(input)
+    return renderMarkdown(ast)
+  }
+
+  describe('task list', () => {
+    it('preserves checked and unchecked items', async () => {
+      const input = `- [x] Todo done\n- [ ] Todo`
+
+      const output = await roundtrip(input)
+      expect(output).toBe(input)
+    })
+  })
+})


### PR DESCRIPTION
The `createParse` function was iterating over `options.plugins` instead of the resolved plugins array, causing built-in plugins (task-list, alert) to be silently skipped.

**Changes:**

- Fix `createParse` to iterate over plugins (the merged list) instead of options.plugins || []
- Add a roundtrip test suite (roundtrip.test.ts) =>  `(parse(input) → renderMarkdown(ast) === input)` 
- Bump alert spec parse timeout to accommodate the now-active plugin

**NB:**
The roundtrip test pattern provides a lightweight but more robust serialization check.
It differs from `index.test.ts` tests that test each stage in isolation using fixed snapshots, the render tests consume a hardcoded AST, so a broken parse won't affect them. The new `roundtrip.test.ts` instead pipes the full chain (parse → renderMarkdown) and asserts the output matches the original input. 

@farnabaz @atinux  I'm questioning the `index.test.ts` implementation. I think it should at least use the parsedAST for the markdown renderer call and not the hardcoded => #37 
