### PR TITLE
fix(specs): preserve indentation of nested components in named slots

### DIFF
--- a/packages/comark/SPEC/COMARK/component-nested-unindented.md
+++ b/packages/comark/SPEC/COMARK/component-nested-unindented.md
@@ -1,0 +1,101 @@
+## Input
+
+```md
+::card
+This is the parent
+
+:::sibling
+Sibling content
+:::
+
+#title
+:::nested
+Slot content
+:::
+
+:::nested
+More slot content
+:::
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "card",
+      {},
+      [
+        "p",
+        {},
+        "This is the parent"
+      ],
+      [
+        "sibling",
+        {},
+        "Sibling content"
+      ],
+      [
+        "template",
+        {
+          "name": "title"
+        },
+        [
+          "nested",
+          {},
+          "Slot content"
+        ],
+        [
+          "nested",
+          {},
+          "More slot content"
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<card>
+  <p>This is the parent</p>
+  <sibling>
+    Sibling content
+  </sibling>
+  <template name="title">
+    <nested>
+      Slot content
+    </nested>
+    <nested>
+      More slot content
+    </nested>
+  </template>
+</card>
+```
+
+## Markdown
+
+```md
+::card
+This is the parent
+
+  :::sibling
+  Sibling content
+  :::
+
+#title
+  :::nested
+  Slot content
+  :::
+
+  :::nested
+  More slot content
+  :::
+::
+```

--- a/packages/comark/SPEC/COMARK/component-slot-nested-components.md
+++ b/packages/comark/SPEC/COMARK/component-slot-nested-components.md
@@ -1,0 +1,85 @@
+## Input
+
+```md
+::component
+#description
+Some text
+
+:::child
+Nested content
+:::
+
+:::child
+More nested content
+:::
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "component",
+      {},
+      [
+        "template",
+        {
+          "name": "description"
+        },
+        [
+          "p",
+          {},
+          "Some text"
+        ],
+        [
+          "child",
+          {},
+          "Nested content"
+        ],
+        [
+          "child",
+          {},
+          "More nested content"
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<component>
+  <template name="description">
+    <p>Some text</p>
+    <child>
+      Nested content
+    </child>
+    <child>
+      More nested content
+    </child>
+  </template>
+</component>
+```
+
+## Markdown
+
+```md
+::component
+#description
+Some text
+
+  :::child
+  Nested content
+  :::
+
+  :::child
+  More nested content
+  :::
+::
+```

--- a/packages/comark/src/internal/stringify/handlers/template.ts
+++ b/packages/comark/src/internal/stringify/handlers/template.ts
@@ -5,7 +5,7 @@ import type { ComarkElement, ComarkNode } from 'comark'
 export async function template(node: ComarkElement, state: State, parent?: ComarkElement) {
   const [_, attrs] = node
 
-  const content = (await state.flow(node, state)).trim()
+  const content = (await state.flow(node, state)).trimEnd()
 
   // Omit #default marker if this is the only slot
   if (attrs.name === 'default') {


### PR DESCRIPTION
Fix renderMarkdown stripping the indentation of nested components at the start of named slots, breaking the parse/serialize round-trip.

`.trim()` was removing the leading 2-space indent from the first child of a slot's rendered content.
Replacing it with `.trimEnd()` preserves leading whitespace while still stripping trailing newlines.

Two specs covering the affected scenarios (`component-nested-unindented.md`, `component-slot-nested-components.md`)
