### PR TITLE
fix(examples): add tailwindcss to dependencies

### DIFF
--- a/examples/3.plugins/vue-vite-mermaid/package.json
+++ b/examples/3.plugins/vue-vite-mermaid/package.json
@@ -12,6 +12,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@comark/vue": "^0.2.1",
     "beautiful-mermaid": "^1.1.3",
+    "tailwindcss": "^4.2.2",
     "vue": "^3.5.32"
   },
   "devDependencies": {

--- a/examples/3.plugins/vue-vite-twoslash/package.json
+++ b/examples/3.plugins/vue-vite-twoslash/package.json
@@ -16,6 +16,7 @@
     "@vueuse/core": "^14.2.1",
     "comark": "^0.2.1",
     "shiki": "^4.0.2",
+    "tailwindcss": "^4.2.2",
     "twoslash-cdn": "^0.3.6",
     "vue": "^3.5.32"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,6 +516,9 @@ importers:
       beautiful-mermaid:
         specifier: ^1.1.3
         version: 1.1.3
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
       vue:
         specifier: ^3.5.32
         version: 3.5.32(typescript@5.9.3)
@@ -565,6 +568,9 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
       twoslash-cdn:
         specifier: ^0.3.6
         version: 0.3.6(typescript@5.9.3)


### PR DESCRIPTION
# Description

when running these 2 examples, user would get an error: `Can't resolve 'tailwindcss' in `

this fixes it