### PR TITLE
feat(json-render): support YAML

### DIFF
--- a/docs/content/4.plugins/10.core/10.json-render.md
+++ b/docs/content/4.plugins/10.core/10.json-render.md
@@ -1,11 +1,11 @@
 ---
 title: JSON Render
-description: Plugin for rendering JSON Render specs as UI components in Comark.
+description: Plugin for rendering JSON Render specs as UI components in Comark. Supports both json-render and yaml-render code blocks.
 navigation:
   icon: i-lucide-braces
 seo:
   title: JSON Render Plugin
-  description: Plugin for rendering JSON Render specs as UI components in Comark.
+  description: Plugin for rendering JSON Render specs as UI components in Comark. Supports both json-render and yaml-render code blocks.
 links:
   - label: Parse API
     icon: i-lucide-code
@@ -19,7 +19,9 @@ links:
     variant: soft
 ---
 
-The JSON Render plugin transforms `json-render` code blocks into UI components. It parses [JSON Render](https://json-render.dev/) specs and converts them into Comark AST nodes, enabling declarative UI composition within markdown.
+The JSON Render plugin transforms `json-render` and `yaml-render` code blocks into UI components. It parses [JSON Render](https://json-render.dev/) specs and converts them into Comark AST nodes, enabling declarative UI composition within markdown.
+
+Both formats produce identical output — choose whichever syntax you prefer. YAML is often more readable for complex specs.
 
 The plugin is part of the core `comark` package — no additional dependencies are required.
 
@@ -27,7 +29,9 @@ The plugin is part of the core `comark` package — no additional dependencies a
 
 ### With Parse API
 
-```typescript
+::code-group
+
+```typescript [json-render]
 import { parse } from 'comark'
 import jsonRender from 'comark/plugins/json-render'
 
@@ -55,9 +59,39 @@ const result = await parse(markdown, {
 })
 ```
 
+```typescript [yaml-render]
+import { parse } from 'comark'
+import jsonRender from 'comark/plugins/json-render'
+
+const markdown = `
+\`\`\`yaml-render
+root: card
+elements:
+  card:
+    type: Card
+    props:
+      title: Hello
+    children:
+      - text
+  text:
+    type: Text
+    props:
+      content: World
+\`\`\`
+`
+
+const result = await parse(markdown, {
+  plugins: [jsonRender()]
+})
+```
+
+::
+
 ### With Vue
 
-```vue
+::code-group
+
+```vue [json-render]
 <script setup lang="ts">
 import { Comark } from '@comark/vue'
 import jsonRender from '@comark/vue/plugins/json-render'
@@ -79,9 +113,34 @@ const markdown = `
 </template>
 ```
 
+```vue [yaml-render]
+<script setup lang="ts">
+import { Comark } from '@comark/vue'
+import jsonRender from '@comark/vue/plugins/json-render'
+
+const markdown = `
+\`\`\`yaml-render
+type: Card
+props:
+  title: Hello
+\`\`\`
+`
+</script>
+
+<template>
+  <Suspense>
+    <Comark :plugins="[jsonRender()]">{{ markdown }}</Comark>
+  </Suspense>
+</template>
+```
+
+::
+
 ### With React
 
-```tsx
+::code-group
+
+```tsx [json-render]
 import { Comark } from '@comark/react'
 import jsonRender from '@comark/react/plugins/json-render'
 
@@ -101,9 +160,32 @@ function App() {
 }
 ```
 
+```tsx [yaml-render]
+import { Comark } from '@comark/react'
+import jsonRender from '@comark/react/plugins/json-render'
+
+const markdown = `
+\`\`\`yaml-render
+type: Card
+props:
+  title: Hello
+\`\`\`
+`
+
+function App() {
+  return (
+    <Comark plugins={[jsonRender()]}>{markdown}</Comark>
+  )
+}
+```
+
+::
+
 ### With Svelte
 
-```svelte [App.svelte]
+::code-group
+
+```svelte [json-render]
 <script lang="ts">
   import { Comark } from '@comark/svelte'
   import jsonRender from '@comark/svelte/plugins/json-render'
@@ -121,15 +203,36 @@ function App() {
 <Comark {markdown} plugins={[jsonRender()]} />
 ```
 
-## JSON Render Spec Format
+```svelte [yaml-render]
+<script lang="ts">
+  import { Comark } from '@comark/svelte'
+  import jsonRender from '@comark/svelte/plugins/json-render'
 
-The plugin supports two spec formats:
+  const markdown = `
+\`\`\`yaml-render
+type: Card
+props:
+  title: Hello
+\`\`\`
+`
+</script>
+
+<Comark {markdown} plugins={[jsonRender()]} />
+```
+
+::
+
+## Spec Format
+
+The plugin supports two spec formats, each available in both JSON and YAML:
 
 ### Full Spec (with root and elements)
 
 A full spec defines a tree of named elements with a root entry point:
 
-~~~
+::code-group
+
+~~~md [json-render]
 ```json-render
 {
   "root": "card-1",
@@ -148,6 +251,25 @@ A full spec defines a tree of named elements with a root entry point:
 ```
 ~~~
 
+~~~md [yaml-render]
+```yaml-render
+root: card-1
+elements:
+  card-1:
+    type: Card
+    props:
+      title: Welcome
+    children:
+      - text-1
+  text-1:
+    type: Text
+    props:
+      content: This is JSON Render inside Comark
+```
+~~~
+
+::
+
 - **`root`** - The key of the root element in the `elements` map
 - **`elements`** - A map of element definitions, each with:
   - **`type`** - The component/element type name
@@ -158,7 +280,9 @@ A full spec defines a tree of named elements with a root entry point:
 
 When you only need a single element, you can omit `root` and `elements`:
 
-~~~
+::code-group
+
+~~~md [json-render]
 ```json-render
 {
   "type": "Text",
@@ -167,15 +291,25 @@ When you only need a single element, you can omit `root` and `elements`:
 ```
 ~~~
 
+~~~md [yaml-render]
+```yaml-render
+type: Text
+props:
+  content: Hello World
+```
+~~~
+
+::
+
 The plugin automatically wraps this in a full spec with a `template` root.
 
 ## How It Works
 
 The plugin runs in the `post` phase of parsing. It:
 
-1. Walks the Comark AST looking for `pre` nodes with `language: "json-render"`
-2. Parses the JSON content of the code block
-3. Converts the JSON Render spec into Comark AST nodes
+1. Walks the Comark AST looking for `pre` nodes with `language: "json-render"` or `language: "yaml-render"`
+2. Parses the content of the code block (JSON or YAML)
+3. Converts the spec into Comark AST nodes
 4. Replaces the original code block with the generated AST
 
 `Text` elements are converted to plain text nodes. All other elements are converted to Comark element nodes with their props as attributes.

--- a/docs/content/4.plugins/index.md
+++ b/docs/content/4.plugins/index.md
@@ -46,7 +46,7 @@ Comark's plugin system extends markdown functionality with specialized features.
   ::
 
   ::card{icon="i-lucide-braces" title="JSON Render" to="/plugins/core/json-render"}
-  Transform JSON Render specs into UI components within markdown
+  Transform JSON Render specs into UI components using `json-render` or `yaml-render` code blocks
   ::
 ::
 

--- a/examples/3.plugins/vue-vite-json-render/README.md
+++ b/examples/3.plugins/vue-vite-json-render/README.md
@@ -1,6 +1,6 @@
 ---
 title: JSON Render
-description: Example showing how to use Comark with JSON Render in Vue and Vite.
+description: Example showing how to use Comark with JSON Render and YAML Render in Vue and Vite.
 navigation:
   icon: i-lucide-braces
 category: Plugins
@@ -18,12 +18,13 @@ defaultValue: src/App.vue
 
 ## Features
 
-This example demonstrates how to use Comark with JSON Render in Vue:
+This example demonstrates how to use Comark with JSON Render and YAML Render in Vue:
 
-- **JSON Render Plugin**: Import and configure the `json-render` plugin to parse `json-render` code blocks
+- **JSON Render Plugin**: Import and configure the `json-render` plugin to parse `json-render` and `yaml-render` code blocks
 - **Full Spec Format**: Define a tree of named elements with a root entry point
 - **Single Element Shorthand**: Use a simplified format for single elements
 - **Nested Layout**: Compose deep component trees by referencing children by key
+- **YAML Support**: Write specs in YAML for improved readability
 - **Nuxt UI**: Styled with Nuxt UI for a polished look with dark mode support
 
 ## Usage
@@ -38,13 +39,21 @@ This example demonstrates how to use Comark with JSON Render in Vue:
    <Comark :plugins="[jsonRender()]" />
    ```
 
-3. Use json-render code blocks in your markdown:
+3. Use `json-render` or `yaml-render` code blocks in your markdown:
    ````markdown
    ```json-render
    {
      "type": "Text",
      "props": { "content": "Hello" }
    }
+   ```
+   ````
+
+   ````markdown
+   ```yaml-render
+   type: Text
+   props:
+     content: Hello
    ```
    ````
 

--- a/examples/3.plugins/vue-vite-json-render/index.html
+++ b/examples/3.plugins/vue-vite-json-render/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Comark · JSON Render</title>
+    <title>Comark · JSON Render & YAML Render</title>
     <link href="/src/index.css" rel="stylesheet">
   </head>
   <body>

--- a/examples/3.plugins/vue-vite-json-render/src/content.ts
+++ b/examples/3.plugins/vue-vite-json-render/src/content.ts
@@ -1,6 +1,6 @@
 export const content = `# JSON Render for Comark
 
-[JSON Render](https://json-render.dev/) lets you describe **UI components declaratively as JSON** inside Markdown code blocks. The Comark plugin parses \`json-render\` fenced blocks and converts them into AST nodes at parse time — no client-side runtime needed.
+[JSON Render](https://json-render.dev/) lets you describe **UI components declaratively as JSON or YAML** inside Markdown code blocks. The Comark plugin parses \`json-render\` and \`yaml-render\` fenced blocks and converts them into AST nodes at parse time — no client-side runtime needed.
 
 ---
 
@@ -35,6 +35,32 @@ A full spec defines a tree of named elements with a \`root\` entry point and an 
 }
 \`\`\`
 
+The same spec in YAML:
+
+\`\`\`yaml-render
+root: card
+elements:
+  card:
+    type: Card
+    props:
+      title: Welcome to YAML Render
+    children:
+      - description
+      - badge
+  description:
+    type: Text
+    props:
+      content: "This card was described in YAML and rendered by the same Comark plugin.\n"
+  badge:
+    type: Badge
+    children:
+      - poweredby
+  poweredby:
+    type: Text
+    props:
+      content: Powered by Comark
+\`\`\`
+
 ### Single Element (Shorthand)
 
 When you only need one element, skip \`root\` and \`elements\` — the plugin wraps it automatically:
@@ -42,8 +68,14 @@ When you only need one element, skip \`root\` and \`elements\` — the plugin wr
 \`\`\`json-render
 {
   "type": "Text",
-  "props": { "content": "A standalone text element using the shorthand format." }
+  "props": { "content": "A standalone text element using the JSON shorthand format." }
 }
+\`\`\`
+
+\`\`\`yaml-render
+type: Text
+props:
+  content: A standalone text element using the YAML shorthand format.
 \`\`\`
 
 ### Nested Layout
@@ -134,4 +166,6 @@ import jsonRender from '@comark/vue/plugins/json-render'
 | \`children\` | \`string[]\` | No | Keys of child elements in the \`elements\` map |
 
 > **Tip** — \`Text\` is a special element type: its \`props.content\` value is rendered as a plain text node rather than as a component.
+
+> **Tip** — Both \`json-render\` and \`yaml-render\` code blocks use the same plugin and produce identical output. Choose whichever format you prefer.
 `

--- a/packages/comark/src/plugins/json-render.ts
+++ b/packages/comark/src/plugins/json-render.ts
@@ -2,6 +2,7 @@ import type { Spec, UIElement } from '@json-render/core'
 import type { ComarkElementAttributes, ComarkNode } from '../types'
 import { defineComarkPlugin } from '../parse'
 import { textContent, visit } from '../utils'
+import { parseYaml } from '../internal/yaml'
 
 function jsonRenderToAst(jrt: Spec | UIElement) {
   if (!(jrt as Spec).root) {
@@ -92,8 +93,20 @@ export default defineComarkPlugin((_config: JsonRenderConfig = {}) => ({
       state.tree,
       node => node[0] === 'pre' && (node[1] as ComarkElementAttributes).language === 'json-render',
       (preNode) => {
-        const ast = JSON.parse(textContent(preNode))
-        return jsonRenderToAst(ast)
+        const content = textContent(preNode)
+        try {
+          /**
+           * Json Render works with both JSON and YAML syntax
+           * Here plugin tries to detect JSON by looking at first character
+           */
+          const ast = content.startsWith('{')
+            ? JSON.parse(content)
+            : parseYaml(content)
+
+          return jsonRenderToAst(ast)
+        } catch (e) {
+          return undefined
+        }
       },
     )
   },

--- a/packages/comark/src/plugins/json-render.ts
+++ b/packages/comark/src/plugins/json-render.ts
@@ -91,21 +91,24 @@ export default defineComarkPlugin((_config: JsonRenderConfig = {}) => ({
   post: async (state) => {
     visit(
       state.tree,
-      node => node[0] === 'pre' && (node[1] as ComarkElementAttributes).language === 'json-render',
+      node => node[0] === 'pre' && (
+        (node[1] as ComarkElementAttributes).language === 'json-render' ||
+        (node[1] as ComarkElementAttributes).language === 'yaml-render'
+      ),
       (preNode) => {
-        const content = textContent(preNode)
+        const language = (preNode[1] as ComarkElementAttributes).language
         try {
-          /**
-           * Json Render works with both JSON and YAML syntax
-           * Here plugin tries to detect JSON by looking at first character
-           */
-          const ast = content.startsWith('{')
-            ? JSON.parse(content)
-            : parseYaml(content)
+          let spec: Spec | UIElement | undefined = undefined
+          if (language === 'json-render') {
+            spec = JSON.parse(textContent(preNode)) as unknown as Spec | UIElement
+          } else if (language === 'yaml-render') {
+            spec = parseYaml(textContent(preNode)) as unknown as Spec | UIElement
+          }
 
-          return jsonRenderToAst(ast)
+          if (spec) {
+            return jsonRenderToAst(spec)
+          }
         } catch (e) {
-          return undefined
         }
       },
     )

--- a/packages/comark/src/plugins/json-render.ts
+++ b/packages/comark/src/plugins/json-render.ts
@@ -32,7 +32,6 @@ function jsonRenderElementToAst(element: UIElement, elements: Record<string, UIE
   ]
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface JsonRenderConfig {
 
 }
@@ -92,8 +91,8 @@ export default defineComarkPlugin((_config: JsonRenderConfig = {}) => ({
     visit(
       state.tree,
       node => node[0] === 'pre' && (
-        (node[1] as ComarkElementAttributes).language === 'json-render' ||
-        (node[1] as ComarkElementAttributes).language === 'yaml-render'
+        (node[1] as ComarkElementAttributes).language === 'json-render'
+        || (node[1] as ComarkElementAttributes).language === 'yaml-render'
       ),
       (preNode) => {
         const language = (preNode[1] as ComarkElementAttributes).language
@@ -101,14 +100,17 @@ export default defineComarkPlugin((_config: JsonRenderConfig = {}) => ({
           let spec: Spec | UIElement | undefined = undefined
           if (language === 'json-render') {
             spec = JSON.parse(textContent(preNode)) as unknown as Spec | UIElement
-          } else if (language === 'yaml-render') {
+          }
+          else if (language === 'yaml-render') {
             spec = parseYaml(textContent(preNode)) as unknown as Spec | UIElement
           }
 
           if (spec) {
             return jsonRenderToAst(spec)
           }
-        } catch (e) {
+        }
+        catch {
+          // nothing to do
         }
       },
     )


### PR DESCRIPTION
This PR add support of YAML in `json-render` code blocks

Current implementation automatically detects the JSON and YAML and parses with appropriate parser.
Although this brings good DX, but using same block for JSON and YAML makes it harder for editors and highlighters to detect and highlight.

Might be good to introduce new `yaml-render` code block, or `json-render lang="yaml"`
