### PR TITLE
test(spec): use parsed AST to detect keys order mismatch

### DIFF
--- a/packages/comark/SPEC/GFM/task-list-multiple.md
+++ b/packages/comark/SPEC/GFM/task-list-multiple.md
@@ -34,9 +34,9 @@ timeout:
           "input",
           {
             "class": "task-list-item-checkbox",
-            ":checked": "true",
+            "type": "checkbox",
             ":disabled": "true",
-            "type": "checkbox"
+            ":checked": "true"
           }
         ],
         " Done"
@@ -50,9 +50,9 @@ timeout:
           "input",
           {
             "class": "task-list-item-checkbox",
-            ":checked": "true",
+            "type": "checkbox",
             ":disabled": "true",
-            "type": "checkbox"
+            ":checked": "true"
           }
         ],
         " Done"
@@ -82,13 +82,13 @@ timeout:
 ```html
 <ul class="contains-task-list">
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" checked disabled type="checkbox" /> Done
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Done
   </li>
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" checked disabled type="checkbox" /> Done
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Done
   </li>
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" disabled type="checkbox" /> todo
+    <input class="task-list-item-checkbox" type="checkbox" disabled /> todo
   </li>
 </ul>
 ```

--- a/packages/comark/SPEC/GFM/task-list.md
+++ b/packages/comark/SPEC/GFM/task-list.md
@@ -33,9 +33,9 @@ timeout:
           "input",
           {
             "class": "task-list-item-checkbox",
-            ":checked": "true",
+            "type": "checkbox",
             ":disabled": "true",
-            "type": "checkbox"
+            ":checked": "true"
           }
         ],
         " Done"
@@ -65,10 +65,10 @@ timeout:
 ```html
 <ul class="contains-task-list">
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" checked disabled type="checkbox" /> Done
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Done
   </li>
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" disabled type="checkbox" /> todo
+    <input class="task-list-item-checkbox" type="checkbox" disabled /> todo
   </li>
 </ul>
 ```

--- a/packages/comark/SPEC/MDC/component-with-codeblock.md
+++ b/packages/comark/SPEC/MDC/component-with-codeblock.md
@@ -42,8 +42,8 @@ options:
       [
         "pre",
         {
-          "filename": "content/index.md",
-          "language": "mdc"
+          "language": "mdc",
+          "filename": "content/index.md"
         },
         [
           "code",
@@ -62,7 +62,7 @@ options:
 
 ```html
 <code-group>
-  <pre filename="content/index.md" language="mdc"><code class="language-mdc">---
+  <pre language="mdc" filename="content/index.md"><code class="language-mdc">---
   title: The Mountains Website
   description: A website about the most iconic mountains in the world.
   ---

--- a/packages/comark/SPEC/MDC/frontmatter-basic.md
+++ b/packages/comark/SPEC/MDC/frontmatter-basic.md
@@ -20,8 +20,8 @@ description: My Description
 ```json
 {
   "frontmatter": {
-    "description": "My Description",
-    "title": "My Title"
+    "title": "My Title",
+    "description": "My Description"
   },
   "meta": {},
   "nodes": [
@@ -46,8 +46,8 @@ description: My Description
 
 ```md
 ---
-description: My Description
 title: My Title
+description: My Description
 ---
 
 # Content

--- a/packages/comark/SPEC/MDC/frontmatter-multiple-fields.md
+++ b/packages/comark/SPEC/MDC/frontmatter-multiple-fields.md
@@ -24,13 +24,13 @@ Content here
 ```json
 {
   "frontmatter": {
+    "title": "Test Post",
     "author": "John Doe",
     "date": "2024-01-01",
     "tags": [
       "test",
       "markdown"
-    ],
-    "title": "Test Post"
+    ]
   },
   "meta": {},
   "nodes": [
@@ -53,12 +53,12 @@ Content here
 
 ```md
 ---
+title: Test Post
 author: John Doe
 date: '2024-01-01'
 tags:
   - test
   - markdown
-title: Test Post
 ---
 
 Content here

--- a/packages/comark/SPEC/MDC/shiki-codeblock-language-meta.md
+++ b/packages/comark/SPEC/MDC/shiki-codeblock-language-meta.md
@@ -31,12 +31,11 @@ console.log(greeting)
       {
         "language": "typescript",
         "filename": "filename",
-        "meta": "some meta",
-        "filename": "filename",
         "highlights": [
           1,
           2
         ],
+        "meta": "some meta",
         "class": "shiki github-dark",
         "tabindex": "0",
         "style": "background-color:#24292e;color:#e1e4e8"
@@ -159,7 +158,7 @@ console.log(greeting)
 ## HTML
 
 ```html
-<pre language="typescript" filename="filename" meta="some meta" highlights="[1,2]" class="shiki github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-typescript"><span class="line highlight"><span style="color:#F97583">const</span><span style="color:#E1E4E8"> </span><span style="color:#79B8FF">greeting</span><span style="color:#F97583">:</span><span style="color:#E1E4E8"> </span><span style="color:#79B8FF">string</span><span style="color:#E1E4E8"> </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> </span><span style="color:#9ECBFF">"Hello, World!"</span></span>
+<pre language="typescript" filename="filename" highlights="[1,2]" meta="some meta" class="shiki github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-typescript"><span class="line highlight"><span style="color:#F97583">const</span><span style="color:#E1E4E8"> </span><span style="color:#79B8FF">greeting</span><span style="color:#F97583">:</span><span style="color:#E1E4E8"> </span><span style="color:#79B8FF">string</span><span style="color:#E1E4E8"> </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> </span><span style="color:#9ECBFF">"Hello, World!"</span></span>
 <span class="line highlight"><span style="color:#E1E4E8">console.</span><span style="color:#B392F0">log</span><span style="color:#E1E4E8">(greeting)</span></span></code></pre>
 ```
 

--- a/packages/comark/test/index.test.ts
+++ b/packages/comark/test/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll } from 'vitest'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { parseFrontmatter } from '../src/internal/front-matter'
@@ -173,7 +173,9 @@ describe('Comark Tests', () => {
 
   testCases.forEach(({ file, testCase }) => {
     describe(file, () => {
-      it('should parse input to AST', { timeout: testCase.timeouts?.parse ?? 5000 }, async () => {
+      let parsedAST: Awaited<ReturnType<typeof parse>>
+
+      beforeAll(async () => {
         const plugins: ComarkPlugin[] = [cjk(), emoji()]
         if (testCase.options?.highlight) {
           const themes = {
@@ -191,31 +193,27 @@ describe('Comark Tests', () => {
             },
           }))
         }
-        const result = await parse(testCase.input, {
+        parsedAST = await parse(testCase.input, {
           autoUnwrap: false,
           ...testCase.options,
           plugins,
         })
-        const expectedAST = JSON.parse(testCase.ast)
+      }, testCase.timeouts?.parse ?? 5000)
 
-        expect(result).toEqual(expectedAST)
+      it('should parse input to AST', () => {
+        const expectedAST = JSON.parse(testCase.ast)
+        expect(parsedAST).toEqual(expectedAST)
       })
 
       it('should render AST to HTML', { timeout: testCase.timeouts?.html ?? 5000 }, () => {
-        const ast = JSON.parse(testCase.ast)
-        const result = renderHTML(ast)
+        const result = renderHTML(parsedAST)
         const expectedHTML = testCase.html.trim()
-
-        // Tests will fail until implementation is complete
         expect(result).toBe(expectedHTML)
       })
 
       it('should render AST to Markdown', { timeout: testCase.timeouts?.markdown ?? 5000 }, () => {
-        const ast = JSON.parse(testCase.ast)
-        const result = renderMarkdown(ast)
+        const result = renderMarkdown(parsedAST)
         const expectedMarkdown = testCase.markdown.trim()
-
-        // Tests will fail until implementation is complete
         expect(result).toBe(expectedMarkdown)
       })
     })


### PR DESCRIPTION
The SPEC tests for HTML and Markdown rendering were using the stored AST snapshot instead of the actual `parse()` output. Since toEqual ignores key order, ordering mismatches between `parse()` and the snapshot went undetected

The AST test passed, but the rendering tests never saw what `parse()` really produced.

Fix: move `parse()` into a beforeAll shared across all blocks, so HTML and Markdown are rendered from the actual parse output.

This exposed stale snapshots in 6 SPEC files (wrong attribute order in HTML, wrong key order in frontmatter, duplicate key in AST) which are corrected in this PR.

