### PR TITLE
feat(props): standardize boolean

### DIFF
--- a/packages/comark/SPEC/MDC/component-nested4.md
+++ b/packages/comark/SPEC/MDC/component-nested4.md
@@ -97,7 +97,7 @@ timeout:
             "button",
             {
               ":data-testid": "$doc.snippet.description",
-              "external": "true",
+              ":external": "true",
               ":to": "$doc.snippet.link",
               "appearance": "primary"
             },

--- a/packages/comark/SPEC/MDC/component-nested4.md
+++ b/packages/comark/SPEC/MDC/component-nested4.md
@@ -129,7 +129,7 @@ timeout:
       <button to="$doc.snippet.link" appearance="primary">
         Button Text
       </button>
-      <button data-testid="$doc.snippet.description" external="true" to="$doc.snippet.link" appearance="primary">
+      <button data-testid="$doc.snippet.description" external to="$doc.snippet.link" appearance="primary">
         Button Text
       </button>
     </template>

--- a/packages/comark/SPEC/MDC/component-props-boolean-inline.md
+++ b/packages/comark/SPEC/MDC/component-props-boolean-inline.md
@@ -1,0 +1,50 @@
+---
+timeout:
+  parse: 5ms
+  html: 5ms
+  markdown: 5ms
+---
+
+## Input
+
+```md
+::my-component{:block :square="false" :disabled="true"}
+My button
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "my-component",
+      {
+        ":block": "true",
+        ":disabled": "true",
+        ":square": "false"
+      },
+      "My button"
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<my-component block square="false" disabled>
+  My button
+</my-component>
+```
+
+## Markdown
+
+```md
+::my-component{block :square="false" disabled}
+My button
+::
+```

--- a/packages/comark/SPEC/MDC/component-props-boolean-inline.md
+++ b/packages/comark/SPEC/MDC/component-props-boolean-inline.md
@@ -3,12 +3,14 @@ timeout:
   parse: 5ms
   html: 5ms
   markdown: 5ms
+options:
+  maxInlineAttributes: 4
 ---
 
 ## Input
 
 ```md
-::my-component{:block :square="false" :disabled="true"}
+::my-component{:block reverse :square="false" :disabled="true"}
 My button
 ::
 ```
@@ -24,6 +26,7 @@ My button
       "my-component",
       {
         ":block": "true",
+        ":reverse": "true",
         ":disabled": "true",
         ":square": "false"
       },
@@ -36,7 +39,7 @@ My button
 ## HTML
 
 ```html
-<my-component block square="false" disabled>
+<my-component block reverse square="false" disabled>
   My button
 </my-component>
 ```
@@ -44,7 +47,7 @@ My button
 ## Markdown
 
 ```md
-::my-component{block :square="false" disabled}
+::my-component{block reverse :square="false" disabled}
 My button
 ::
 ```

--- a/packages/comark/SPEC/MDC/component-props-boolean-yaml.md
+++ b/packages/comark/SPEC/MDC/component-props-boolean-yaml.md
@@ -10,7 +10,7 @@ options:
 ## Input
 
 ```md
-::my-component{:block :square="false" :disabled="true"}
+::my-component{:block reverse :square="false" :disabled="true"}
 My button
 ::
 ```
@@ -26,6 +26,7 @@ My button
       "my-component",
       {
         ":block": "true",
+        ":reverse": "true",
         ":square": "false",
         ":disabled": "true"
       },
@@ -38,7 +39,7 @@ My button
 ## HTML
 
 ```html
-<my-component block square="false" disabled>
+<my-component block reverse square="false" disabled>
   My button
 </my-component>
 ```
@@ -49,6 +50,7 @@ My button
 ::my-component
 ---
 block: true
+reverse: true
 square: false
 disabled: true
 ---

--- a/packages/comark/SPEC/MDC/component-props-boolean-yaml.md
+++ b/packages/comark/SPEC/MDC/component-props-boolean-yaml.md
@@ -1,0 +1,57 @@
+---
+timeout:
+  parse: 5ms
+  html: 5ms
+  markdown: 5ms
+options:
+  maxInlineAttributes: 0
+---
+
+## Input
+
+```md
+::my-component{:block :square="false" :disabled="true"}
+My button
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "my-component",
+      {
+        ":block": "true",
+        ":square": "false",
+        ":disabled": "true"
+      },
+      "My button"
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<my-component block square="false" disabled>
+  My button
+</my-component>
+```
+
+## Markdown
+
+```md
+::my-component
+---
+block: true
+square: false
+disabled: true
+---
+My button
+::
+```

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -311,7 +311,7 @@ function processBlockToken(tokens: any[], startIndex: number, insideNestedContex
   // Handle Comark block components (e.g., ::component ... ::)
   if (token.type === 'mdc_block_open') {
     const componentName = token.tag || 'component'
-    const attrs = processAttributes(token.attrs, { handleBoolean: false })
+    const attrs = processAttributes(token.attrs)
     // Process children until mdc_block_close, handling slots (#slotname)
     const children = processBlockChildrenWithSlots(tokens, startIndex + 1, 'mdc_block_close')
     // Return the component even if it has no children (empty component like ::component\n::)

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -75,7 +75,8 @@ function processAttributes(
 
   for (const attr of attrsArray) {
     if (Array.isArray(attr) && attr.length >= 2) {
-      let [key, value] = attr
+      const [key] = attr
+      let value = attr[1]
 
       // Filter empty values if requested
       if (filterEmpty && (value === '' || value === null || value === undefined)) {
@@ -84,8 +85,8 @@ function processAttributes(
 
       // Handle boolean attributes: {bool} -> {":bool": "true"}
       if (handleBoolean && !key.startsWith(':') && !key.startsWith('#') && !key.startsWith('.') && (!value || value === 'true' || value === '')) {
-        key = `:${key}`
-        value = 'true'
+        attrs[`:${key}`] = 'true'
+        continue
       }
 
       // Handle JSON values

--- a/packages/comark/src/internal/stringify/attributes.ts
+++ b/packages/comark/src/internal/stringify/attributes.ts
@@ -44,9 +44,10 @@ export function htmlAttributes(attributes: Record<string, unknown>) {
         if (value === 'true') {
           return key.slice(1)
         }
-
         return `${key.slice(1)}="${value}"`
       }
+
+      if (value === 'true') return key
 
       if (typeof value === 'object') {
         return `${key}="${JSON.stringify(value).replace(/"/g, '\\"')}"`
@@ -64,5 +65,14 @@ export function htmlAttributes(attributes: Record<string, unknown>) {
  * @returns The stringified attributes
  */
 export function comarkYamlAttributes(attributes: Record<string, unknown>) {
-  return `---\n${stringifyYaml(attributes).trim()}\n---`
+  // Normalize boolean attributes to remove the colon prefix
+  const normalized = Object.fromEntries(
+    Object.entries(attributes).map(([key, value]) => {
+      if (key.startsWith(':') && (value === 'true' || value === 'false')) {
+        return [key.slice(1), value]
+      }
+      return [key, value]
+    }),
+  )
+  return `---\n${stringifyYaml(normalized).trim()}\n---`
 }

--- a/packages/comark/src/internal/yaml.ts
+++ b/packages/comark/src/internal/yaml.ts
@@ -18,9 +18,8 @@ export function stringifyYaml(data: Record<string, unknown>): string {
   const yamlOutput = dump(data, {
     indent: 2,
     replacer: (_key, value) => {
-      if (value === 'true' || value === 'false') {
-        return Boolean(value)
-      }
+      if (value === 'true') return true
+      if (value === 'false') return false
       return value
     },
   })


### PR DESCRIPTION
Add support for bound boolean props in MDC block components and fix attribute stringification across HTML and YAML renderers.

