### PR TITLE
feat(comark): add punctuation plugin

### DIFF
--- a/docs/app/components/Playground.vue
+++ b/docs/app/components/Playground.vue
@@ -5,6 +5,7 @@ import math from '@comark/vue/plugins/math'
 import emoji from '@comark/vue/plugins/emoji'
 import mermaid from '@comark/vue/plugins/mermaid'
 import jsonRender from '@comark/vue/plugins/json-render'
+import punctuation from '@comark/vue/plugins/punctuation'
 
 import { renderMarkdown } from 'comark/render'
 import { Splitpanes, Pane } from 'splitpanes'
@@ -33,6 +34,7 @@ const pluginToggles = useLocalStorage('comark-playground-plugins', {
   emoji: true,
   mermaid: true,
   jsonRender: true,
+  punctuation: false,
 }, { mergeDefaults: true })
 
 const parseOptions = useLocalStorage('comark-playground-parse-options', {
@@ -71,6 +73,12 @@ const pluginDefs = [
     label: 'JSON Render',
     icon: 'i-lucide-braces',
     factory: () => jsonRender(),
+  },
+  {
+    key: 'punctuation',
+    label: 'Punctuation',
+    icon: 'i-lucide-quote',
+    factory: () => punctuation(),
   },
 ] as const
 

--- a/docs/content/4.plugins/10.core/12.punctuation.md
+++ b/docs/content/4.plugins/10.core/12.punctuation.md
@@ -87,33 +87,33 @@ const result = await parse('"Hello" -- world... (c)', {
 
 Straight quotes are converted to curly (typographic) quotes:
 
-| Input | Output |
-|-------|--------|
-| `"text"` | \u201Ctext\u201D |
-| `'text'` | \u2018text\u2019 |
-| `don't` | don\u2019t |
+| Input | Output | Rendered |
+|-------|--------|----------|
+| `"text"` | \u201Ctext\u201D | “text” |
+| `'text'` | \u2018text\u2019 | ‘text’ |
+| `don't` | don\u2019t | don’t |
 
 ### Dashes
 
-| Input | Output | Name |
-|-------|--------|------|
-| `--` | \u2013 | En-dash |
-| `---` | \u2014 | Em-dash |
+| Input | Output | Rendered | Name |
+|-------|--------|----------|------|
+| `--` | \u2013 | – | En-dash |
+| `---` | \u2014 | — | Em-dash |
 
 ### Ellipsis
 
-| Input | Output |
-|-------|--------|
-| `...` | \u2026 |
+| Input | Output | Rendered |
+|-------|--------|----------|
+| `...` | \u2026 | … |
 
 ### Symbols
 
-| Input | Output |
-|-------|--------|
-| `(c)` | \u00A9 (copyright) |
-| `(r)` | \u00AE (registered) |
-| `(tm)` | \u2122 (trademark) |
-| `+-` | \u00B1 (plus-minus) |
+| Input | Output | Rendered |
+|-------|--------|----------|
+| `(c)` | \u00A9 | © (copyright) |
+| `(r)` | \u00AE | ® (registered) |
+| `(tm)` | \u2122 | ™ (trademark) |
+| `+-` | \u00B1 | ± (plus-minus) |
 
 ## Code Preservation
 

--- a/docs/content/4.plugins/10.core/12.punctuation.md
+++ b/docs/content/4.plugins/10.core/12.punctuation.md
@@ -1,0 +1,150 @@
+---
+title: Punctuation
+description: Plugin for converting plain-text punctuation into typographically correct Unicode characters.
+navigation:
+  icon: i-lucide-quote
+seo:
+  title: Punctuation Plugin
+  description: Plugin for smart quotes, dashes, ellipsis, and symbols in Comark documents.
+links:
+  - label: Parse API
+    icon: i-lucide-code
+    to: /api/parse
+    color: neutral
+    variant: soft
+  - label: Vue Rendering
+    icon: i-simple-icons-vuedotjs
+    to: /rendering/vue
+    color: neutral
+    variant: soft
+---
+
+The Punctuation plugin transforms plain-text punctuation into typographically correct Unicode characters — smart quotes, dashes, ellipsis, and common symbols.
+
+No peer dependencies are required.
+
+## Basic Usage
+
+### With Vue
+
+```vue [App.vue]
+<script setup lang="ts">
+import { Comark } from '@comark/vue'
+import punctuation from '@comark/vue/plugins/punctuation'
+
+const markdown = `"Hello" -- world... (c) 2025`
+</script>
+
+<template>
+  <Suspense>
+    <Comark :plugins="[punctuation()]">{{ markdown }}</Comark>
+  </Suspense>
+</template>
+```
+
+### With React
+
+```tsx [App.tsx]
+import { Comark } from '@comark/react'
+import punctuation from '@comark/react/plugins/punctuation'
+
+const markdown = `"Hello" -- world... (c) 2025`
+
+function App() {
+  return (
+    <Comark plugins={[punctuation()]}>{markdown}</Comark>
+  )
+}
+```
+
+### With Svelte
+
+```svelte [App.svelte]
+<script lang="ts">
+  import { Comark } from '@comark/svelte'
+  import punctuation from '@comark/svelte/plugins/punctuation'
+
+  const markdown = `"Hello" -- world... (c) 2025`
+</script>
+
+<Comark {markdown} plugins={[punctuation()]} />
+```
+
+### With Parse API
+
+```typescript [parse.ts]
+import { parse } from 'comark'
+import punctuation from 'comark/plugins/punctuation'
+
+const result = await parse('"Hello" -- world... (c)', {
+  plugins: [punctuation()]
+})
+```
+
+## Transformations
+
+### Smart Quotes
+
+Straight quotes are converted to curly (typographic) quotes:
+
+| Input | Output |
+|-------|--------|
+| `"text"` | \u201Ctext\u201D |
+| `'text'` | \u2018text\u2019 |
+| `don't` | don\u2019t |
+
+### Dashes
+
+| Input | Output | Name |
+|-------|--------|------|
+| `--` | \u2013 | En-dash |
+| `---` | \u2014 | Em-dash |
+
+### Ellipsis
+
+| Input | Output |
+|-------|--------|
+| `...` | \u2026 |
+
+### Symbols
+
+| Input | Output |
+|-------|--------|
+| `(c)` | \u00A9 (copyright) |
+| `(r)` | \u00AE (registered) |
+| `(tm)` | \u2122 (trademark) |
+| `+-` | \u00B1 (plus-minus) |
+
+## Code Preservation
+
+Text inside `code`, `pre`, `math`, `kbd`, `script`, and `style` elements is **not** transformed:
+
+```mdc
+Transform this: "hello" -- world...
+
+Don't transform this: `"hello" -- world...`
+```
+
+## Configuration
+
+```typescript
+punctuation({
+  quotes: true,     // Smart quotes
+  dashes: true,     // En-dash and em-dash
+  ellipsis: true,   // Ellipsis character
+  symbols: true,    // (c), (r), (tm), +-
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `quotes` | `boolean` | `true` | Convert straight quotes to smart quotes |
+| `dashes` | `boolean` | `true` | Convert `--` to en-dash and `---` to em-dash |
+| `ellipsis` | `boolean` | `true` | Convert `...` to ellipsis character |
+| `symbols` | `boolean` | `true` | Convert `(c)`, `(r)`, `(tm)`, `+-` |
+
+## Related
+
+- [Emoji](/plugins/core/emoji) — Emoji shortcode conversion
+- [Parse API](/api/parse) — Main parsing API
+- [Creating Plugins](/plugins/creating-plugins) — Build your own plugin

--- a/docs/content/4.plugins/index.md
+++ b/docs/content/4.plugins/index.md
@@ -48,6 +48,10 @@ Comark's plugin system extends markdown functionality with specialized features.
   ::card{icon="i-lucide-braces" title="JSON Render" to="/plugins/core/json-render"}
   Transform JSON Render specs into UI components using `json-render` or `yaml-render` code blocks
   ::
+
+  ::card{icon="i-lucide-quote" title="Punctuation" to="/plugins/core/punctuation"}
+  Convert plain-text punctuation into typographically correct Unicode characters
+  ::
 ::
 
 ## Guides

--- a/examples/3.plugins/vue-vite-punctuation/README.md
+++ b/examples/3.plugins/vue-vite-punctuation/README.md
@@ -1,0 +1,46 @@
+---
+title: Punctuation
+description: Example showing how to use Comark with the punctuation plugin for smart quotes, dashes, and symbols in Vue and Vite.
+navigation:
+  icon: i-lucide-quote
+category: Plugins
+path: /examples/plugins/vue-vite-punctuation
+---
+
+::code-explorer
+---
+org: comarkdown
+repo: comark
+path: examples/3.plugins/vue-vite-punctuation
+defaultValue: src/App.vue
+---
+::
+
+## Features
+
+This example demonstrates the punctuation plugin in Vue:
+
+- **Smart quotes**: `"text"` → \u201Ctext\u201D, `'text'` → \u2018text\u2019
+- **Dashes**: `--` → \u2013 (en-dash), `---` → \u2014 (em-dash)
+- **Ellipsis**: `...` → \u2026
+- **Symbols**: `(c)` → \u00A9, `(r)` → \u00AE, `(tm)` → \u2122, `+-` → \u00B1
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { Comark } from '@comark/vue'
+import punctuation from '@comark/vue/plugins/punctuation'
+</script>
+
+<template>
+  <Suspense>
+    <Comark :plugins="[punctuation()]">{{ markdown }}</Comark>
+  </Suspense>
+</template>
+```
+
+## Learn More
+
+- [Punctuation Plugin Documentation](/plugins/core/punctuation)
+- [Comark Documentation](https://comark.dev)

--- a/examples/3.plugins/vue-vite-punctuation/README.md
+++ b/examples/3.plugins/vue-vite-punctuation/README.md
@@ -20,10 +20,10 @@ defaultValue: src/App.vue
 
 This example demonstrates the punctuation plugin in Vue:
 
-- **Smart quotes**: `"text"` → \u201Ctext\u201D, `'text'` → \u2018text\u2019
-- **Dashes**: `--` → \u2013 (en-dash), `---` → \u2014 (em-dash)
-- **Ellipsis**: `...` → \u2026
-- **Symbols**: `(c)` → \u00A9, `(r)` → \u00AE, `(tm)` → \u2122, `+-` → \u00B1
+- **Smart quotes**: `"text"` → “text”, `'text'` → ‘text’
+- **Dashes**: `--` → – (en-dash), `---` → — (em-dash)
+- **Ellipsis**: `...` → …
+- **Symbols**: `(c)` → ©, `(r)` → ®, `(tm)` → ™, `+-` → ±
 
 ## Usage
 

--- a/examples/3.plugins/vue-vite-punctuation/index.html
+++ b/examples/3.plugins/vue-vite-punctuation/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Comark + Punctuation - Vue Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/3.plugins/vue-vite-punctuation/package.json
+++ b/examples/3.plugins/vue-vite-punctuation/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "comark-vue-vite-punctuation",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@comark/vue": "workspace:*",
+    "vue": "catalog:"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vue-tsc": "catalog:"
+  }
+}

--- a/examples/3.plugins/vue-vite-punctuation/src/App.vue
+++ b/examples/3.plugins/vue-vite-punctuation/src/App.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { Comark } from '@comark/vue'
+import punctuation from '@comark/vue/plugins/punctuation'
+
+const markdown = `
+# Punctuation Plugin Example
+
+The punctuation plugin transforms plain-text punctuation into typographically correct Unicode characters.
+
+## Smart Quotes
+
+"Double quotes become curly" and 'single quotes too'.
+
+Apostrophes in contractions like don't, won't, and it's are handled correctly.
+
+## Dashes
+
+An en-dash for ranges: pages 10--20, years 2020--2025.
+
+An em-dash for parenthetical statements --- like this one --- adds emphasis.
+
+## Ellipsis
+
+Trailing off... becomes a proper ellipsis character.
+
+## Symbols
+
+- Copyright: (c) 2025 Comark Contributors
+- Registered: Comark(r)
+- Trademark: Comark(tm)
+- Plus-minus: tolerance +-5%
+
+## Code Is Preserved
+
+Inline code like \`"hello" -- world...\` is not transformed.
+
+\`\`\`
+"Quotes" and -- dashes inside code blocks are also preserved.
+\`\`\`
+
+## Mixed Content
+
+"She said 'hello' to the group" --- and then left... That's all (c) 2025.
+`
+</script>
+
+<template>
+  <Suspense>
+    <Comark :plugins="[punctuation()]">
+      {{ markdown }}
+    </Comark>
+  </Suspense>
+</template>
+
+<style>
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  max-width: 720px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  line-height: 1.6;
+  color: #1a1a1a;
+}
+
+h1, h2, h3 {
+  margin-top: 2rem;
+}
+
+code:not(pre code) {
+  background: #f0f0f0;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.25rem;
+  font-size: 0.9em;
+}
+
+pre {
+  background: #f5f5f5;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+}
+
+ul {
+  padding-left: 1.5em;
+}
+</style>

--- a/examples/3.plugins/vue-vite-punctuation/src/main.ts
+++ b/examples/3.plugins/vue-vite-punctuation/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/examples/3.plugins/vue-vite-punctuation/tsconfig.json
+++ b/examples/3.plugins/vue-vite-punctuation/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/examples/3.plugins/vue-vite-punctuation/vite.config.ts
+++ b/examples/3.plugins/vue-vite-punctuation/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+})

--- a/packages/comark/src/plugins/punctuation.ts
+++ b/packages/comark/src/plugins/punctuation.ts
@@ -1,0 +1,204 @@
+import type { ComarkNode } from 'comark'
+import { defineComarkPlugin } from '../utils/helpers.ts'
+
+export interface PunctuationOptions {
+  /**
+   * Convert straight quotes to smart (curly) quotes
+   * @default true
+   */
+  quotes?: boolean
+
+  /**
+   * Convert -- to en-dash and --- to em-dash
+   * @default true
+   */
+  dashes?: boolean
+
+  /**
+   * Convert ... to ellipsis character
+   * @default true
+   */
+  ellipsis?: boolean
+
+  /**
+   * Convert (c), (r), (tm), +- to ©, ®, ™, ±
+   * @default true
+   */
+  symbols?: boolean
+}
+
+const OPEN_DOUBLE = '\u201C'
+const CLOSE_DOUBLE = '\u201D'
+const OPEN_SINGLE = '\u2018'
+const CLOSE_SINGLE = '\u2019'
+
+/** Tags whose text content should not be transformed */
+const SKIP_TAGS = new Set(['code', 'pre', 'math', 'script', 'style', 'kbd'])
+
+function isWhitespaceOrOpener(code: number): boolean {
+  // space, tab, newline, carriage return, (, [, {
+  return code === 32 || code === 9 || code === 10 || code === 13
+    || code === 40 || code === 91 || code === 123
+}
+
+function isLetter(code: number): boolean {
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+}
+
+/**
+ * Single-pass text transformation
+ * (ellipsis, dashes, symbols, smart quotes) in one scan with no regex.
+ */
+function applyPunctuation(
+  text: string,
+  quotes: boolean,
+  dashes: boolean,
+  ellipsis: boolean,
+  symbols: boolean,
+): string {
+  const len = text.length
+  let result = ''
+
+  for (let i = 0; i < len; i++) {
+    const code = text.charCodeAt(i)
+
+    // Ellipsis: ...
+    if (ellipsis && code === 46 /* . */ && i + 2 < len
+      && text.charCodeAt(i + 1) === 46 && text.charCodeAt(i + 2) === 46) {
+      result += '\u2026'
+      i += 2
+      continue
+    }
+
+    // Dashes: --- (em-dash) or -- (en-dash)
+    if (dashes && code === 45 /* - */ && i + 1 < len && text.charCodeAt(i + 1) === 45) {
+      if (i + 2 < len && text.charCodeAt(i + 2) === 45) {
+        result += '\u2014'
+        i += 2
+      }
+      else {
+        result += '\u2013'
+        i += 1
+      }
+      continue
+    }
+
+    // Symbols: (c), (C), (r), (R), (tm), (TM), +-
+    if (symbols) {
+      if (code === 40 /* ( */) {
+        const remaining = len - i
+        if (remaining >= 3 && text.charCodeAt(i + 2) === 41 /* ) */) {
+          const inner = text.charCodeAt(i + 1)
+          // c, C
+          if (inner === 99 || inner === 67) {
+            result += '\u00A9'
+            i += 2
+            continue
+          }
+          // r, R
+          if (inner === 114 || inner === 82) {
+            result += '\u00AE'
+            i += 2
+            continue
+          }
+        }
+        if (remaining >= 4 && text.charCodeAt(i + 3) === 41 /* ) */) {
+          const c1 = text.charCodeAt(i + 1)
+          const c2 = text.charCodeAt(i + 2)
+          // t/T, m/M
+          if ((c1 === 116 || c1 === 84) && (c2 === 109 || c2 === 77)) {
+            result += '\u2122'
+            i += 3
+            continue
+          }
+        }
+      }
+      if (code === 43 /* + */ && i + 1 < len && text.charCodeAt(i + 1) === 45 /* - */) {
+        result += '\u00B1'
+        i += 1
+        continue
+      }
+    }
+
+    // Smart quotes
+    if (quotes) {
+      if (code === 34 /* " */) {
+        const prevCode = i > 0 ? text.charCodeAt(i - 1) : 32
+        result += (isWhitespaceOrOpener(prevCode) || i === 0) ? OPEN_DOUBLE : CLOSE_DOUBLE
+        continue
+      }
+      if (code === 39 /* ' */) {
+        const prevCode = i > 0 ? text.charCodeAt(i - 1) : 32
+        const nextCode = i + 1 < len ? text.charCodeAt(i + 1) : 0
+        // Apostrophe in contractions: letter before AND letter after
+        if (isLetter(prevCode) && isLetter(nextCode)) {
+          result += CLOSE_SINGLE
+        }
+        else {
+          result += (isWhitespaceOrOpener(prevCode) || i === 0) ? OPEN_SINGLE : CLOSE_SINGLE
+        }
+        continue
+      }
+    }
+
+    result += text[i]
+  }
+
+  return result
+}
+
+/**
+ * Punctuation plugin for comark
+ *
+ * Transforms common punctuation patterns into their typographically correct Unicode characters:
+ * - Smart (curly) quotes: "text" → \u201Ctext\u201D, 'text' → \u2018text\u2019
+ * - Dashes: -- → \u2013 (en-dash), --- → \u2014 (em-dash)
+ * - Ellipsis: ... → \u2026
+ * - Symbols: (c) → \u00A9, (r) → \u00AE, (tm) → \u2122, +- → \u00B1
+ *
+ * Does not transform text inside code, pre, math, kbd, script, or style elements.
+ *
+ * @param options Punctuation configuration
+ *
+ * @example
+ * ```ts
+ * import { parse } from 'comark'
+ * import punctuation from 'comark/plugins/punctuation'
+ *
+ * const result = await parse('"Hello" -- world...', {
+ *   plugins: [punctuation()]
+ * })
+ * ```
+ */
+export default defineComarkPlugin((options: PunctuationOptions = {}) => {
+  const {
+    quotes = true,
+    dashes = true,
+    ellipsis = true,
+    symbols = true,
+  } = options
+
+  return {
+    name: 'punctuation',
+    post(state) {
+      function walkNodes(nodes: ComarkNode[], startIndex: number, skip: boolean): void {
+        for (let i = startIndex; i < nodes.length; i++) {
+          const node = nodes[i]
+
+          if (typeof node === 'string') {
+            if (!skip) {
+              nodes[i] = applyPunctuation(node, quotes, dashes, ellipsis, symbols)
+            }
+            continue
+          }
+
+          if (Array.isArray(node) && node[0] != null) {
+            walkNodes(node as ComarkNode[], 2, skip || SKIP_TAGS.has(node[0] as string))
+          }
+        }
+      }
+
+      walkNodes(state.tree.nodes, 0, false)
+    },
+  }
+})

--- a/packages/comark/src/plugins/punctuation.ts
+++ b/packages/comark/src/plugins/punctuation.ts
@@ -35,19 +35,19 @@ const CLOSE_SINGLE = '\u2019'
 /** Tags whose text content should not be transformed */
 const SKIP_TAGS = new Set(['code', 'pre', 'math', 'script', 'style', 'kbd'])
 
-function isWhitespaceOrOpener(code: number): boolean {
-  // space, tab, newline, carriage return, (, [, {
-  return code === 32 || code === 9 || code === 10 || code === 13
-    || code === 40 || code === 91 || code === 123
+function isWhitespaceOrOpener(ch: string): boolean {
+  return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r'
+    || ch === '(' || ch === '[' || ch === '{'
 }
 
-function isLetter(code: number): boolean {
-  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+function isLetter(ch: string): boolean {
+  return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
 }
 
 /**
- * Single-pass text transformation
+ * Single-pass O(n) text transformation — replaces punctuation patterns
  * (ellipsis, dashes, symbols, smart quotes) in one scan with no regex.
+ * Uses slice-based string building to minimize allocations.
  */
 function applyPunctuation(
   text: string,
@@ -58,93 +58,99 @@ function applyPunctuation(
 ): string {
   const len = text.length
   let result = ''
+  let last = 0
 
   for (let i = 0; i < len; i++) {
-    const code = text.charCodeAt(i)
+    const ch = text[i]
 
     // Ellipsis: ...
-    if (ellipsis && code === 46 /* . */ && i + 2 < len
-      && text.charCodeAt(i + 1) === 46 && text.charCodeAt(i + 2) === 46) {
-      result += '\u2026'
+    if (ellipsis && ch === '.' && i + 2 < len
+      && text[i + 1] === '.' && text[i + 2] === '.') {
+      result += text.slice(last, i) + '\u2026'
       i += 2
+      last = i + 1
       continue
     }
 
     // Dashes: --- (em-dash) or -- (en-dash)
-    if (dashes && code === 45 /* - */ && i + 1 < len && text.charCodeAt(i + 1) === 45) {
-      if (i + 2 < len && text.charCodeAt(i + 2) === 45) {
-        result += '\u2014'
+    if (dashes && ch === '-' && i + 1 < len && text[i + 1] === '-') {
+      if (i + 2 < len && text[i + 2] === '-') {
+        result += text.slice(last, i) + '\u2014'
         i += 2
       }
       else {
-        result += '\u2013'
+        result += text.slice(last, i) + '\u2013'
         i += 1
       }
+      last = i + 1
       continue
     }
 
     // Symbols: (c), (C), (r), (R), (tm), (TM), +-
-    if (symbols) {
-      if (code === 40 /* ( */) {
-        const remaining = len - i
-        if (remaining >= 3 && text.charCodeAt(i + 2) === 41 /* ) */) {
-          const inner = text.charCodeAt(i + 1)
-          // c, C
-          if (inner === 99 || inner === 67) {
-            result += '\u00A9'
-            i += 2
-            continue
-          }
-          // r, R
-          if (inner === 114 || inner === 82) {
-            result += '\u00AE'
-            i += 2
-            continue
-          }
+    if (symbols && ch === '(') {
+      const remaining = len - i
+      if (remaining >= 3 && text[i + 2] === ')') {
+        const inner = text[i + 1]
+        if (inner === 'c' || inner === 'C') {
+          result += text.slice(last, i) + '\u00A9'
+          i += 2
+          last = i + 1
+          continue
         }
-        if (remaining >= 4 && text.charCodeAt(i + 3) === 41 /* ) */) {
-          const c1 = text.charCodeAt(i + 1)
-          const c2 = text.charCodeAt(i + 2)
-          // t/T, m/M
-          if ((c1 === 116 || c1 === 84) && (c2 === 109 || c2 === 77)) {
-            result += '\u2122'
-            i += 3
-            continue
-          }
+        if (inner === 'r' || inner === 'R') {
+          result += text.slice(last, i) + '\u00AE'
+          i += 2
+          last = i + 1
+          continue
         }
       }
-      if (code === 43 /* + */ && i + 1 < len && text.charCodeAt(i + 1) === 45 /* - */) {
-        result += '\u00B1'
-        i += 1
-        continue
+      if (remaining >= 4 && text[i + 3] === ')') {
+        const c1 = text[i + 1]
+        const c2 = text[i + 2]
+        if ((c1 === 't' || c1 === 'T') && (c2 === 'm' || c2 === 'M')) {
+          result += text.slice(last, i) + '\u2122'
+          i += 3
+          last = i + 1
+          continue
+        }
       }
+    }
+    if (symbols && ch === '+' && i + 1 < len && text[i + 1] === '-') {
+      result += text.slice(last, i) + '\u00B1'
+      i += 1
+      last = i + 1
+      continue
     }
 
     // Smart quotes
     if (quotes) {
-      if (code === 34 /* " */) {
-        const prevCode = i > 0 ? text.charCodeAt(i - 1) : 32
-        result += (isWhitespaceOrOpener(prevCode) || i === 0) ? OPEN_DOUBLE : CLOSE_DOUBLE
+      if (ch === '"') {
+        const prev = i > 0 ? text[i - 1] : ' '
+        result += text.slice(last, i) + ((isWhitespaceOrOpener(prev) || i === 0) ? OPEN_DOUBLE : CLOSE_DOUBLE)
+        last = i + 1
         continue
       }
-      if (code === 39 /* ' */) {
-        const prevCode = i > 0 ? text.charCodeAt(i - 1) : 32
-        const nextCode = i + 1 < len ? text.charCodeAt(i + 1) : 0
+      if (ch === '\'') {
+        const prev = i > 0 ? text[i - 1] : ' '
+        const next = i + 1 < len ? text[i + 1] : ''
+        result += text.slice(last, i)
         // Apostrophe in contractions: letter before AND letter after
-        if (isLetter(prevCode) && isLetter(nextCode)) {
+        if (isLetter(prev) && isLetter(next)) {
           result += CLOSE_SINGLE
         }
         else {
-          result += (isWhitespaceOrOpener(prevCode) || i === 0) ? OPEN_SINGLE : CLOSE_SINGLE
+          result += (isWhitespaceOrOpener(prev) || i === 0) ? OPEN_SINGLE : CLOSE_SINGLE
         }
+        last = i + 1
         continue
       }
     }
-
-    result += text[i]
   }
 
-  return result
+  // Fast path: no substitutions were made
+  if (last === 0) return text
+
+  return result + text.slice(last)
 }
 
 /**

--- a/packages/comark/test/punctuation.test.ts
+++ b/packages/comark/test/punctuation.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import { parse } from '../src/parse'
+import punctuation from '../src/plugins/punctuation'
+
+describe('punctuation plugin', () => {
+  it('should convert straight double quotes to smart quotes', async () => {
+    const md = 'She said "hello world" to him.'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u201C') // left double quote
+    expect(text).toContain('\u201D') // right double quote
+    expect(text).not.toContain('"')
+  })
+
+  it('should convert straight single quotes to smart quotes', async () => {
+    const md = 'She said \'hello\' to him.'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u2018') // left single quote
+    expect(text).toContain('\u2019') // right single quote
+  })
+
+  it('should handle apostrophes in contractions', async () => {
+    const md = 'don\'t won\'t can\'t'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    // Apostrophes should become right single quote
+    expect(text).toContain('don\u2019t')
+    expect(text).toContain('won\u2019t')
+    expect(text).toContain('can\u2019t')
+  })
+
+  it('should convert -- to en-dash', async () => {
+    const md = 'pages 10--20'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u2013') // en-dash
+    expect(text).not.toContain('--')
+  })
+
+  it('should convert --- to em-dash', async () => {
+    const md = 'hello --- world'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u2014') // em-dash
+  })
+
+  it('should convert ... to ellipsis', async () => {
+    const md = 'wait for it...'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u2026') // ellipsis
+    expect(text).not.toContain('...')
+  })
+
+  it('should convert (c) to copyright symbol', async () => {
+    const md = 'Copyright (c) 2024'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u00A9')
+  })
+
+  it('should convert (r) to registered symbol', async () => {
+    const md = 'Product(r) name'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u00AE')
+  })
+
+  it('should convert (tm) to trademark symbol', async () => {
+    const md = 'Brand(tm) value'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u2122')
+  })
+
+  it('should convert +- to plus-minus symbol', async () => {
+    const md = 'tolerance: +-5%'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u00B1')
+  })
+
+  it('should NOT transform text inside code elements', async () => {
+    const md = 'text `"hello" -- world...` more text'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    // Find the code element
+    const code = findNode(tree.nodes, 'code')
+    expect(code).toBeTruthy()
+    const codeText = flattenText([code])
+    // Code content should remain unchanged
+    expect(codeText).toContain('"')
+    expect(codeText).toContain('--')
+    expect(codeText).toContain('...')
+  })
+
+  it('should NOT transform text inside pre elements', async () => {
+    const md = '```\n"hello" -- world...\n```'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const pre = findNode(tree.nodes, 'pre')
+    expect(pre).toBeTruthy()
+    const preText = flattenText([pre])
+    expect(preText).toContain('"')
+    expect(preText).toContain('--')
+  })
+
+  it('should respect disabled options', async () => {
+    const md = '"hello" -- world... (c)'
+    const tree = await parse(md, {
+      plugins: [punctuation({ quotes: false, dashes: false, ellipsis: false, symbols: false })],
+    })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('"')
+    expect(text).toContain('--')
+    expect(text).toContain('...')
+    expect(text).toContain('(c)')
+  })
+
+  it('should handle mixed content with formatting', async () => {
+    const md = '"Hello **bold** world"'
+    const tree = await parse(md, { plugins: [punctuation()] })
+
+    const text = flattenText(tree.nodes)
+    expect(text).toContain('\u201C')
+    expect(text).toContain('\u201D')
+  })
+})
+
+// Test helpers
+
+function flattenText(nodes: any[]): string {
+  let text = ''
+  for (const node of nodes) {
+    if (typeof node === 'string') {
+      text += node
+    }
+    else if (Array.isArray(node) && node.length > 2) {
+      text += flattenText(node.slice(2))
+    }
+  }
+  return text
+}
+
+function findNode(nodes: any[], tag: string): any {
+  for (const node of nodes) {
+    if (Array.isArray(node) && node[0] === tag) return node
+    if (Array.isArray(node) && node.length > 2) {
+      const found = findNode(node.slice(2), tag)
+      if (found) return found
+    }
+  }
+  return null
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -806,6 +806,28 @@ importers:
         specifier: 'catalog:'
         version: 3.2.6(typescript@5.9.3)
 
+  examples/3.plugins/vue-vite-punctuation:
+    dependencies:
+      '@comark/vue':
+        specifier: workspace:*
+        version: link:../../../packages/comark-vue
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.32(typescript@5.9.3)
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: 'catalog:'
+        version: 6.0.5(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.32(typescript@5.9.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.8(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vue-tsc:
+        specifier: 'catalog:'
+        version: 3.2.6(typescript@5.9.3)
+
   examples/3.plugins/vue-vite-twoslash:
     dependencies:
       '@comark/vue':


### PR DESCRIPTION
closes #108 

this PR adds a new `punctuation` plugin that transforms common plain-text punctuation patterns into their typographically correct Unicode characters in a single O(n) pass with no regex

`"text"`	=> 	\u201Ctext\u201D (smart double quotes)
`'text'`	=>	\u2018text\u2019 (smart single quotes)
`don't`	=>	don\u2019t (apostrophe)
`--`	=>	\u2013 (en-dash)
`---`		=>	\u2014 (em-dash)
`...`		=>	\u2026 (ellipsis)
`+-`		=>	\u00B1
`(c)(r)(tm)`	=>	\u00A9 \u00AE \u2122

this would be the first irritation, we can improve and add more features:

- **fractions**: `1/2` becomes `½`
- **localization**
  - for example `French` has different rules I believe `"Bonjour"` becomes `« Bonjour »` @atinux is that right?
  - or `Persian`: we could convert the numbers, or the Zero-Width Non-Joiner or `ك` to `ک`

![Screenshot 2026-04-14 at 8 43 26 PM](https://github.com/user-attachments/assets/d6f2d18c-2a36-4dae-86a4-34cc660220c0)

