### PR TITLE
feat(comark): add breaks plugin

### DIFF
--- a/docs/app/components/Playground.vue
+++ b/docs/app/components/Playground.vue
@@ -6,6 +6,7 @@ import emoji from '@comark/vue/plugins/emoji'
 import mermaid from '@comark/vue/plugins/mermaid'
 import jsonRender from '@comark/vue/plugins/json-render'
 import punctuation from '@comark/vue/plugins/punctuation'
+import breaks from '@comark/vue/plugins/breaks'
 
 import { renderMarkdown } from 'comark/render'
 import { Splitpanes, Pane } from 'splitpanes'
@@ -35,6 +36,7 @@ const pluginToggles = useLocalStorage('comark-playground-plugins', {
   mermaid: true,
   jsonRender: true,
   punctuation: false,
+  breaks: false,
 }, { mergeDefaults: true })
 
 const parseOptions = useLocalStorage('comark-playground-parse-options', {
@@ -79,6 +81,12 @@ const pluginDefs = [
     label: 'Punctuation',
     icon: 'i-lucide-quote',
     factory: () => punctuation(),
+  },
+  {
+    key: 'breaks',
+    label: 'Breaks',
+    icon: 'i-lucide-corner-down-left',
+    factory: () => breaks(),
   },
 ] as const
 

--- a/docs/content/4.plugins/10.core/13.breaks.md
+++ b/docs/content/4.plugins/10.core/13.breaks.md
@@ -1,0 +1,90 @@
+---
+title: Breaks
+description: Plugin for converting soft line breaks into br components. 
+navigation:
+  icon: i-lucide-corner-down-left
+seo:
+  title: Breaks Plugin
+  description: Plugin for converting soft line breaks into br components in Comark documents.
+links:
+  - label: Parse API
+    icon: i-lucide-code
+    to: /api/parse
+    color: neutral
+    variant: soft
+---
+
+The Breaks plugin transforms soft line breaks into `<br>` components.
+
+No peer dependencies are required.
+
+## Basic Usage
+
+### With Vue
+
+```vue [App.vue]
+<script setup lang="ts">
+import { Comark } from '@comark/vue'
+import breaks from '@comark/vue/plugins/breaks'
+
+const markdown = `Hello
+world`
+</script>
+
+<template>
+  <Suspense>
+    <Comark :plugins="[breaks()]">{{ markdown }}</Comark>
+    <!-- <p>Hello<br>world</p> -->
+  </Suspense>
+</template>
+```
+
+### With React
+
+```tsx [App.tsx]
+import { Comark } from '@comark/react'
+import breaks from '@comark/react/plugins/breaks'
+
+const markdown = `Hello
+World`
+
+function App() {
+  return (
+    <Comark plugins={[breaks()]}>{markdown}</Comark>
+  )
+  // <p>Hello<br>world</p>
+}
+```
+
+### With Svelte
+
+```svelte [App.svelte]
+<script lang="ts">
+  import { Comark } from '@comark/svelte'
+  import breaks from '@comark/svelte/plugins/breaks'
+
+  const markdown = `Hello
+  world`
+</script>
+
+<Comark {markdown} plugins={[breaks()]} />
+<!-- <p>Hello<br>world</p> -->
+```
+
+### With Parse API
+
+```typescript [parse.ts]
+import { parse } from 'comark'
+import breaks from 'comark/plugins/breaks'
+
+const result = await parse('Hello\nWorld', {
+  plugins: [breaks()]
+})
+/**
+{
+  frontmatter: {},
+  meta: {},
+  nodes: [ [ 'p', {}, 'Hello', ['br', {}], 'world'] ]
+}
+ */
+```

--- a/docs/content/4.plugins/index.md
+++ b/docs/content/4.plugins/index.md
@@ -52,6 +52,10 @@ Comark's plugin system extends markdown functionality with specialized features.
   ::card{icon="i-lucide-quote" title="Punctuation" to="/plugins/core/punctuation"}
   Convert plain-text punctuation into typographically correct Unicode characters
   ::
+
+  ::card{icon="i-lucide-corner-down-left" title="Breaks" to="/plugins/core/breaks"}
+  Convert soft line breaks directly into `:br` components
+  ::
 ::
 
 ## Guides

--- a/packages/comark/src/plugins/breaks.ts
+++ b/packages/comark/src/plugins/breaks.ts
@@ -1,0 +1,44 @@
+import { defineComarkPlugin } from '../utils/helpers.ts'
+import { visit } from 'comark/utils'
+
+export default defineComarkPlugin(() => ({
+  name: 'breaks',
+  post(state) {
+    visit(
+      state.tree,
+      node => Array.isArray(node) && node.length > 2,
+      (node) => {
+        const parent = node as any[]
+        const newParent = [parent[0], parent[1]]
+        let hasModified = false
+
+        for (let i = 2; i < parent.length; i++) {
+          const child = parent[i]
+
+          if (typeof child === 'string' && child.includes('\n')) {
+            hasModified = true
+            const lines = child.split('\n')
+
+            lines.forEach((line, index) => {
+              if (line.length > 0) {
+                newParent.push(line)
+              }
+              if (index < lines.length - 1) {
+                newParent.push(['br', {}])
+              }
+            })
+          }
+          else {
+            newParent.push(child)
+          }
+        }
+
+        if (hasModified) {
+          parent.length = 0
+          parent.push(...newParent)
+        }
+      },
+
+    )
+  },
+}))

--- a/packages/comark/test/breaks.test.ts
+++ b/packages/comark/test/breaks.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { parse } from '../src/parse'
+import breaks from '../src/plugins/breaks'
+
+describe('breaks plugin', () => {
+  it('should replace all occurrences of \n with the comark :br component', async () => {
+    const md = 'She said "hello world" to\nhim.'
+    const tree = await parse(md, { plugins: [breaks()] })
+
+    expect(tree.nodes).toEqual([[
+      'p',
+      {},
+      'She said "hello world" to',
+      [
+        'br',
+        {},
+      ],
+      'him.',
+    ]])
+  })
+})


### PR DESCRIPTION
It is a direct port of [`remark-breaks`](https://github.com/remarkjs/remark-breaks), designed to turn soft line breaks `\n` into `<br>` components. This allows users to have line breaks in the rendered output without requiring add `:br` or backslash at the end of the line.