### PR TITLE
fix(render): correct list indentation and block content in list items

### DIFF
--- a/packages/comark/SPEC/COMARK/shiki-ordered-list-nested-codeblock.md
+++ b/packages/comark/SPEC/COMARK/shiki-ordered-list-nested-codeblock.md
@@ -108,7 +108,8 @@ options:
 ## Markdown
 
 ```md
-1. Setup:```rust
-let x = 1;
-```
+1. Setup:
+   ```rust
+   let x = 1;
+   ```
 ```

--- a/packages/comark/SPEC/common-mark/ordered-list-mixed-blocks-nested.md
+++ b/packages/comark/SPEC/common-mark/ordered-list-mixed-blocks-nested.md
@@ -1,0 +1,151 @@
+## Input
+
+```md
+1. Complex item:
+
+    ```js
+    code()
+    ```
+
+   > A note
+
+   - Nested with table:
+
+     | X   | Y   |
+     |-----|-----|
+     | 1   | 2   |
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ol",
+      {},
+      [
+        "li",
+        {},
+        "Complex item:",
+        [
+          "pre",
+          {
+            "language": "js"
+          },
+          [
+            "code",
+            {
+              "class": "language-js"
+            },
+            "code()"
+          ]
+        ],
+        [
+          "blockquote",
+          {},
+          "A note"
+        ],
+        [
+          "ul",
+          {},
+          [
+            "li",
+            {},
+            "Nested with table:",
+            [
+              "table",
+              {},
+              [
+                "thead",
+                {},
+                [
+                  "tr",
+                  {},
+                  [
+                    "th",
+                    {},
+                    "X"
+                  ],
+                  [
+                    "th",
+                    {},
+                    "Y"
+                  ]
+                ]
+              ],
+              [
+                "tbody",
+                {},
+                [
+                  "tr",
+                  {},
+                  [
+                    "td",
+                    {},
+                    "1"
+                  ],
+                  [
+                    "td",
+                    {},
+                    "2"
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ol>
+  <li>
+    Complex item:<pre language="js"><code class="language-js">code()</code></pre>
+    <blockquote>
+      A note
+    </blockquote>
+    <ul>
+      <li>
+        Nested with table:
+        <table>
+          <thead>
+            <tr>
+              <th>X</th>
+              <th>Y</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>2</td>
+            </tr>
+          </tbody>
+        </table>
+      </li>
+    </ul>
+  </li>
+</ol>
+```
+
+## Markdown
+
+```md
+1. Complex item:
+   ```js
+   code()
+   ```
+   > A note
+
+   - Nested with table:
+     | X   | Y   |
+     | --- | --- |
+     | 1   | 2   |
+```

--- a/packages/comark/SPEC/common-mark/ordered-list-multiple-blocks.md
+++ b/packages/comark/SPEC/common-mark/ordered-list-multiple-blocks.md
@@ -1,0 +1,82 @@
+## Input
+
+```md
+1. First point:
+
+   > A quote here
+
+    ```js
+    code()
+    ```
+
+2. Second point
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ol",
+      {},
+      [
+        "li",
+        {},
+        "First point:",
+        [
+          "blockquote",
+          {},
+          "A quote here"
+        ],
+        [
+          "pre",
+          {
+            "language": "js"
+          },
+          [
+            "code",
+            {
+              "class": "language-js"
+            },
+            "code()"
+          ]
+        ]
+      ],
+      [
+        "li",
+        {},
+        "Second point"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ol>
+  <li>
+    First point:
+    <blockquote>
+      A quote here
+    </blockquote>
+    <pre language="js"><code class="language-js">code()</code></pre>
+  </li>
+  <li>Second point</li>
+</ol>
+```
+
+## Markdown
+
+```md
+1. First point:
+   > A quote here
+   ```js
+   code()
+   ```
+2. Second point
+```

--- a/packages/comark/SPEC/common-mark/ordered-list-nested-codeblock.md
+++ b/packages/comark/SPEC/common-mark/ordered-list-nested-codeblock.md
@@ -1,0 +1,77 @@
+## Input
+
+```md
+1. First level
+   1. Second level with code:
+
+       ```rust
+       let x = 42;
+       ```
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ol",
+      {},
+      [
+        "li",
+        {},
+        "First level",
+        [
+          "ol",
+          {},
+          [
+            "li",
+            {},
+            "Second level with code:",
+            [
+              "pre",
+              {
+                "language": "rust"
+              },
+              [
+                "code",
+                {
+                  "class": "language-rust"
+                },
+                "let x = 42;"
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ol>
+  <li>
+    First level
+    <ol>
+      <li>
+        Second level with code:<pre language="rust"><code class="language-rust">let x = 42;</code></pre>
+      </li>
+    </ol>
+  </li>
+</ol>
+```
+
+## Markdown
+
+```md
+1. First level
+   1. Second level with code:
+      ```rust
+      let x = 42;
+      ```
+```

--- a/packages/comark/SPEC/common-mark/ordered-list-nested.md
+++ b/packages/comark/SPEC/common-mark/ordered-list-nested.md
@@ -81,7 +81,7 @@
 1. First item
 2. Second item
 3. Third item
-  1. Indented item
-  2. Indented item
+   1. Indented item
+   2. Indented item
 4. Fourth item
 ```

--- a/packages/comark/SPEC/common-mark/unordered-list-blockquote.md
+++ b/packages/comark/SPEC/common-mark/unordered-list-blockquote.md
@@ -1,0 +1,52 @@
+## Input
+
+```md
+- Item with quote:
+
+  > This is a blockquote
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ul",
+      {},
+      [
+        "li",
+        {},
+        "Item with quote:",
+        [
+          "blockquote",
+          {},
+          "This is a blockquote"
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ul>
+  <li>
+    Item with quote:
+    <blockquote>
+      This is a blockquote
+    </blockquote>
+  </li>
+</ul>
+```
+
+## Markdown
+
+```md
+- Item with quote:
+  > This is a blockquote
+```

--- a/packages/comark/SPEC/common-mark/unordered-list-nested-blockquotes.md
+++ b/packages/comark/SPEC/common-mark/unordered-list-nested-blockquotes.md
@@ -1,0 +1,81 @@
+## Input
+
+```md
+- Item with quote:
+
+  > Quote level 1
+
+  - Nested item with quote:
+
+    > Quote level 2
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ul",
+      {},
+      [
+        "li",
+        {},
+        "Item with quote:",
+        [
+          "blockquote",
+          {},
+          "Quote level 1"
+        ],
+        [
+          "ul",
+          {},
+          [
+            "li",
+            {},
+            "Nested item with quote:",
+            [
+              "blockquote",
+              {},
+              "Quote level 2"
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ul>
+  <li>
+    Item with quote:
+    <blockquote>
+      Quote level 1
+    </blockquote>
+    <ul>
+      <li>
+        Nested item with quote:
+        <blockquote>
+          Quote level 2
+        </blockquote>
+      </li>
+    </ul>
+  </li>
+</ul>
+```
+
+## Markdown
+
+```md
+- Item with quote:
+  > Quote level 1
+
+  - Nested item with quote:
+    > Quote level 2
+```

--- a/packages/comark/SPEC/common-mark/unordered-list-nested-deep-codeblock.md
+++ b/packages/comark/SPEC/common-mark/unordered-list-nested-deep-codeblock.md
@@ -1,0 +1,93 @@
+## Input
+
+```md
+- Level 1
+  - Level 2
+    - Level 3 with code:
+
+        ```py
+        print("deep")
+        ```
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ul",
+      {},
+      [
+        "li",
+        {},
+        "Level 1",
+        [
+          "ul",
+          {},
+          [
+            "li",
+            {},
+            "Level 2",
+            [
+              "ul",
+              {},
+              [
+                "li",
+                {},
+                "Level 3 with code:",
+                [
+                  "pre",
+                  {
+                    "language": "py"
+                  },
+                  [
+                    "code",
+                    {
+                      "class": "language-py"
+                    },
+                    "print(\"deep\")"
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ul>
+  <li>
+    Level 1
+    <ul>
+      <li>
+        Level 2
+        <ul>
+          <li>
+            Level 3 with code:<pre language="py"><code class="language-py">print("deep")</code></pre>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+```
+
+## Markdown
+
+```md
+- Level 1
+  - Level 2
+    - Level 3 with code:
+      ```py
+      print("deep")
+      ```
+```

--- a/packages/comark/SPEC/common-mark/unordered-list-table.md
+++ b/packages/comark/SPEC/common-mark/unordered-list-table.md
@@ -1,0 +1,102 @@
+## Input
+
+```md
+- Item with table:
+
+  | Name  | Value |
+  |-------|-------|
+  | foo   | bar   |
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ul",
+      {},
+      [
+        "li",
+        {},
+        "Item with table:",
+        [
+          "table",
+          {},
+          [
+            "thead",
+            {},
+            [
+              "tr",
+              {},
+              [
+                "th",
+                {},
+                "Name"
+              ],
+              [
+                "th",
+                {},
+                "Value"
+              ]
+            ]
+          ],
+          [
+            "tbody",
+            {},
+            [
+              "tr",
+              {},
+              [
+                "td",
+                {},
+                "foo"
+              ],
+              [
+                "td",
+                {},
+                "bar"
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ul>
+  <li>
+    Item with table:
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>foo</td>
+          <td>bar</td>
+        </tr>
+      </tbody>
+    </table>
+  </li>
+</ul>
+```
+
+## Markdown
+
+```md
+- Item with table:
+  | Name | Value |
+  | ---- | ----- |
+  | foo  | bar   |
+```

--- a/packages/comark/SPEC/common-mark/xyz.md
+++ b/packages/comark/SPEC/common-mark/xyz.md
@@ -341,8 +341,8 @@ And here's an ordered list:
 1. First numbered item
 2. Second numbered item
 3. Third numbered item
-  - Nested unordered item
-  - Another nested item
+   - Nested unordered item
+   - Another nested item
 
 ## Section Two
 

--- a/packages/comark/src/internal/stringify/handlers/li.ts
+++ b/packages/comark/src/internal/stringify/handlers/li.ts
@@ -1,5 +1,10 @@
 import type { State } from 'comark/render'
 import type { ComarkElement, ComarkNode } from 'comark'
+import { indent } from '../indent.ts'
+
+// Block elements that need explicit indentation in list items.
+// Note: ol/ul are handled by their own handlers which manage indentation via listIndent context.
+const blockElements = new Set(['pre', 'blockquote', 'table'])
 
 export async function li(node: ComarkElement, state: State) {
   const children = node.slice(2) as ComarkNode[]
@@ -18,9 +23,21 @@ export async function li(node: ComarkElement, state: State) {
     prefix += input[1].checked || input[1][':checked'] ? '[x] ' : '[ ] '
   }
 
+  const prefixWidth = prefix.length
   let result = ''
+
   for (const child of children) {
-    result += await state.one(child, state, node)
+    const rendered = await state.one(child, state, node)
+
+    if (Array.isArray(child) && blockElements.has(child[0] as string)) {
+      // Block-level child: put on its own line and indent to align with list prefix
+      const trimmed = rendered.replace(/\n\n$/, '\n').replace(/\n$/, '')
+      const indented = indent(trimmed, { width: prefixWidth })
+      result = result.trimEnd() + '\n' + indented + '\n'
+    }
+    else {
+      result += rendered
+    }
   }
   result = result.trim()
 

--- a/packages/comark/src/internal/stringify/handlers/li.ts
+++ b/packages/comark/src/internal/stringify/handlers/li.ts
@@ -32,7 +32,7 @@ export async function li(node: ComarkElement, state: State) {
     if (Array.isArray(child) && blockElements.has(child[0] as string)) {
       // Block-level child: put on its own line and indent to align with list prefix
       const indented = indent(rendered, { width: prefixWidth })
-      result = result.trimEnd() + '\n' + indented + '\n'
+      result = result.trimEnd() + '\n' + indented.trimEnd() + '\n'
     }
     else {
       result += rendered

--- a/packages/comark/src/internal/stringify/handlers/li.ts
+++ b/packages/comark/src/internal/stringify/handlers/li.ts
@@ -31,8 +31,7 @@ export async function li(node: ComarkElement, state: State) {
 
     if (Array.isArray(child) && blockElements.has(child[0] as string)) {
       // Block-level child: put on its own line and indent to align with list prefix
-      const trimmed = rendered.replace(/\n\n$/, '\n').replace(/\n$/, '')
-      const indented = indent(trimmed, { width: prefixWidth })
+      const indented = indent(rendered, { width: prefixWidth })
       result = result.trimEnd() + '\n' + indented + '\n'
     }
     else {

--- a/packages/comark/src/internal/stringify/handlers/ol.ts
+++ b/packages/comark/src/internal/stringify/handlers/ol.ts
@@ -5,7 +5,7 @@ import { indent } from '../indent.ts'
 export async function ol(node: ComarkElement, state: State) {
   const children = node.slice(2) as ComarkNode[]
 
-  const revert = state.applyContext({ list: true, order: 1 })
+  const revert = state.applyContext({ list: true, order: 1, listIndent: 3 })
 
   let result = ''
   for (const child of children) {
@@ -14,7 +14,7 @@ export async function ol(node: ComarkElement, state: State) {
   result = result.trim()
 
   if (revert.list) {
-    result = '\n' + indent(result)
+    result = '\n' + indent(result, { width: revert.listIndent as number || 2 })
   }
   else {
     result = result + state.context.blockSeparator

--- a/packages/comark/src/internal/stringify/handlers/ul.ts
+++ b/packages/comark/src/internal/stringify/handlers/ul.ts
@@ -5,7 +5,7 @@ import { indent } from '../indent.ts'
 export async function ul(node: ComarkElement, state: State) {
   const children = node.slice(2) as ComarkNode[]
 
-  const revert = state.applyContext({ list: true, order: false })
+  const revert = state.applyContext({ list: true, order: false, listIndent: 2 })
 
   let result = ''
   for (const child of children) {
@@ -14,7 +14,7 @@ export async function ul(node: ComarkElement, state: State) {
   result = result.trim()
 
   if (revert.list) {
-    result = '\n' + indent(result)
+    result = '\n' + indent(result, { width: revert.listIndent as number || 2 })
   }
   else {
     result = result + state.context.blockSeparator

--- a/packages/comark/src/internal/stringify/indent.ts
+++ b/packages/comark/src/internal/stringify/indent.ts
@@ -1,8 +1,9 @@
-export function indent(text: string, { ignoreFirstLine = false, level = 1 }: { ignoreFirstLine?: boolean, level?: number } = {}) {
+export function indent(text: string, { ignoreFirstLine = false, level = 1, width }: { ignoreFirstLine?: boolean, level?: number, width?: number } = {}) {
+  const pad = width ? ' '.repeat(width) : '  '.repeat(level)
   return text.split('\n').map((line, index) => {
     if (ignoreFirstLine && index === 0) {
       return line
     }
-    return line ? '  '.repeat(level) + line : line
+    return line ? pad + line : line
   }).join('\n')
 }


### PR DESCRIPTION
## Summary

Fix two markdown rendering bugs in `renderMarkdown`:

- **#114 — Nested list indentation:** Nested lists now use the correct indentation width matching the parent list marker (`3` spaces for `1. `, `2` spaces for `- `), conforming to [CommonMark 0.31.2 §5.2](https://spec.commonmark.org/0.31.2/#list-items) — continuation blocks must be indented to the column of the first non-blank character after the list marker (Examples [254](https://spec.commonmark.org/0.31.2/#example-254), [109](https://spec.commonmark.org/0.31.2/#example-109)).
- **#118 — Block content in list items:** Block-level elements (`pre`, `blockquote`, `table`) inside list items are now rendered on their own line with proper indentation, instead of being concatenated to the preceding inline text. Per [CommonMark 0.31.2 §5.2 Example 263](https://spec.commonmark.org/0.31.2/#example-263), fenced code blocks in list items must be indented to align with list content.

## Changes

| File | Change |
| ---- | ------ |
| `indent.ts`            | Add `width` parameter for character-count indentation |
| `ul.ts`                | Set `listIndent: 2` in context (matches `- ` prefix)  |
| `ol.ts`                | Set `listIndent: 3` in context (matches `1. ` prefix) |
| `li.ts`                | Detect block-level children, render them on a new line with prefix-aligned indentation |
| 3 SPEC files           | Update expected markdown output to match corrected behavior |

## Test plan

- [x] All existing tests pass (746 passed, 2 pre-existing shiki timeouts unrelated)
- [x] Roundtrip stable: `parse → renderMarkdown → parse → renderMarkdown` produces identical output
- [x] Verified against CommonMark spec §5.2: indentation matches the column of first content after list marker

Closes #114, closes #118