### PR TITLE
feat(rendering): expose `dump` options for frontmatter serialization

### DIFF
--- a/docs/content/3.rendering/1.markdown.md
+++ b/docs/content/3.rendering/1.markdown.md
@@ -62,6 +62,7 @@ This is an alert
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `maxInlineAttributes` | `number` | `3` | Maximum attributes before switching to YAML block syntax. Set to `0` to always use block syntax |
+| `frontmatterOptions` | `DumpOptions` | `{ indent: 2, lineWidth: -1 }` | js-yaml [DumpOptions](https://github.com/nodeca/js-yaml#dump-object---options-) passed to the frontmatter serializer |
 | `components` | `Record<string, NodeHandler>` | `{}` | Custom render handlers for specific elements |
 | `data` | `Record<string, any>` | `{}` | Additional data passed to render handlers |
 
@@ -98,6 +99,16 @@ const md = await renderMarkdown(tree, { maxInlineAttributes: 0 })
 ```
 
 ::
+
+### Frontmatter YAML Options
+
+By default frontmatter strings are never line-wrapped (`lineWidth: -1`). Pass any [js-yaml DumpOptions](https://github.com/nodeca/js-yaml#dump-object---options-) via `frontmatterOptions` to override this or control other serialization behaviour:
+
+```typescript
+const md = await renderMarkdown(tree, {
+  frontmatterOptions: { lineWidth: 80, sortKeys: true },
+})
+```
 
 ---
 

--- a/packages/comark/src/internal/frontmatter.ts
+++ b/packages/comark/src/internal/frontmatter.ts
@@ -1,3 +1,4 @@
+import type { DumpOptions } from 'js-yaml'
 import { parseYaml, stringifyYaml } from './yaml.ts'
 
 const FRONTMATTER_DELIMITER_DEFAULT = '---'
@@ -35,12 +36,12 @@ export function parseFrontmatter(content: string): { content: string, data: Reco
  * @param content - The content to render
  * @returns The rendered content
  */
-export function renderFrontmatter(data: Record<string, any> | undefined | null, content?: string): string {
+export function renderFrontmatter(data: Record<string, any> | undefined | null, content?: string, yamlOptions?: DumpOptions): string {
   if (!data || Object.keys(data).length === 0) {
     return (content?.trim() || '')
   }
 
-  const fm = stringifyYaml(data).trim()
+  const fm = stringifyYaml(data, yamlOptions).trim()
   if (content) {
     return FRONTMATTER_DELIMITER_DEFAULT + LF + fm + LF + FRONTMATTER_DELIMITER_DEFAULT + LF + LF + content.trim()
   }

--- a/packages/comark/src/internal/yaml.ts
+++ b/packages/comark/src/internal/yaml.ts
@@ -1,4 +1,4 @@
-import { dump, JSON_SCHEMA, load } from 'js-yaml'
+import { dump, JSON_SCHEMA, load, type DumpOptions } from 'js-yaml'
 
 /**
  * Parse YAML content
@@ -14,9 +14,11 @@ export function parseYaml(content: string): Record<string, unknown> {
  * @param data - The data to stringify
  * @returns The stringified data
  */
-export function stringifyYaml(data: Record<string, unknown>): string {
+export function stringifyYaml(data: Record<string, unknown>, options?: DumpOptions): string {
   const yamlOutput = dump(data, {
     indent: 2,
+    lineWidth: -1,
+    ...options,
     replacer: (_key, value) => {
       if (value === 'true') return true
       if (value === 'false') return false

--- a/packages/comark/src/render.ts
+++ b/packages/comark/src/render.ts
@@ -33,5 +33,5 @@ export async function render(tree: ComarkTree, context: RenderOptions = {}): Pro
  */
 export async function renderMarkdown(tree: ComarkTree, options?: RenderMarkdownOptions): Promise<string> {
   const content = await render(tree, { format: 'markdown/comark', ...options })
-  return renderFrontmatter(tree.frontmatter, content)
+  return renderFrontmatter(tree.frontmatter, content, options?.frontmatterOptions)
 }

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -1,3 +1,4 @@
+import type { DumpOptions } from 'js-yaml'
 import type MarkdownExit from 'markdown-exit'
 import type MarkdownIt from 'markdown-it'
 
@@ -203,6 +204,11 @@ export interface RenderMarkdownOptions extends RenderOptions {
    * @default 3
    */
   maxInlineAttributes?: number
+  /**
+   * Options for YAML serialization of frontmatter (js-yaml DumpOptions).
+   * Defaults: indent=2, lineWidth=-1.
+   */
+  frontmatterOptions?: DumpOptions
 }
 // #endregion
 

--- a/packages/comark/test/frontmatter.test.ts
+++ b/packages/comark/test/frontmatter.test.ts
@@ -281,6 +281,63 @@ describe('renderFrontmatter', () => {
   })
 })
 
+describe('renderFrontmatter with frontmatterOptions', () => {
+  it('should pass lineWidth to js-yaml', () => {
+    const data = {
+      description: 'This is a very long description that should be wrapped when lineWidth is set to a small value',
+    }
+    const result = renderFrontmatter(data, 'Content', { lineWidth: 40 })
+    expect(result).toContain('---')
+    // With lineWidth: 40, js-yaml should wrap the long string
+    const lines = result.split('\n')
+    const descLines = lines.filter(l => l.includes('description') || (l.startsWith('  ') && !l.startsWith('  -')))
+    expect(descLines.length).toBeGreaterThan(1)
+
+    expect(result).toEqual(`---\ndescription: >-
+  This is a very long description that
+  should be wrapped when lineWidth is set
+  to a small value
+---
+
+Content`)
+  })
+
+  it('should sort keys when sortKeys is true', () => {
+    const data = { zebra: 'last', alpha: 'first', middle: 'mid' }
+    const result = renderFrontmatter(data, 'Content', { sortKeys: true })
+    const alphaIdx = result.indexOf('alpha')
+    const middleIdx = result.indexOf('middle')
+    const zebraIdx = result.indexOf('zebra')
+    expect(alphaIdx).toBeLessThan(middleIdx)
+    expect(middleIdx).toBeLessThan(zebraIdx)
+  })
+
+  it('should use custom indent', () => {
+    const data = {
+      meta: { title: 'Test', nested: { deep: true } },
+    }
+    const result = renderFrontmatter(data, 'Content', { indent: 4 })
+    expect(result).toContain('    title: Test')
+  })
+
+  it('should default to lineWidth -1 (no wrapping)', () => {
+    const longValue = 'x'.repeat(200)
+    const data = { description: longValue }
+    const result = renderFrontmatter(data, 'Content')
+    // Default: no line wrapping, value stays on one line
+    const descLine = result.split('\n').find(l => l.startsWith('description:'))
+    expect(descLine).toContain(longValue)
+  })
+
+  it('should override defaults when options provided', () => {
+    const data = { title: 'Hello' }
+    const result = renderFrontmatter(data, 'Content', { indent: 4 })
+    expect(result).toContain('---')
+    expect(result).toContain('title: Hello')
+    expect(result).toContain('Content')
+  })
+})
+
 describe('parseFrontmatter and renderFrontmatter roundtrip', () => {
   it('should roundtrip simple frontmatter', () => {
     const original = { title: 'Test', author: 'John' }


### PR DESCRIPTION
Add `frontmatterOptions?: DumpOptions` to `RenderMarkdownOptions`

Allowing callers to pass any `js-yaml` DumpOptions to the frontmatter serializer. 

Defaults to `indent: 2`, `lineWidth: -1` 

Thread the option through `renderMarkdown` → `renderFrontmatter` → `stringifyYaml`.

Also adds docs for the new option

