### PR TITLE
fix(img): prevent undefined alt text in image markdown output

### DIFF
--- a/packages/comark/SPEC/COMARK/image-no-alt.md
+++ b/packages/comark/SPEC/COMARK/image-no-alt.md
@@ -1,0 +1,38 @@
+## Input
+
+```md
+![](/my/cool/path)
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {},
+      [
+        "img",
+        {
+          "src": "/my/cool/path"
+        }
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<p><img src="/my/cool/path" /></p>
+```
+
+## Markdown
+
+```md
+![](/my/cool/path)
+```

--- a/packages/comark/src/internal/stringify/handlers/img.ts
+++ b/packages/comark/src/internal/stringify/handlers/img.ts
@@ -4,7 +4,7 @@ import { comarkAttributes } from '../attributes.ts'
 
 export function img(node: ComarkElement, _state: State) {
   const [_, attrs] = node
-  const { title, src, alt, ...rest } = attrs
+  const { title, src, alt = '', ...rest } = attrs
 
   const attrsString = Object.keys(rest).length > 0
     ? comarkAttributes(rest)


### PR DESCRIPTION
## Summary

Fixes #146.

When an image has no alt text (`![](/path)`), the `alt` attribute is absent from the AST node (the parser only sets it when `token.content` is truthy). The markdown renderer then used `alt` directly in a template literal, causing JavaScript to stringify `undefined` as the literal string `"undefined"`.

- Default `alt` to `''` in the destructuring in `packages/comark/src/internal/stringify/handlers/img.ts`
- Add SPEC test case `image-no-alt.md` to verify the round-trip produces `![]()` not `![undefined]()`