### PR TITLE
fix: finalize highlight behavior

### DIFF
--- a/examples/1.frameworks/nextjs/lib/posts.ts
+++ b/examples/1.frameworks/nextjs/lib/posts.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { parse } from 'comark'
 import type { ComarkTree } from 'comark'
-import highlight from 'comark/plugins/highlight'
+import highlight from '@comark/react/plugins/highlight'
 
 export interface PostMeta {
   slug: string

--- a/examples/2.vite/html/src/main.ts
+++ b/examples/2.vite/html/src/main.ts
@@ -1,5 +1,5 @@
 import { createRender } from '@comark/html'
-import highlight from 'comark/plugins/highlight'
+import highlight from '@comark/html/plugins/highlight'
 import math, { Math } from '@comark/html/plugins/math'
 import mermaid, { Mermaid } from '@comark/html/plugins/mermaid'
 import katexCss from 'katex/dist/katex.min.css?raw'
@@ -26,7 +26,7 @@ Links look like this: [comark.dev](https://comark.dev)
 
 ## Code Block
 
-\`\`\`typescript [main.ts]
+\`\`\`typescript [main.ts] {1,3}
 import { render } from '@comark/html'
 
 const html = await render('# Hello World')

--- a/examples/2.vite/html/src/preview.css
+++ b/examples/2.vite/html/src/preview.css
@@ -33,7 +33,7 @@ code {
 pre {
   background: #0d1117;
   border-radius: 6px;
-  padding: 16px;
+  padding: 1rem;
   overflow-x: auto;
   margin: 0 0 16px;
 }
@@ -44,15 +44,10 @@ pre code {
   font-size: 85%;
   white-space: pre;
 }
-.shiki span.line {
-  display: block;
-}
-.shiki span.line:empty {
-  height: 1lh;
-}
 .shiki span.line.highlight {
+  display: inline-block;
   background-color: rgba(255, 255, 0, 0.1);
-  display: block;
+  width: calc(100% + 2rem);
   margin: 0 -1rem;
   padding: 0 1rem;
 }

--- a/examples/2.vite/svelte/src/index.css
+++ b/examples/2.vite/svelte/src/index.css
@@ -25,7 +25,8 @@ body {
 }
 .shiki span.line.highlight {
   background-color: rgba(255, 255, 0, 0.1);
-  display: block;
+  display: inline-block;
+  width: calc(100% + 2rem);
   margin: 0 -1rem;
   padding: 0 1rem;
 }

--- a/packages/comark-ansi/src/handlers/pre.ts
+++ b/packages/comark-ansi/src/handlers/pre.ts
@@ -44,7 +44,7 @@ function renderHighlighted(codeNode: ComarkElement, colors: boolean): string {
     if (child[0] !== 'span') return ''
     // span.line — render its token children
     return (child.slice(2) as ComarkNode[]).map(t => renderToken(t, colors)).join('')
-  }).join('\n')
+  }).join('')
 }
 
 // --- Handler ---

--- a/packages/comark-ansi/src/index.ts
+++ b/packages/comark-ansi/src/index.ts
@@ -2,7 +2,7 @@ import type { ParseOptions, RenderOptions } from 'comark'
 import { createParse } from 'comark'
 import { renderANSI } from './render.ts'
 
-export { renderANSI, RenderANSIOptions } from './render.ts'
+export { renderANSI, type RenderANSIOptions } from './render.ts'
 
 function defaultWrite(string: string) {
   if (typeof process !== 'undefined') {

--- a/packages/comark-ansi/test/index.test.ts
+++ b/packages/comark-ansi/test/index.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { parse } from 'comark'
+import highlight from 'comark/plugins/highlight'
+import githubDark from 'shiki/dist/themes/github-dark.mjs'
 import { renderANSI, createLog, log } from '../src/index'
 
 // Helpers
@@ -159,6 +161,65 @@ describe('renderANSI', () => {
       const out = await plain('```ts [app.ts]\nconst x = 1\n```')
       expect(out).toContain('app.ts')
       expect(out).toContain('const x = 1')
+    })
+  })
+
+  describe('code highlight', () => {
+    const highlightPlugin = highlight({
+      themes: { light: githubDark, dark: githubDark },
+    })
+
+    async function highlighted(markdown: string, colors = false) {
+      const tree = await parse(markdown, { plugins: [highlightPlugin] })
+      return renderANSI(tree, { colors })
+    }
+
+    it('renders highlighted code with ANSI true-color sequences', async () => {
+      const out = await highlighted('```js\nconst x = 1\n```', true)
+      // Should contain true-color ANSI escape (38;2;r;g;b)
+      expect(out).toMatch(/\x1B\[38;2;\d+;\d+;\d+m/)
+      expect(out).toContain('const')
+      expect(out).toContain('x')
+    })
+
+    it('renders highlighted code without ANSI true-color when colors disabled', async () => {
+      const out = await highlighted('```js\nconst x = 1\n```', false)
+      // No true-color sequences in token output
+      expect(out).not.toMatch(/\x1B\[38;2;\d+;\d+;\d+m/)
+      expect(out).toContain('const')
+      expect(out).toContain('x')
+    })
+
+    it('renders multi-line highlighted code', async () => {
+      const out = await highlighted('```js\nconst a = 1\nconst b = 2\n```', false)
+      expect(out).toContain('const a = 1')
+      expect(out).toContain('const b = 2')
+    })
+
+    it('renders highlighted code with language header', async () => {
+      const out = await highlighted('```typescript\nlet x = 1\n```', false)
+      expect(out).toContain('typescript')
+      expect(out).toContain('let')
+    })
+
+    it('renders highlighted code with line highlights', async () => {
+      const out = await highlighted('```js {1}\nconst a = 1\n\nconst b = 2\n```', false)
+      expect(out).toContain('const a = 1')
+      expect(out).toContain('const b = 2')
+      expect(out).toBe("```\u001b[1m\u001b[36mjs\u001b[0m\nconst a = 1\n\nconst b = 2\n```\n")
+    })
+
+    it('each token gets its own color escape', async () => {
+      const out = await highlighted('```js\nfunction hello() {}\n```', true)
+      // Multiple color codes for different tokens (keyword, name, punctuation)
+      const colorMatches = out.match(/\x1B\[38;2;\d+;\d+;\d+m/g)
+      expect(colorMatches).not.toBeNull()
+      expect(colorMatches!.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('resets color after each token', async () => {
+      const out = await highlighted('```js\nconst x = 1\n```', true)
+      expect(out).toContain('\x1B[0m') // RESET
     })
   })
 

--- a/packages/comark-ansi/test/index.test.ts
+++ b/packages/comark-ansi/test/index.test.ts
@@ -177,6 +177,7 @@ describe('renderANSI', () => {
     it('renders highlighted code with ANSI true-color sequences', async () => {
       const out = await highlighted('```js\nconst x = 1\n```', true)
       // Should contain true-color ANSI escape (38;2;r;g;b)
+      // eslint-disable-next-line no-control-regex
       expect(out).toMatch(/\x1B\[38;2;\d+;\d+;\d+m/)
       expect(out).toContain('const')
       expect(out).toContain('x')
@@ -185,6 +186,7 @@ describe('renderANSI', () => {
     it('renders highlighted code without ANSI true-color when colors disabled', async () => {
       const out = await highlighted('```js\nconst x = 1\n```', false)
       // No true-color sequences in token output
+      // eslint-disable-next-line no-control-regex
       expect(out).not.toMatch(/\x1B\[38;2;\d+;\d+;\d+m/)
       expect(out).toContain('const')
       expect(out).toContain('x')
@@ -206,12 +208,13 @@ describe('renderANSI', () => {
       const out = await highlighted('```js {1}\nconst a = 1\n\nconst b = 2\n```', false)
       expect(out).toContain('const a = 1')
       expect(out).toContain('const b = 2')
-      expect(out).toBe("```\u001b[1m\u001b[36mjs\u001b[0m\nconst a = 1\n\nconst b = 2\n```\n")
+      expect(out).toBe('```\u001B[1m\u001B[36mjs\u001B[0m\nconst a = 1\n\nconst b = 2\n```\n')
     })
 
     it('each token gets its own color escape', async () => {
       const out = await highlighted('```js\nfunction hello() {}\n```', true)
       // Multiple color codes for different tokens (keyword, name, punctuation)
+      // eslint-disable-next-line no-control-regex
       const colorMatches = out.match(/\x1B\[38;2;\d+;\d+;\d+m/g)
       expect(colorMatches).not.toBeNull()
       expect(colorMatches!.length).toBeGreaterThanOrEqual(2)

--- a/packages/comark-html/package.json
+++ b/packages/comark-html/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "katex": ">=0.16",
     "beautiful-mermaid": ">=1.0",
-    "shiki": "^3.22.0"
+    "shiki": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "katex": {

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-dual-theme.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-dual-theme.md
@@ -43,7 +43,8 @@ console.log(greeting)
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -102,10 +103,12 @@ console.log(greeting)
             "\""
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -159,7 +162,8 @@ console.log(greeting)
 ## HTML
 
 ```html
-<pre language="typescript" class="shiki shiki-themes min-light nord dark:nord" tabindex="0" style="background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"><code class="language-typescript"><span class="line"><span style="color:#D32F2F;--shiki-dark:#81A1C1">const</span><span style="color:#1976D2;--shiki-dark:#D8DEE9"> greeting</span><span style="color:#D32F2F;--shiki-dark:#81A1C1">:</span><span style="color:#1976D2;--shiki-dark:#8FBCBB"> string</span><span style="color:#D32F2F;--shiki-dark:#81A1C1"> =</span><span style="color:#22863A;--shiki-dark:#ECEFF4"> "</span><span style="color:#22863A;--shiki-dark:#A3BE8C">Hello, World!</span><span style="color:#22863A;--shiki-dark:#ECEFF4">"</span></span><span class="line"><span style="color:#1976D2;--shiki-dark:#D8DEE9">console</span><span style="color:#6F42C1;--shiki-dark:#ECEFF4">.</span><span style="color:#6F42C1;--shiki-dark:#88C0D0">log</span><span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">(</span><span style="color:#24292EFF;--shiki-dark:#D8DEE9">greeting</span><span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">)</span></span></code></pre>
+<pre language="typescript" class="shiki shiki-themes min-light nord dark:nord" tabindex="0" style="background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"><code class="language-typescript"><span class="line" style="display: inline"><span style="color:#D32F2F;--shiki-dark:#81A1C1">const</span><span style="color:#1976D2;--shiki-dark:#D8DEE9"> greeting</span><span style="color:#D32F2F;--shiki-dark:#81A1C1">:</span><span style="color:#1976D2;--shiki-dark:#8FBCBB"> string</span><span style="color:#D32F2F;--shiki-dark:#81A1C1"> =</span><span style="color:#22863A;--shiki-dark:#ECEFF4"> "</span><span style="color:#22863A;--shiki-dark:#A3BE8C">Hello, World!</span><span style="color:#22863A;--shiki-dark:#ECEFF4">"</span></span>
+<span class="line" style="display: inline"><span style="color:#1976D2;--shiki-dark:#D8DEE9">console</span><span style="color:#6F42C1;--shiki-dark:#ECEFF4">.</span><span style="color:#6F42C1;--shiki-dark:#88C0D0">log</span><span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">(</span><span style="color:#24292EFF;--shiki-dark:#D8DEE9">greeting</span><span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">)</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-highlight-complex.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-highlight-complex.md
@@ -59,7 +59,8 @@ func main() {
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -76,16 +77,20 @@ func main() {
             " main"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           }
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -116,16 +121,20 @@ func main() {
             "\""
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           }
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -149,10 +158,12 @@ func main() {
             "() {"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -190,10 +201,12 @@ func main() {
             ")"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -231,10 +244,12 @@ func main() {
             ")"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -272,10 +287,12 @@ func main() {
             ")"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -313,10 +330,12 @@ func main() {
             ")"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -354,10 +373,12 @@ func main() {
             ")"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -376,7 +397,17 @@ func main() {
 ## HTML
 
 ```html
-<pre language="go" highlights="[1,3,5,6,7,10]" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-go"><span class="line"><span style="color:#F97583">package</span><span style="color:#B392F0"> main</span></span><span class="line"></span><span class="line"><span style="color:#F97583">import</span><span style="color:#9ECBFF"> "</span><span style="color:#B392F0">fmt</span><span style="color:#9ECBFF">"</span></span><span class="line"></span><span class="line"><span style="color:#F97583">func</span><span style="color:#B392F0"> main</span><span style="color:#E1E4E8">() {</span></span><span class="line"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 6"</span><span style="color:#E1E4E8">)</span></span><span class="line"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 7"</span><span style="color:#E1E4E8">)</span></span><span class="line"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 8"</span><span style="color:#E1E4E8">)</span></span><span class="line"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 9"</span><span style="color:#E1E4E8">)</span></span><span class="line"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 10"</span><span style="color:#E1E4E8">)</span></span><span class="line"><span style="color:#E1E4E8">}</span></span></code></pre>
+<pre language="go" highlights="[1,3,5,6,7,10]" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-go"><span class="line highlight" style="display: inline-block"><span style="color:#F97583">package</span><span style="color:#B392F0"> main</span></span>
+<span class="line" style="display: inline"></span>
+<span class="line highlight" style="display: inline-block"><span style="color:#F97583">import</span><span style="color:#9ECBFF"> "</span><span style="color:#B392F0">fmt</span><span style="color:#9ECBFF">"</span></span>
+<span class="line" style="display: inline"></span>
+<span class="line highlight" style="display: inline-block"><span style="color:#F97583">func</span><span style="color:#B392F0"> main</span><span style="color:#E1E4E8">() {</span></span>
+<span class="line highlight" style="display: inline-block"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 6"</span><span style="color:#E1E4E8">)</span></span>
+<span class="line highlight" style="display: inline-block"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 7"</span><span style="color:#E1E4E8">)</span></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 8"</span><span style="color:#E1E4E8">)</span></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 9"</span><span style="color:#E1E4E8">)</span></span>
+<span class="line highlight" style="display: inline-block"><span style="color:#E1E4E8">    fmt.</span><span style="color:#B392F0">Println</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Line 10"</span><span style="color:#E1E4E8">)</span></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">}</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-language-meta.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-language-meta.md
@@ -48,7 +48,8 @@ console.log(greeting)
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -93,10 +94,12 @@ console.log(greeting)
             " \"Hello, World!\""
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -129,7 +132,8 @@ console.log(greeting)
 ## HTML
 
 ```html
-<pre language="typescript" filename="filename" highlights="[1,2]" meta="some meta" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-typescript"><span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> greeting</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "Hello, World!"</span></span><span class="line"><span style="color:#E1E4E8">console.</span><span style="color:#B392F0">log</span><span style="color:#E1E4E8">(greeting)</span></span></code></pre>
+<pre language="typescript" filename="filename" highlights="[1,2]" meta="some meta" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-typescript"><span class="line highlight" style="display: inline-block"><span style="color:#F97583">const</span><span style="color:#79B8FF"> greeting</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "Hello, World!"</span></span>
+<span class="line highlight" style="display: inline-block"><span style="color:#E1E4E8">console.</span><span style="color:#B392F0">log</span><span style="color:#E1E4E8">(greeting)</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-language-only.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-language-only.md
@@ -40,7 +40,8 @@ console.log(greeting)
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -85,10 +86,12 @@ console.log(greeting)
             " \"Hello, World!\""
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -121,7 +124,8 @@ console.log(greeting)
 ## HTML
 
 ```html
-<pre language="typescript" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0"><code class="language-typescript"><span class="line"><span style="color:#F97583">const</span><span style="color:#79B8FF"> greeting</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "Hello, World!"</span></span><span class="line"><span style="color:#E1E4E8">console.</span><span style="color:#B392F0">log</span><span style="color:#E1E4E8">(greeting)</span></span></code></pre>
+<pre language="typescript" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0"><code class="language-typescript"><span class="line" style="display: inline"><span style="color:#F97583">const</span><span style="color:#79B8FF"> greeting</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "Hello, World!"</span></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">console.</span><span style="color:#B392F0">log</span><span style="color:#E1E4E8">(greeting)</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-no-language.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-no-language.md
@@ -39,7 +39,8 @@ No language specified
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -47,10 +48,12 @@ No language specified
             "Plain text code block"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -67,7 +70,8 @@ No language specified
 ## HTML
 
 ```html
-<pre class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code><span class="line"><span>Plain text code block</span></span><span class="line"><span>No language specified</span></span></code></pre>
+<pre class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code><span class="line" style="display: inline"><span>Plain text code block</span></span>
+<span class="line" style="display: inline"><span>No language specified</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-rust-example.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-rust-example.md
@@ -52,7 +52,8 @@ fn main() {
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -76,10 +77,12 @@ fn main() {
             "() {"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -117,10 +120,12 @@ fn main() {
             ";"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -158,10 +163,12 @@ fn main() {
             ";"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line highlight",
+            "style": "display: inline-block"
           },
           [
             "span",
@@ -206,10 +213,12 @@ fn main() {
             " y);"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -228,7 +237,11 @@ fn main() {
 ## HTML
 
 ```html
-<pre language="rust" filename="main.rs" highlights="[1,2,3,4]" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-rust"><span class="line"><span style="color:#F97583">fn</span><span style="color:#B392F0"> main</span><span style="color:#E1E4E8">() {</span></span><span class="line"><span style="color:#F97583">    let</span><span style="color:#E1E4E8"> x </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 5</span><span style="color:#E1E4E8">;</span></span><span class="line"><span style="color:#F97583">    let</span><span style="color:#E1E4E8"> y </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 10</span><span style="color:#E1E4E8">;</span></span><span class="line"><span style="color:#B392F0">    println!</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Sum: {}"</span><span style="color:#E1E4E8">, x </span><span style="color:#F97583">+</span><span style="color:#E1E4E8"> y);</span></span><span class="line"><span style="color:#E1E4E8">}</span></span></code></pre>
+<pre language="rust" filename="main.rs" highlights="[1,2,3,4]" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-rust"><span class="line highlight" style="display: inline-block"><span style="color:#F97583">fn</span><span style="color:#B392F0"> main</span><span style="color:#E1E4E8">() {</span></span>
+<span class="line highlight" style="display: inline-block"><span style="color:#F97583">    let</span><span style="color:#E1E4E8"> x </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 5</span><span style="color:#E1E4E8">;</span></span>
+<span class="line highlight" style="display: inline-block"><span style="color:#F97583">    let</span><span style="color:#E1E4E8"> y </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 10</span><span style="color:#E1E4E8">;</span></span>
+<span class="line highlight" style="display: inline-block"><span style="color:#B392F0">    println!</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Sum: {}"</span><span style="color:#E1E4E8">, x </span><span style="color:#F97583">+</span><span style="color:#E1E4E8"> y);</span></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">}</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-special-chars.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-special-chars.md
@@ -46,7 +46,8 @@ options:
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -91,10 +92,12 @@ options:
             ">"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -132,10 +135,12 @@ options:
             ">"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -173,10 +178,12 @@ options:
             ">"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -242,10 +249,12 @@ options:
             ">"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -278,7 +287,11 @@ options:
 ## HTML
 
 ```html
-<pre language="html" filename="template.html" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-html"><span class="line"><span style="color:#E1E4E8">&lt;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> class</span><span style="color:#E1E4E8">=</span><span style="color:#9ECBFF">"container"</span><span style="color:#E1E4E8">&gt;</span></span><span class="line"><span style="color:#E1E4E8">  &lt;</span><span style="color:#85E89D">h1</span><span style="color:#E1E4E8">&gt;Title & Subtitle&lt;/</span><span style="color:#85E89D">h1</span><span style="color:#E1E4E8">&gt;</span></span><span class="line"><span style="color:#E1E4E8">  &lt;</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">&gt;Text with "quotes" and 'apostrophes'&lt;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">&gt;</span></span><span class="line"><span style="color:#E1E4E8">  &lt;</span><span style="color:#85E89D">script</span><span style="color:#E1E4E8">&gt;</span><span style="color:#B392F0">alert</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">'XSS &lt; &gt; test'</span><span style="color:#E1E4E8">);&lt;/</span><span style="color:#85E89D">script</span><span style="color:#E1E4E8">&gt;</span></span><span class="line"><span style="color:#E1E4E8">&lt;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">&gt;</span></span></code></pre>
+<pre language="html" filename="template.html" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-html"><span class="line" style="display: inline"><span style="color:#E1E4E8">&lt;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> class</span><span style="color:#E1E4E8">=</span><span style="color:#9ECBFF">"container"</span><span style="color:#E1E4E8">&gt;</span></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">  &lt;</span><span style="color:#85E89D">h1</span><span style="color:#E1E4E8">&gt;Title & Subtitle&lt;/</span><span style="color:#85E89D">h1</span><span style="color:#E1E4E8">&gt;</span></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">  &lt;</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">&gt;Text with "quotes" and 'apostrophes'&lt;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">&gt;</span></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">  &lt;</span><span style="color:#85E89D">script</span><span style="color:#E1E4E8">&gt;</span><span style="color:#B392F0">alert</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">'XSS &lt; &gt; test'</span><span style="color:#E1E4E8">);&lt;/</span><span style="color:#85E89D">script</span><span style="color:#E1E4E8">&gt;</span></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">&lt;/</span><span style="color:#85E89D">div</span><span style="color:#E1E4E8">&gt;</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-twoslash.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-twoslash.md
@@ -43,7 +43,8 @@ const message = "Hello from twoslash"
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -133,10 +134,12 @@ const message = "Hello from twoslash"
             " \"Hello from twoslash\""
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           }
         ]
       ]
@@ -148,8 +151,9 @@ const message = "Hello from twoslash"
 ## HTML
 
 ```html
-<pre language="ts" meta="twoslash" class="shiki shiki-themes min-light twoslash lsp dark:min-light" tabindex="0"><code class="language-ts"><span class="line"><span style="color:#D32F2F">const</span><span style="color:#1976D2"> </span><span style="color:#1976D2"><span class="twoslash-hover twoslash-query-persisted"><span class="twoslash-popup-container"><div class="twoslash-popup-arrow"></div>
-<code class="twoslash-popup-code"><span style="color:#D32F2F">const</span><span style="color:#1976D2"> message</span><span style="color:#D32F2F">:</span><span style="color:#22863A"> "Hello from twoslash"</span></code></span>message</span></span><span style="color:#D32F2F"> =</span><span style="color:#22863A"> "Hello from twoslash"</span></span><span class="line"></span></code></pre>
+<pre language="ts" meta="twoslash" class="shiki shiki-themes min-light twoslash lsp dark:min-light" tabindex="0"><code class="language-ts"><span class="line" style="display: inline"><span style="color:#D32F2F">const</span><span style="color:#1976D2"> </span><span style="color:#1976D2"><span class="twoslash-hover twoslash-query-persisted"><span class="twoslash-popup-container"><div class="twoslash-popup-arrow"></div>
+<code class="twoslash-popup-code"><span style="color:#D32F2F">const</span><span style="color:#1976D2"> message</span><span style="color:#D32F2F">:</span><span style="color:#22863A"> "Hello from twoslash"</span></code></span>message</span></span><span style="color:#D32F2F"> =</span><span style="color:#22863A"> "Hello from twoslash"</span></span>
+<span class="line" style="display: inline"></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-with-empty-lines.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-with-empty-lines.md
@@ -48,7 +48,8 @@ More content here.
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -58,16 +59,20 @@ More content here.
             "# My Page Title"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           }
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -77,16 +82,20 @@ More content here.
             "This is the opening paragraph used as the description."
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           }
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -96,16 +105,20 @@ More content here.
             "## Section One"
           ]
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           }
         ],
+        "\n",
         [
           "span",
           {
-            "class": "line"
+            "class": "line",
+            "style": "display: inline"
           },
           [
             "span",
@@ -124,7 +137,13 @@ More content here.
 ## HTML
 
 ```html
-<pre language="markdown" filename="content.md" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-markdown"><span class="line"><span style="color:#79B8FF;--shiki-light-font-weight:bold"># My Page Title</span></span><span class="line"></span><span class="line"><span style="color:#E1E4E8">This is the opening paragraph used as the description.</span></span><span class="line"></span><span class="line"><span style="color:#79B8FF;--shiki-light-font-weight:bold">## Section One</span></span><span class="line"></span><span class="line"><span style="color:#E1E4E8">More content here.</span></span></code></pre>
+<pre language="markdown" filename="content.md" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-markdown"><span class="line" style="display: inline"><span style="color:#79B8FF;--shiki-light-font-weight:bold"># My Page Title</span></span>
+<span class="line" style="display: inline"></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">This is the opening paragraph used as the description.</span></span>
+<span class="line" style="display: inline"></span>
+<span class="line" style="display: inline"><span style="color:#79B8FF;--shiki-light-font-weight:bold">## Section One</span></span>
+<span class="line" style="display: inline"></span>
+<span class="line" style="display: inline"><span style="color:#E1E4E8">More content here.</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-ordered-list-nested-codeblock.md
+++ b/packages/comark/SPEC/COMARK/shiki-ordered-list-nested-codeblock.md
@@ -48,7 +48,8 @@ options:
             [
               "span",
               {
-                "class": "line"
+                "class": "line",
+                "style": "display: inline"
               },
               [
                 "span",
@@ -99,7 +100,7 @@ options:
 ```html
 <ol>
   <li>
-    Setup:<pre language="rust" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0"><code class="language-rust"><span class="line"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> x </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 1</span><span style="color:#E1E4E8">;</span></span></code></pre>
+    Setup:<pre language="rust" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0"><code class="language-rust"><span class="line" style="display: inline"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> x </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 1</span><span style="color:#E1E4E8">;</span></span></code></pre>
   </li>
 </ol>
 ```

--- a/packages/comark/src/internal/stringify/handlers/pre.ts
+++ b/packages/comark/src/internal/stringify/handlers/pre.ts
@@ -30,18 +30,6 @@ export function pre(node: ComarkElement, state: State) {
   return result + state.context.blockSeparator
 }
 
-function extractCode(node: ComarkElement): string {
-  const codeNode = node[2]
-  if (Array.isArray(codeNode) && codeNode[0] === 'code') {
-    const spans = (codeNode as ComarkElement).slice(2)
-    const lineSpans = spans.filter(s => Array.isArray(s) && String((s as ComarkElement)[1]?.class ?? '').includes('line'))
-    if (lineSpans.length > 0) {
-      return lineSpans.map(span => textContent(span as ComarkElement)).join('\n')
-    }
-  }
-  return textContent(node)
-}
-
 function formatHighlights(highlights: number[]): string {
   if (highlights.length === 0) return ''
 

--- a/packages/comark/src/internal/stringify/handlers/pre.ts
+++ b/packages/comark/src/internal/stringify/handlers/pre.ts
@@ -24,7 +24,7 @@ export function pre(node: ComarkElement, state: State) {
     : ''
 
   const result = '```' + language + filename + highlights + meta + '\n'
-    + String(node[1]?.code || extractCode(node)).trim()
+    + String(node[1]?.code || textContent(node)).trim()
     + '\n```'
 
   return result + state.context.blockSeparator

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -252,6 +252,7 @@ export async function highlightCodeBlocks(
   const newNodes = JSON.parse(JSON.stringify(tree.nodes)) as ComarkNode[]
   for (let i = 0; i < codeBlocks.length; i++) {
     const { node, path } = codeBlocks[i]
+    const preAttrs = node[1] as Record<string, any>
     const result = highlightedResults[i]
 
     const preNode = result.nodes[0]
@@ -264,9 +265,28 @@ export async function highlightCodeBlocks(
         )
 
     const codeChildren = preNode[2].slice(2) as ComarkNode[]
-    const children = typeof preNode === 'string' ? preNode : codeChildren.filter(element => element !== '\n')
+    let children = typeof preNode === 'string'
+      ? preNode
+      : codeChildren
 
-    const preAttrs = node[1] as Record<string, any>
+
+    if (Array.isArray(children)) {
+      let line = 1
+      for (const child of children) {
+        if (Array.isArray(child)) {
+          if (Array.isArray(preAttrs.highlights) && preAttrs.highlights.includes(line)) {
+            child[1].class = `${child[1].class ?? ''} highlight`.trim()
+          }
+
+          // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
+          child[1].style = "display: inline-block"
+
+          line += 1
+        }
+      }
+    }
+
+
     const newPreAttrs: Record<string, any> = {
       ...preAttrs,
       class: [...preNodeClasses, options.themes?.dark?.name ? `dark:${options.themes?.dark?.name}` : ''].filter(Boolean).join(' '),

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -276,10 +276,13 @@ export async function highlightCodeBlocks(
         if (Array.isArray(child)) {
           if (Array.isArray(preAttrs.highlights) && preAttrs.highlights.includes(line)) {
             child[1].class = `${child[1].class ?? ''} highlight`.trim()
+            // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
+            child[1].style = "display: inline-block"
+          } else {
+            // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
+            child[1].style = "display: inline"
           }
 
-          // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
-          child[1].style = "display: inline-block"
 
           line += 1
         }

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -265,10 +265,9 @@ export async function highlightCodeBlocks(
         )
 
     const codeChildren = preNode[2].slice(2) as ComarkNode[]
-    let children = typeof preNode === 'string'
+    const children = typeof preNode === 'string'
       ? preNode
       : codeChildren
-
 
     if (Array.isArray(children)) {
       let line = 1
@@ -277,18 +276,17 @@ export async function highlightCodeBlocks(
           if (Array.isArray(preAttrs.highlights) && preAttrs.highlights.includes(line)) {
             child[1].class = `${child[1].class ?? ''} highlight`.trim()
             // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
-            child[1].style = "display: inline-block"
-          } else {
-            // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
-            child[1].style = "display: inline"
+            child[1].style = 'display: inline-block'
           }
-
+          else {
+            // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
+            child[1].style = 'display: inline'
+          }
 
           line += 1
         }
       }
     }
-
 
     const newPreAttrs: Record<string, any> = {
       ...preAttrs,

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -15,7 +15,7 @@ export type ComarkText = string
  * @param {} - The attributes of the comment
  * @param string - The content of the comment
  */
-export type ComarkComment = [null, {}, string]
+export type ComarkComment = [null, ComarkElementAttributes, string]
 
 /**
  * The Comark element attributes

--- a/packages/comark/test/utils/index.ts
+++ b/packages/comark/test/utils/index.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error - @nuxtjs/mdc is not a peer dependency
 import type { MDCRoot } from '@nuxtjs/mdc'
 import type { ComarkTree } from 'comark'
 import remarkGFM from 'remark-gfm'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,8 +586,8 @@ importers:
         specifier: workspace:*
         version: link:../comark
       shiki:
-        specifier: ^3.22.0
-        version: 3.23.0
+        specifier: ^4.0.0
+        version: 4.0.2
     devDependencies:
       beautiful-mermaid:
         specifier: ^1.1.3

--- a/scripts/stub.mjs
+++ b/scripts/stub.mjs
@@ -40,8 +40,8 @@ for (const srcFile of srcFiles) {
   if (!srcRel.startsWith('.')) srcRel = './' + srcRel
 
   const content = readFileSync(srcFile, 'utf-8')
-  const hasDefault = /\bexport\s+default\b/.test(content)
-    || /export\s*\{\s*default\s*\}/.test(content)
+  const hasDefault = /^\bexport\s+default\b/.test(content)
+    || /^export\s*\{\s*default\s*\}/.test(content)
 
   // JS stub: re-export from source (bundlers handle .ts imports)
   writeFileSync(distJs,

--- a/scripts/stub.mjs
+++ b/scripts/stub.mjs
@@ -40,8 +40,8 @@ for (const srcFile of srcFiles) {
   if (!srcRel.startsWith('.')) srcRel = './' + srcRel
 
   const content = readFileSync(srcFile, 'utf-8')
-  const hasDefault = /^\bexport\s+default\b/.test(content)
-    || /^export\s*\{\s*default\s*\}/.test(content)
+  const hasDefault = /(^|\n)export\s+default\b/.test(content)
+    || /(^|\n)export\s*\{\s*default\s*\}/.test(content)
 
   // JS stub: re-export from source (bundlers handle .ts imports)
   writeFileSync(distJs,

--- a/scripts/stub.mjs
+++ b/scripts/stub.mjs
@@ -40,8 +40,8 @@ for (const srcFile of srcFiles) {
   if (!srcRel.startsWith('.')) srcRel = './' + srcRel
 
   const content = readFileSync(srcFile, 'utf-8')
-  const hasDefault = /(^|\n)export\s+default\b/.test(content)
-    || /(^|\n)export\s*\{\s*default\s*\}/.test(content)
+  const hasDefault = /(?:^|\n)export\s+default\b/.test(content)
+    || /(?:^|\n)export\s*\{\s*default\s*\}/.test(content)
 
   // JS stub: re-export from source (bundlers handle .ts imports)
   writeFileSync(distJs,


### PR DESCRIPTION
This PR aim to define the final structure for highlighted codes. Comark will keep `\n` chars between lines and will treat `.line` spans as inline element.
The final behavior is same as Shiki's default behavior