### PR TITLE
feat: use parent heading id as prefix for child headings

### DIFF
--- a/packages/comark/SPEC/COMARK/headings-ids.md
+++ b/packages/comark/SPEC/COMARK/headings-ids.md
@@ -9,9 +9,11 @@
 
 #### H4
 
-##### H5
+### Another H3
 
-###### H6
+## Another H2
+
+#### H4
 ```
 
 ## AST
@@ -50,18 +52,25 @@
       "H4"
     ],
     [
-      "h5",
+      "h3",
       {
-        "id": "h2-h3-h4-h5"
+        "id": "h2-another-h3"
       },
-      "H5"
+      "Another H3"
     ],
     [
-      "h6",
+      "h2",
       {
-        "id": "h2-h3-h4-h5-h6"
+        "id": "another-h2"
       },
-      "H6"
+      "Another H2"
+    ],
+    [
+      "h4",
+      {
+        "id": "another-h2-h4"
+      },
+      "H4"
     ]
   ]
 }
@@ -74,8 +83,9 @@
 <h2 id="h2">H2</h2>
 <h3 id="h2-h3">H3</h3>
 <h4 id="h2-h3-h4">H4</h4>
-<h5 id="h2-h3-h4-h5">H5</h5>
-<h6 id="h2-h3-h4-h5-h6">H6</h6>
+<h3 id="h2-another-h3">Another H3</h3>
+<h2 id="another-h2">Another H2</h2>
+<h4 id="another-h2-h4">H4</h4>
 ```
 
 ## Markdown
@@ -89,7 +99,9 @@
 
 #### H4
 
-##### H5
+### Another H3
 
-###### H6
+## Another H2
+
+#### H4
 ```

--- a/packages/comark/SPEC/common-mark/headings-id.md
+++ b/packages/comark/SPEC/common-mark/headings-id.md
@@ -65,28 +65,28 @@
     [
       "h3",
       {
-        "id": "slash-in-title"
+        "id": "ending-space-slash-in-title"
       },
       "Slash - in - Title"
     ],
     [
       "h3",
       {
-        "id": "starting-dash"
+        "id": "ending-space-starting-dash"
       },
       "-Starting dash"
     ],
     [
       "h3",
       {
-        "id": "ending-dash"
+        "id": "ending-space-ending-dash"
       },
       "Ending dash-"
     ],
     [
       "h3",
       {
-        "id": "dash"
+        "id": "ending-space-dash"
       },
       "-Dash-"
     ]
@@ -102,10 +102,10 @@
 <h2 id="c-great">C. Great</h2>
 <h2 id="_1-introduction">1. Introduction</h2>
 <h2 id="ending-space">ending space</h2>
-<h3 id="slash-in-title">Slash - in - Title</h3>
-<h3 id="starting-dash">-Starting dash</h3>
-<h3 id="ending-dash">Ending dash-</h3>
-<h3 id="dash">-Dash-</h3>
+<h3 id="ending-space-slash-in-title">Slash - in - Title</h3>
+<h3 id="ending-space-starting-dash">-Starting dash</h3>
+<h3 id="ending-space-ending-dash">Ending dash-</h3>
+<h3 id="ending-space-dash">-Dash-</h3>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/xyz.md
+++ b/packages/comark/SPEC/common-mark/xyz.md
@@ -114,7 +114,7 @@ And here's a code block:
     [
       "h3",
       {
-        "id": "subsection"
+        "id": "section-one-subsection"
       },
       "Subsection"
     ],
@@ -141,7 +141,7 @@ And here's a code block:
     [
       "h4",
       {
-        "id": "nested-heading"
+        "id": "section-one-subsection-nested-heading"
       },
       "Nested Heading"
     ],
@@ -273,12 +273,12 @@ And here's a code block:
 <p>This is a comprehensive markdown document with <strong>multiple features</strong> and <em>various</em> formatting options.</p>
 <h2 id="section-one">Section One</h2>
 <p>Here's a paragraph with a <a href="https://nuxt.com">link to Nuxt</a> and some <code>inline code</code>. You can also find <strong>bold text</strong> and <em>italic text</em> together.</p>
-<h3 id="subsection">Subsection</h3>
+<h3 id="section-one-subsection">Subsection</h3>
 <blockquote>
   <p>This is a blockquote with important information.</p>
   <p>It can span multiple lines and contain <strong>formatted text</strong>.</p>
 </blockquote>
-<h4 id="nested-heading">Nested Heading</h4>
+<h4 id="section-one-subsection-nested-heading">Nested Heading</h4>
 <p>Here's an unordered list:</p>
 <ul>
   <li>First item</li>

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -381,10 +381,7 @@ function processBlockToken(tokens: any[], startIndex: number, insideNestedContex
     if (children.nodes.length > 0) {
       // Always generate ID for all headings, no exceptions
       const textContent = extractTextContent(children.nodes)
-      const baseSlug = slugify(textContent)
-      const uniqueBaseSlug = uniqueSlug(baseSlug, level, state)
-
-      const headingId = uniqueBaseSlug
+      const headingId = uniqueSlug(slugify(textContent), level, state)
 
       // Always attach ID to the heading element itself
       return { node: [headingTag, { id: headingId }, ...children.nodes] as ComarkNode, nextIndex: children.nextIndex + 1 }

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -25,6 +25,7 @@ const INLINE_TAG_MAP: Record<string, string> = {
 
 interface ProcessState {
   headingSlugCounts: Map<string, number>
+  headingStack: Array<{ level: number, id: string }>
   preservePositions: boolean
 }
 
@@ -36,6 +37,7 @@ interface ProcessState {
 export function marmdownItTokensToComarkTree(tokens: any[], options: { startLine: number, preservePositions: boolean } = { startLine: 0, preservePositions: false }): ComarkNode[] {
   const state: ProcessState = {
     headingSlugCounts: new Map<string, number>(),
+    headingStack: [],
     preservePositions: options.preservePositions,
   }
   const nodes: ComarkNode[] = []
@@ -372,14 +374,17 @@ function processBlockToken(tokens: any[], startIndex: number, insideNestedContex
   }
 
   if (token.type === 'heading_open') {
-    const level = token.tag.replace('h', '')
+    const level = Number.parseInt(token.tag.replace('h', ''), 10)
     const headingTag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
     // Process heading children with inHeading flag for Comark component handling
     const children = processBlockChildren(tokens, startIndex + 1, 'heading_close', true, true, insideNestedContext, state)
     if (children.nodes.length > 0) {
       // Always generate ID for all headings, no exceptions
       const textContent = extractTextContent(children.nodes)
-      const headingId = uniqueSlug(slugify(textContent), state)
+      const baseSlug = slugify(textContent)
+      const uniqueBaseSlug = uniqueSlug(baseSlug, level, state)
+
+      const headingId = uniqueBaseSlug
 
       // Always attach ID to the heading element itself
       return { node: [headingTag, { id: headingId }, ...children.nodes] as ComarkNode, nextIndex: children.nextIndex + 1 }
@@ -638,8 +643,24 @@ function slugify(text: string): string {
 /**
  * Return a unique slug by appending a numeric suffix for duplicates
  */
-function uniqueSlug(slug: string, state?: ProcessState): string {
+function uniqueSlug(slug: string, level: number, state?: ProcessState): string {
   if (!state) return slug
+  // Build hierarchical ID: pop headings at same or deeper level, then prefix with parent's ID
+  // Pop headings at same level or deeper
+  while (state.headingStack.length > 0 && state.headingStack[state.headingStack.length - 1].level >= level) {
+    state.headingStack.pop()
+  }
+  // Use parent's full ID as prefix (h1 doesn't prefix children)
+  if (state.headingStack.length > 0) {
+    const parent = state.headingStack[state.headingStack.length - 1]
+    if (parent.level >= 2) {
+      slug = parent.id + '-' + slug
+    }
+  }
+
+  // Push onto stack for child headings to reference
+  state.headingStack.push({ level, id: slug })
+
   const count = state.headingSlugCounts.get(slug) ?? 0
   state.headingSlugCounts.set(slug, count + 1)
   return count === 0 ? slug : `${slug}-${count}`


### PR DESCRIPTION
This PR introduce new way to generate id for headings and prevent duplicate ids in sub headers and leverage headers hierarchy

Thanks to @benjamincanac  for the idea.

Update: Props to @larbish for the idea actually!

```
## h2

### h3

## second h2

### h3

```

## old behavior:

```html
<h2 id="h2">h2</h2>
<h3 id="h3">h3</h3> ---------------------
<h2 id="second-h2">second-h2</h2>          | -> both have same id
<h3 id="h3">h3</h3> ----------------------
```


## new behavior:

```html
<h2 id="h2">h2</h2>
<h3 id="h2-h3">h3</h3> ------------------
<h2 id="second-h2">second-h2</h2>          | -> Now they have different id
<h3 id="second-h2-h3">h3</h3> ----------
```