### PR TITLE
perf(plugins): optimize highlight code processing

### DIFF
--- a/benchmarks/plugin-highlight.ts
+++ b/benchmarks/plugin-highlight.ts
@@ -1,0 +1,145 @@
+import { bench, run, group, barplot } from 'mitata'
+import MarkdownIt from 'markdown-it'
+import MarkdownExit from 'markdown-exit'
+import pluginMdc from '@comark/markdown-it'
+import { createParse } from 'comark'
+import highlight, { getHighlighter } from '../packages/comark/src/plugins/highlight'
+import { codeToHast } from 'shiki/core'
+
+const short = `
+# Quick Start
+
+Install with:
+
+\`\`\`bash
+npm install comark
+\`\`\`
+
+Then use it:
+
+\`\`\`javascript
+import { parse } from 'comark'
+const tree = await parse('# Hello')
+\`\`\`
+`
+
+const medium = `
+# API Reference
+
+## Parse
+
+\`\`\`typescript
+import { parse } from 'comark'
+
+interface ParseOptions {
+  autoClose?: boolean
+  streaming?: boolean
+  plugins?: ComarkPlugin[]
+}
+
+const tree = await parse(markdown, {
+  autoClose: true,
+  plugins: [highlight()],
+})
+\`\`\`
+
+## Render
+
+\`\`\`vue
+<script setup>
+import { Comark } from '@comark/vue'
+import highlight from '@comark/vue/plugins/highlight'
+</script>
+
+<template>
+  <Suspense>
+    <Comark :plugins="[highlight()]">{{ content }}</Comark>
+  </Suspense>
+</template>
+\`\`\`
+
+## Configuration
+
+\`\`\`json
+{
+  "name": "my-project",
+  "dependencies": {
+    "comark": "^0.2.0",
+    "@comark/vue": "^0.2.0"
+  }
+}
+\`\`\`
+`
+
+const long = Array.from({ length: 20 }, (_, i) => `
+## Module ${i + 1}
+
+\`\`\`typescript
+export function module${i + 1}(input: string): string {
+  const result = input.trim()
+  return result.length > 0 ? result : 'default'
+}
+\`\`\`
+
+\`\`\`bash
+npm run build:module-${i + 1}
+\`\`\`
+`).join('\n')
+
+// markdown-it / markdown-exit produce flat tokens — to get syntax highlighting
+// they still need shiki. We benchmark both pipelines with the same shiki work.
+const markdownIt = new MarkdownIt({ html: true, linkify: true })
+  .enable(['table', 'strikethrough']).use(pluginMdc)
+const markdownExit = new MarkdownExit({ html: true, linkify: true })
+  .enable(['table', 'strikethrough']).use(pluginMdc)
+
+// comark: baseline vs highlight plugin
+const comark = createParse()
+const comarkHl = createParse({ plugins: [highlight()] })
+
+// Pre-warm shiki so we benchmark steady-state, not cold-start
+const shiki = await getHighlighter()
+
+// Warm up comark highlight to ensure shiki languages are loaded
+await comarkHl(medium)
+
+// Helper: extract fence tokens from markdown-it/exit and highlight them with shiki
+// This simulates what a real markdown-it + shiki pipeline does.
+async function highlightTokens(tokens: any[]) {
+  for (const token of tokens) {
+    if (token.type === 'fence' && token.info) {
+      await codeToHast(shiki, token.content, {
+        lang: token.info.split(/\s/)[0],
+        themes: { light: 'material-theme-lighter', dark: 'material-theme-palenight' },
+      })
+    }
+  }
+}
+
+for (const [label, content] of [
+  ['short (2 blocks)', short],
+  ['medium (3 blocks)', medium],
+  ['long (40 blocks)', long],
+] as const) {
+  barplot(() => {
+    group(`highlight — ${label}`, () => {
+      bench('comark', async () => {
+        await comark(content)
+      })
+      bench('comark + highlight', async () => {
+        await comarkHl(content)
+      })
+      bench('markdown-it + shiki', async () => {
+        const tokens = markdownIt.parse(content, {})
+        await highlightTokens(tokens)
+      })
+      bench('markdown-exit + shiki', async () => {
+        const tokens = markdownExit.parse(content, {})
+        await highlightTokens(tokens)
+      })
+    })
+  })
+}
+
+console.log('🏃 Running benchmarks...\n')
+await run()

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -62,8 +62,11 @@ const loadedLanguages: Set<string> = new Set()
  * Uses a singleton pattern to avoid creating multiple highlighters
  */
 export async function getHighlighter(options: HighlightOptions = {}): Promise<ShikiPrimitive> {
-  // If highlighter exists, load any new themes that aren't loaded yet
   if (highlighter) {
+    // Fast path: skip registerDefaults() when no custom themes/languages are requested
+    if (!options.themes && !options.languages) {
+      return highlighter
+    }
     const { themes, languages } = await registerDefaults(options)
     await Promise.all(themes.map(theme => loadTheme(highlighter!, theme)))
     await Promise.all(languages.map(language => loadLanguage(highlighter!, language)))
@@ -160,6 +163,31 @@ async function loadLanguage(hl: ShikiPrimitive, language: LanguageRegistration |
 }
 
 /**
+ * Convert a hast (HTML AST) node into a ComarkNode.
+ * Uses pre-allocated arrays to avoid spread overhead.
+ */
+function hastToComarkNode(input: any): ComarkNode {
+  if (input.type === 'text') return input.value
+  if (input.type === 'comment') return [null, {}, input.value]
+
+  const props = input.properties || {}
+  if (input.tag === 'code' && props?.className && props.className.length === 0) {
+    delete props.className
+  }
+
+  const children = input.children
+  if (!children || children.length === 0) return [input.tagName, props]
+  const len = children.length
+  const result = new Array(len + 2)
+  result[0] = input.tagName
+  result[1] = props
+  for (let i = 0; i < len; i++) {
+    result[i + 2] = hastToComarkNode(children[i])
+  }
+  return result as ComarkNode
+}
+
+/**
  * Highlight code using Shiki with codeToTokens
  * Returns comark nodes built from hast
  */
@@ -184,7 +212,7 @@ export async function highlightCode(code: string, attrs: CodeBlockAttributes, op
         __raw: attrs.meta,
       },
     })
-    const allTokens = result.children.map(hastToMinimarkNode) as ComarkNode[]
+    const allTokens = result.children.map(hastToComarkNode) as ComarkNode[]
 
     return {
       nodes: allTokens,
@@ -199,18 +227,6 @@ export async function highlightCode(code: string, attrs: CodeBlockAttributes, op
       language,
     }
   }
-
-  function hastToMinimarkNode(input: any) {
-    const props = input.properties || {}
-    if (input.type === 'comment') return [null, {}, input.value]
-    if (input.type === 'text') return input.value
-    if (input.tag === 'code' && props?.className && props.className.length === 0) delete props.className
-    return [
-      input.tagName,
-      props,
-      ...(input.children || []).map(hastToMinimarkNode),
-    ]
-  }
 }
 
 /**
@@ -224,58 +240,108 @@ export async function highlightCodeBlocks(
   interface CodeBlockRef { node: ComarkNode, path: number[] }
 
   const codeBlocks: CodeBlockRef[] = []
+  const pathBuf: number[] = []
 
-  const findCodeBlocks = (nodes: ComarkNode[], path: number[]): void => {
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i]
-      if (typeof node === 'string') continue
-      if (!Array.isArray(node) || node.length < 3) continue
-
-      if (node[0] === 'pre' && Array.isArray(node[2]) && node[2][0] === 'code') {
-        const codeContent = node[2][2]
+  // Recursively find <pre><code> blocks, tracking their path via push/pop on a shared buffer
+  const walkChildren = (element: ComarkElement): void => {
+    for (let i = 2; i < element.length; i++) {
+      const child = element[i]
+      if (typeof child === 'string') continue
+      if (!Array.isArray(child) || child.length < 3) continue
+      pathBuf.push(i - 2)
+      if (child[0] === 'pre' && Array.isArray(child[2]) && child[2][0] === 'code') {
+        const codeContent = child[2][2]
         if (typeof codeContent === 'string') {
-          codeBlocks.push({ node, path: [...path, i] })
+          codeBlocks.push({ node: child, path: pathBuf.slice() })
         }
       }
-
-      findCodeBlocks(node.slice(2) as ComarkNode[], [...path, i])
+      walkChildren(child as ComarkElement)
+      pathBuf.pop()
     }
   }
-  findCodeBlocks(tree.nodes, [])
+
+  for (let i = 0; i < tree.nodes.length; i++) {
+    const node = tree.nodes[i]
+    if (typeof node === 'string') continue
+    if (!Array.isArray(node) || node.length < 3) continue
+    if (node[0] === 'pre' && Array.isArray(node[2]) && node[2][0] === 'code') {
+      const codeContent = node[2][2]
+      if (typeof codeContent === 'string') {
+        codeBlocks.push({ node, path: [i] })
+      }
+    }
+    pathBuf.length = 1
+    pathBuf[0] = i
+    walkChildren(node as ComarkElement)
+  }
 
   if (codeBlocks.length === 0) return tree
 
-  const highlightedResults = await Promise.all(
-    codeBlocks.map(({ node }) => {
-      return highlightCode((node[2] as any)[2] as string, node[1] as CodeBlockAttributes, options)
-    }),
-  )
+  const hl = await getHighlighter(options)
+  const { themes = { light: 'material-theme-lighter', dark: 'material-theme-palenight' } } = options
+  const lightTheme = themes.light || themes.dark || 'material-theme-lighter'
+  const darkTheme = themes.dark || themes.light || 'material-theme-palenight'
+  const themeOptions = {
+    light: lightTheme,
+    dark: lightTheme !== darkTheme ? darkTheme : undefined,
+  }
 
-  const newNodes = JSON.parse(JSON.stringify(tree.nodes)) as ComarkNode[]
+  // codeToHast (shiki/core) is synchronous, so we loop directly instead of using Promise.all
+  const highlightedResults: Array<{ nodes: ComarkNode[], language: string }> = new Array(codeBlocks.length)
+  for (let i = 0; i < codeBlocks.length; i++) {
+    const { node } = codeBlocks[i]
+    const code = (node[2] as any)[2] as string
+    const attrs = node[1] as CodeBlockAttributes
+    const language: string = (attrs as any)?.language
+    try {
+      const result = codeToHast(hl, code, {
+        lang: language,
+        transformers: options.transformers,
+        themes: themeOptions,
+        meta: {
+          __raw: attrs.meta,
+        },
+      })
+      highlightedResults[i] = {
+        nodes: result.children.map(hastToComarkNode) as ComarkNode[],
+        language,
+      }
+    }
+    catch {
+      highlightedResults[i] = { nodes: [code], language }
+    }
+  }
+
+  const darkClassSuffix = options.themes?.dark?.name ? ` dark:${options.themes.dark.name}` : ''
+
+  // Build new nodes array, spine-copying only paths to modified <pre> nodes
+  const newNodes = [...tree.nodes] as ComarkNode[]
   for (let i = 0; i < codeBlocks.length; i++) {
     const { node, path } = codeBlocks[i]
     const preAttrs = node[1] as Record<string, any>
     const result = highlightedResults[i]
 
     const preNode = result.nodes[0]
-    const preNodeClasses = typeof preNode === 'string'
-      ? ['shiki', options.themes?.light?.name]
-      : (
-          Array.isArray((preNode[1] as ComarkElementAttributes).class)
-            ? (preNode[1] as ComarkElementAttributes).class as string[]
-            : String((preNode[1] as ComarkElementAttributes).class).split(' ')
-        )
+    let classStr: string
+    if (typeof preNode === 'string') {
+      classStr = 'shiki' + (options.themes?.light?.name ? ` ${options.themes.light.name}` : '')
+    }
+    else {
+      const cls = (preNode[1] as ComarkElementAttributes).class
+      classStr = Array.isArray(cls) ? cls.join(' ') : String(cls)
+    }
+    if (darkClassSuffix) classStr += darkClassSuffix
 
-    const codeChildren = preNode[2].slice(2) as ComarkNode[]
-    const children = typeof preNode === 'string'
+    const codeChildren = typeof preNode === 'string'
       ? preNode
-      : codeChildren
+      : (preNode[2] as ComarkElement).slice(2) as ComarkNode[]
 
-    if (Array.isArray(children)) {
+    if (Array.isArray(codeChildren)) {
+      const highlightSet = Array.isArray(preAttrs.highlights) ? new Set<number>(preAttrs.highlights) : null
       let line = 1
-      for (const child of children) {
+      for (const child of codeChildren) {
         if (Array.isArray(child)) {
-          if (Array.isArray(preAttrs.highlights) && preAttrs.highlights.includes(line)) {
+          if (highlightSet !== null && highlightSet.has(line)) {
             child[1].class = `${child[1].class ?? ''} highlight`.trim()
             // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
             child[1].style = 'display: inline-block'
@@ -292,7 +358,7 @@ export async function highlightCodeBlocks(
 
     const newPreAttrs: Record<string, any> = {
       ...preAttrs,
-      class: [...preNodeClasses, options.themes?.dark?.name ? `dark:${options.themes?.dark?.name}` : ''].filter(Boolean).join(' '),
+      class: classStr,
       tabindex: '0',
     }
 
@@ -320,15 +386,31 @@ export async function highlightCodeBlocks(
 
     const codeEl = node[2] as ComarkElement
     const codeAttrs = (codeEl[1] as Record<string, any>) || {}
-    const newPreNode: ComarkNode = ['pre', newPreAttrs, ['code', codeAttrs, ...children]]
+    let newPreNode: ComarkNode
+    if (Array.isArray(codeChildren)) {
+      const codeNode = new Array(codeChildren.length + 2) as ComarkElement
+      codeNode[0] = 'code'
+      codeNode[1] = codeAttrs
+      for (let j = 0; j < codeChildren.length; j++) codeNode[j + 2] = codeChildren[j]
+      newPreNode = ['pre', newPreAttrs, codeNode]
+    }
+    else {
+      newPreNode = ['pre', newPreAttrs, ['code', codeAttrs, codeChildren]]
+    }
 
     if (path.length === 1) {
       newNodes[path[0]] = newPreNode
     }
     else {
-      let current = newNodes[path[0]] as ComarkElement
+      // Copy only the spine from root to this node to preserve immutability
+      const rootIdx = path[0]
+      let current = [...(newNodes[rootIdx] as ComarkElement)] as ComarkElement
+      newNodes[rootIdx] = current
       for (let j = 1; j < path.length - 1; j++) {
-        current = current[path[j] + 2] as ComarkElement
+        const childSlot = path[j] + 2
+        const next = [...(current[childSlot] as ComarkElement)] as ComarkElement
+        current[childSlot] = next
+        current = next
       }
       const childSlot = path[path.length - 1] + 2
       current[childSlot] = newPreNode

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -178,6 +178,7 @@ function hastToComarkNode(input: any): ComarkNode {
   const children = input.children
   if (!children || children.length === 0) return [input.tagName, props]
   const len = children.length
+  // eslint-disable-next-line unicorn/no-new-array -- pre-allocated for perf
   const result = new Array(len + 2)
   result[0] = input.tagName
   result[1] = props
@@ -287,6 +288,7 @@ export async function highlightCodeBlocks(
   }
 
   // codeToHast (shiki/core) is synchronous, so we loop directly instead of using Promise.all
+  // eslint-disable-next-line unicorn/no-new-array -- pre-allocated for perf
   const highlightedResults: Array<{ nodes: ComarkNode[], language: string }> = new Array(codeBlocks.length)
   for (let i = 0; i < codeBlocks.length; i++) {
     const { node } = codeBlocks[i]
@@ -388,6 +390,7 @@ export async function highlightCodeBlocks(
     const codeAttrs = (codeEl[1] as Record<string, any>) || {}
     let newPreNode: ComarkNode
     if (Array.isArray(codeChildren)) {
+      // eslint-disable-next-line unicorn/no-new-array -- pre-allocated for perf
       const codeNode = new Array(codeChildren.length + 2) as ComarkElement
       codeNode[0] = 'code'
       codeNode[1] = codeAttrs

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -4,6 +4,7 @@ import { defineComarkPlugin } from '../utils/helpers.ts'
 import { createShikiPrimitive } from 'shiki'
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 import { codeToHast } from 'shiki/core'
+import comakLanguage from '../utils/comark.tmLanguage.ts'
 
 export interface HighlightOptions {
   /**
@@ -129,7 +130,7 @@ async function registerDefaults(options: HighlightOptions) {
       import('shiki/dist/langs/svelte.mjs').then(m => ({ type: 'lang' as const, value: m.default })),
       import('shiki/dist/langs/typescript.mjs').then(m => ({ type: 'lang' as const, value: m.default })),
       import('shiki/dist/langs/javascript.mjs').then(m => ({ type: 'lang' as const, value: m.default })),
-      import('shiki/dist/langs/mdc.mjs').then(m => ({ type: 'lang' as const, value: m.default })),
+      // import('shiki/dist/langs/mdc.mjs').then(m => ({ type: 'lang' as const, value: m.default })),
       import('shiki/dist/langs/bash.mjs').then(m => ({ type: 'lang' as const, value: m.default })),
       import('shiki/dist/langs/json.mjs').then(m => ({ type: 'lang' as const, value: m.default })),
       import('shiki/dist/langs/yaml.mjs').then(m => ({ type: 'lang' as const, value: m.default })),
@@ -142,6 +143,8 @@ async function registerDefaults(options: HighlightOptions) {
     if (result.type === 'theme') themes.push(result.value)
     else languages.push(result.value)
   }
+  // Remove custom language after updating language in shiki core
+  languages.push(comakLanguage as LanguageRegistration)
 
   return { themes, languages }
 }
@@ -189,55 +192,10 @@ function hastToComarkNode(input: any): ComarkNode {
 }
 
 /**
- * Highlight code using Shiki with codeToTokens
- * Returns comark nodes built from hast
- */
-export async function highlightCode(code: string, attrs: CodeBlockAttributes, options: HighlightOptions = {}): Promise<{ nodes: ComarkNode[], language: string, bgColor?: string, fgColor?: string }> {
-  // Extract language from attributes
-  const language: string = (attrs as any)?.language
-  try {
-    const hl = await getHighlighter(options)
-    const { themes = { light: 'material-theme-lighter', dark: 'material-theme-palenight' } } = options
-
-    const lightTheme = themes.light || themes.dark || 'material-theme-lighter'
-    const darkTheme = themes.dark || themes.light || 'material-theme-palenight'
-    // Use codeToTokens to get raw tokens
-    const result = await codeToHast(hl, code, {
-      lang: language,
-      transformers: options.transformers,
-      themes: {
-        light: lightTheme,
-        dark: lightTheme !== darkTheme ? darkTheme : undefined,
-      },
-      meta: {
-        __raw: attrs.meta,
-      },
-    })
-    const allTokens = result.children.map(hastToComarkNode) as ComarkNode[]
-
-    return {
-      nodes: allTokens,
-      language,
-    }
-  }
-  catch (error) {
-    // If highlighting fails, return the original code
-    console.error('Shiki highlighting error:', error)
-    return {
-      nodes: [code],
-      language,
-    }
-  }
-}
-
-/**
  * Apply syntax highlighting to all code blocks in a Comark tree
  * Uses codeToTokens API with batched async operations
  */
-export async function highlightCodeBlocks(
-  tree: ComarkTree,
-  options: HighlightOptions = {},
-): Promise<ComarkTree> {
+export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOptions = {}): Promise<ComarkTree> {
   interface CodeBlockRef { node: ComarkNode, path: number[] }
 
   const codeBlocks: CodeBlockRef[] = []
@@ -287,7 +245,6 @@ export async function highlightCodeBlocks(
     dark: lightTheme !== darkTheme ? darkTheme : undefined,
   }
 
-  // codeToHast (shiki/core) is synchronous, so we loop directly instead of using Promise.all
   // eslint-disable-next-line unicorn/no-new-array -- pre-allocated for perf
   const highlightedResults: Array<{ nodes: ComarkNode[], language: string }> = new Array(codeBlocks.length)
   for (let i = 0; i < codeBlocks.length; i++) {

--- a/packages/comark/src/utils/comark.tmLanguage.ts
+++ b/packages/comark/src/utils/comark.tmLanguage.ts
@@ -1,0 +1,569 @@
+export default {
+  $schema: 'https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json',
+  name: 'mdc',
+  aliases: ['comark'],
+  displayName: 'MDC - Components in Markdown',
+  injectionSelector: 'L:text.html.markdown',
+  scopeName: 'text.markdown.mdc.standalone',
+  patterns: [
+    {
+      include: 'text.html.markdown#frontMatter',
+    },
+    {
+      include: '#block',
+    },
+  ],
+  repository: {
+    'block': {
+      patterns: [
+        {
+          include: '#inline',
+        },
+        {
+          include: '#component_block',
+        },
+        {
+          include: 'text.html.markdown#separator',
+        },
+        {
+          include: '#heading',
+        },
+        {
+          include: '#blockquote',
+        },
+        {
+          include: '#lists',
+        },
+        {
+          include: 'text.html.markdown#fenced_code_block',
+        },
+        {
+          include: 'text.html.markdown#link-def',
+        },
+        {
+          include: 'text.html.markdown#html',
+        },
+        {
+          include: '#paragraph',
+        },
+      ],
+    },
+    'inline': {
+      patterns: [
+        {
+          include: '#component_inline',
+        },
+        {
+          include: '#span',
+        },
+        {
+          include: '#attributes',
+        },
+        {
+          include: 'text.html.markdown#inline',
+        },
+      ],
+    },
+    'span': {
+      match: '(?x)\n  (\\[)           # Open\n    ([^]]*)\n  (\\])\n  (               # attributes\n    ({)\n      ([^{]*)\n    (})\n  )?\n  \\s',
+      name: 'span.component.mdc',
+      captures: {
+        1: {
+          name: 'punctuation.definition.tag.start.component',
+        },
+        2: {
+          name: 'string.other.link.description.title.markdown',
+        },
+        3: {
+          name: 'punctuation.definition.tag.end.component',
+        },
+        4: {
+          patterns: [
+            {
+              include: '#attributes',
+            },
+          ],
+        },
+      },
+    },
+    'attributes': {
+      match: '(?x)(               # attributes\n    ({)\n      ((?:[^{}\'"]+|\'[^\']*\'|"[^"]*")*)\n    (})\n  )',
+      name: 'attributes.mdc',
+      captures: {
+        1: {
+          name: 'punctuation.definition.tag.start.component',
+        },
+        3: {
+          patterns: [
+            {
+              include: '#attribute',
+            },
+          ],
+        },
+        4: {
+          name: 'punctuation.definition.tag.end.component',
+        },
+      },
+    },
+    'component_inline': {
+      match: '(?x)\n  (^|\\G|\\s+)\n  (:)              # component colon\n  (?i:             # component name\n    (\\w[\\w\\d-]*)\n  )\n  (\n      (\\{(?:[^{}\'"]+|\'[^\']*\'|"[^"]*")*\\}) # attributes\n      (\\[[^\\]]*\\])?                          # slot\n    | (\\[[^\\]]*\\])                           # slot\n      (\\{(?:[^{}\'"]+|\'[^\']*\'|"[^"]*")*\\})? # attributes\n  )?\n  \\s',
+      name: 'inline.component.mdc',
+      captures: {
+        2: {
+          name: 'punctuation.definition.tag.start.component',
+        },
+        3: {
+          name: 'entity.name.tag.component',
+        },
+        5: {
+          patterns: [
+            {
+              include: '#attributes',
+            },
+          ],
+        },
+        6: {
+          patterns: [
+            {
+              include: '#span',
+            },
+          ],
+        },
+        7: {
+          patterns: [
+            {
+              include: '#span',
+            },
+          ],
+        },
+        8: {
+          patterns: [
+            {
+              include: '#attributes',
+            },
+          ],
+        },
+      },
+    },
+    'component_block': {
+      begin: '(?x)\n  (^|\\G)(\\s*)\n  (:{2,})     # component colons\n  (?i:\n    (\\w[\\w\\d-]+)   # component name\n    (                 # folowing spaces or attributes\n        \\s*\n      | \\s*(\\{(?:[^{}\'"]+|\'[^\']*\'|"[^"]*")*\\})\n    )\n    $\n  )',
+      name: 'block.component.mdc',
+      end: '(^|\\G)(\\2)(\\3)\\s*$',
+      beginCaptures: {
+        3: {
+          name: 'punctuation.definition.tag.start.mdc',
+        },
+        4: {
+          name: 'entity.name.tag.mdc',
+        },
+        5: {
+          patterns: [
+            {
+              include: '#attributes',
+            },
+          ],
+        },
+      },
+      endCaptures: {
+        3: {
+          name: 'punctuation.definition.tag.end.mdc',
+        },
+      },
+      patterns: [
+        {
+          match: '(^|\\G)\\s*([:]{2,})$',
+          captures: {
+            2: {
+              name: 'punctuation.definition.tag.end.mdc',
+            },
+          },
+        },
+        {
+          begin: '(^|\\G)(\\s*)(-{3})(\\s*)$',
+          end: '(^|\\G)(\\s*(-{3})(\\s*)$)',
+          patterns: [
+            {
+              include: 'source.yaml',
+            },
+          ],
+        },
+        {
+          match: '^(\\s*)(#[\\w\\-\\_]*)\\s*(<!--(.*)-->)?$',
+          captures: {
+            2: {
+              name: 'entity.other.attribute-name.html',
+            },
+            3: {
+              name: 'comment.block.html',
+            },
+          },
+        },
+        {
+          include: '#block',
+        },
+      ],
+    },
+    'attribute': {
+      patterns: [
+        {
+          match: '(?x)\n  (\n    ([^=><\\s]*)  # attribute name\n    (             # attribute value\n        =["]([^"]*)(["])|[\']([^\']*)([\'])\n      | =[^\\s\'"}]*\n    )?\n    \\s*\n  )',
+          captures: {
+            2: {
+              name: 'entity.other.attribute-name.html',
+            },
+            3: {
+              patterns: [
+                {
+                  include: '#attribute-interior',
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+    'attribute-interior': {
+      patterns: [
+        {
+          begin: '=',
+          beginCaptures: {
+            0: {
+              name: 'punctuation.separator.key-value.html',
+            },
+          },
+          end: '(?<=[^\\s=])(?!\\s*=)|(?=/?>)',
+          patterns: [
+            {
+              match: '([^\\s"\'=<>`/]|/(?!>))+',
+              name: 'string.unquoted.html',
+            },
+            {
+              begin: '"',
+              beginCaptures: {
+                0: {
+                  name: 'punctuation.definition.string.begin.html',
+                },
+              },
+              end: '"',
+              endCaptures: {
+                0: {
+                  name: 'punctuation.definition.string.end.html',
+                },
+              },
+              name: 'string.quoted.double.html',
+              patterns: [
+                {
+                  include: '#entities',
+                },
+              ],
+            },
+            {
+              begin: '\'',
+              beginCaptures: {
+                0: {
+                  name: 'punctuation.definition.string.begin.html',
+                },
+              },
+              end: '\'',
+              endCaptures: {
+                0: {
+                  name: 'punctuation.definition.string.end.html',
+                },
+              },
+              name: 'string.quoted.single.html',
+              patterns: [
+                {
+                  include: '#entities',
+                },
+              ],
+            },
+            {
+              match: '=',
+              name: 'invalid.illegal.unexpected-equals-sign.html',
+            },
+          ],
+        },
+      ],
+    },
+    'entities': {
+      patterns: [
+        {
+          captures: {
+            1: {
+              name: 'punctuation.definition.entity.html',
+            },
+            912: {
+              name: 'punctuation.definition.entity.html',
+            },
+          },
+          match: '(?x)\n\t\t\t\t\t\t(&)\t(?=[a-zA-Z])\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\t(a(s(ymp(eq)?|cr|t)|n(d(slope|d|v|and)?|g(s(t|ph)|zarr|e|le|rt(vb(d)?)?|msd(a(h|c|d|e|f|a|g|b))?)?)|c(y|irc|d|ute|E)?|tilde|o(pf|gon)|uml|p(id|os|prox(eq)?|e|E|acir)?|elig|f(r)?|w(conint|int)|l(pha|e(ph|fsym))|acute|ring|grave|m(p|a(cr|lg))|breve)|A(s(sign|cr)|nd|MP|c(y|irc)|tilde|o(pf|gon)|uml|pplyFunction|fr|Elig|lpha|acute|ring|grave|macr|breve))\n\t\t\t\t\t\t  | (B(scr|cy|opf|umpeq|e(cause|ta|rnoullis)|fr|a(ckslash|r(v|wed))|reve)|b(s(cr|im(e)?|ol(hsub|b)?|emi)|n(ot|e(quiv)?)|c(y|ong)|ig(s(tar|qcup)|c(irc|up|ap)|triangle(down|up)|o(times|dot|plus)|uplus|vee|wedge)|o(t(tom)?|pf|wtie|x(h(d|u|D|U)?|times|H(d|u|D|U)?|d(R|l|r|L)|u(R|l|r|L)|plus|D(R|l|r|L)|v(R|h|H|l|r|L)?|U(R|l|r|L)|V(R|h|H|l|r|L)?|minus|box))|Not|dquo|u(ll(et)?|mp(e(q)?|E)?)|prime|e(caus(e)?|t(h|ween|a)|psi|rnou|mptyv)|karow|fr|l(ock|k(1(2|4)|34)|a(nk|ck(square|triangle(down|left|right)?|lozenge)))|a(ck(sim(eq)?|cong|prime|epsilon)|r(vee|wed(ge)?))|r(eve|vbar)|brk(tbrk)?))\n\t\t\t\t\t\t  | (c(s(cr|u(p(e)?|b(e)?))|h(cy|i|eck(mark)?)|ylcty|c(irc|ups(sm)?|edil|a(ps|ron))|tdot|ir(scir|c(eq|le(d(R|circ|S|dash|ast)|arrow(left|right)))?|e|fnint|E|mid)?|o(n(int|g(dot)?)|p(y(sr)?|f|rod)|lon(e(q)?)?|m(p(fn|le(xes|ment))?|ma(t)?))|dot|u(darr(l|r)|p(s|c(up|ap)|or|dot|brcap)?|e(sc|pr)|vee|wed|larr(p)?|r(vearrow(left|right)|ly(eq(succ|prec)|vee|wedge)|arr(m)?|ren))|e(nt(erdot)?|dil|mptyv)|fr|w(conint|int)|lubs(uit)?|a(cute|p(s|c(up|ap)|dot|and|brcup)?|r(on|et))|r(oss|arr))|C(scr|hi|c(irc|onint|edil|aron)|ircle(Minus|Times|Dot|Plus)|Hcy|o(n(tourIntegral|int|gruent)|unterClockwiseContourIntegral|p(f|roduct)|lon(e)?)|dot|up(Cap)?|OPY|e(nterDot|dilla)|fr|lo(seCurly(DoubleQuote|Quote)|ckwiseContourIntegral)|a(yleys|cute|p(italDifferentialD)?)|ross))\n\t\t\t\t\t\t  | (d(s(c(y|r)|trok|ol)|har(l|r)|c(y|aron)|t(dot|ri(f)?)|i(sin|e|v(ide(ontimes)?|onx)?|am(s|ond(suit)?)?|gamma)|Har|z(cy|igrarr)|o(t(square|plus|eq(dot)?|minus)?|ublebarwedge|pf|wn(harpoon(left|right)|downarrows|arrow)|llar)|d(otseq|a(rr|gger))?|u(har|arr)|jcy|e(lta|g|mptyv)|f(isht|r)|wangle|lc(orn|rop)|a(sh(v)?|leth|rr|gger)|r(c(orn|rop)|bkarow)|b(karow|lac)|Arr)|D(s(cr|trok)|c(y|aron)|Scy|i(fferentialD|a(critical(Grave|Tilde|Do(t|ubleAcute)|Acute)|mond))|o(t(Dot|Equal)?|uble(Right(Tee|Arrow)|ContourIntegral|Do(t|wnArrow)|Up(DownArrow|Arrow)|VerticalBar|L(ong(RightArrow|Left(RightArrow|Arrow))|eft(RightArrow|Tee|Arrow)))|pf|wn(Right(TeeVector|Vector(Bar)?)|Breve|Tee(Arrow)?|arrow|Left(RightVector|TeeVector|Vector(Bar)?)|Arrow(Bar|UpArrow)?))|Zcy|el(ta)?|D(otrahd)?|Jcy|fr|a(shv|rr|gger)))\n\t\t\t\t\t\t  | (e(s(cr|im|dot)|n(sp|g)|c(y|ir(c)?|olon|aron)|t(h|a)|o(pf|gon)|dot|u(ro|ml)|p(si(v|lon)?|lus|ar(sl)?)|e|D(ot|Dot)|q(s(im|lant(less|gtr))|c(irc|olon)|u(iv(DD)?|est|als)|vparsl)|f(Dot|r)|l(s(dot)?|inters|l)?|a(ster|cute)|r(Dot|arr)|g(s(dot)?|rave)?|x(cl|ist|p(onentiale|ectation))|m(sp(1(3|4))?|pty(set|v)?|acr))|E(s(cr|im)|c(y|irc|aron)|ta|o(pf|gon)|NG|dot|uml|TH|psilon|qu(ilibrium|al(Tilde)?)|fr|lement|acute|grave|x(ists|ponentialE)|m(pty(SmallSquare|VerySmallSquare)|acr)))\n\t\t\t\t\t\t  | (f(scr|nof|cy|ilig|o(pf|r(k(v)?|all))|jlig|partint|emale|f(ilig|l(ig|lig)|r)|l(tns|lig|at)|allingdotseq|r(own|a(sl|c(1(2|8|3|4|5|6)|78|2(3|5)|3(8|4|5)|45|5(8|6)))))|F(scr|cy|illed(SmallSquare|VerySmallSquare)|o(uriertrf|pf|rAll)|fr))\n\t\t\t\t\t\t  | (G(scr|c(y|irc|edil)|t|opf|dot|T|Jcy|fr|amma(d)?|reater(Greater|SlantEqual|Tilde|Equal(Less)?|FullEqual|Less)|g|breve)|g(s(cr|im(e|l)?)|n(sim|e(q(q)?)?|E|ap(prox)?)|c(y|irc)|t(c(c|ir)|dot|quest|lPar|r(sim|dot|eq(qless|less)|less|a(pprox|rr)))?|imel|opf|dot|jcy|e(s(cc|dot(o(l)?)?|l(es)?)?|q(slant|q)?|l)?|v(nE|ertneqq)|fr|E(l)?|l(j|E|a)?|a(cute|p|mma(d)?)|rave|g(g)?|breve))\n\t\t\t\t\t\t  | (h(s(cr|trok|lash)|y(phen|bull)|circ|o(ok(leftarrow|rightarrow)|pf|arr|rbar|mtht)|e(llip|arts(uit)?|rcon)|ks(earow|warow)|fr|a(irsp|lf|r(dcy|r(cir|w)?)|milt)|bar|Arr)|H(s(cr|trok)|circ|ilbertSpace|o(pf|rizontalLine)|ump(DownHump|Equal)|fr|a(cek|t)|ARDcy))\n\t\t\t\t\t\t  | (i(s(cr|in(s(v)?|dot|v|E)?)|n(care|t(cal|prod|e(rcal|gers)|larhk)?|odot|fin(tie)?)?|c(y|irc)?|t(ilde)?|i(nfin|i(nt|int)|ota)?|o(cy|ta|pf|gon)|u(kcy|ml)|jlig|prod|e(cy|xcl)|quest|f(f|r)|acute|grave|m(of|ped|a(cr|th|g(part|e|line))))|I(scr|n(t(e(rsection|gral))?|visible(Comma|Times))|c(y|irc)|tilde|o(ta|pf|gon)|dot|u(kcy|ml)|Ocy|Jlig|fr|Ecy|acute|grave|m(plies|a(cr|ginaryI))?))\n\t\t\t\t\t\t  | (j(s(cr|ercy)|c(y|irc)|opf|ukcy|fr|math)|J(s(cr|ercy)|c(y|irc)|opf|ukcy|fr))\n\t\t\t\t\t\t  | (k(scr|hcy|c(y|edil)|opf|jcy|fr|appa(v)?|green)|K(scr|c(y|edil)|Hcy|opf|Jcy|fr|appa))\n\t\t\t\t\t\t  | (l(s(h|cr|trok|im(e|g)?|q(uo(r)?|b)|aquo)|h(ar(d|u(l)?)|blk)|n(sim|e(q(q)?)?|E|ap(prox)?)|c(y|ub|e(il|dil)|aron)|Barr|t(hree|c(c|ir)|imes|dot|quest|larr|r(i(e|f)?|Par))?|Har|o(ng(left(arrow|rightarrow)|rightarrow|mapsto)|times|z(enge|f)?|oparrow(left|right)|p(f|lus|ar)|w(ast|bar)|a(ng|rr)|brk)|d(sh|ca|quo(r)?|r(dhar|ushar))|ur(dshar|uhar)|jcy|par(lt)?|e(s(s(sim|dot|eq(qgtr|gtr)|approx|gtr)|cc|dot(o(r)?)?|g(es)?)?|q(slant|q)?|ft(harpoon(down|up)|threetimes|leftarrows|arrow(tail)?|right(squigarrow|harpoons|arrow(s)?))|g)?|v(nE|ertneqq)|f(isht|loor|r)|E(g)?|l(hard|corner|tri|arr)?|a(ng(d|le)?|cute|t(e(s)?|ail)?|p|emptyv|quo|rr(sim|hk|tl|pl|fs|lp|b(fs)?)?|gran|mbda)|r(har(d)?|corner|tri|arr|m)|g(E)?|m(idot|oust(ache)?)|b(arr|r(k(sl(d|u)|e)|ac(e|k))|brk)|A(tail|arr|rr))|L(s(h|cr|trok)|c(y|edil|aron)|t|o(ng(RightArrow|left(arrow|rightarrow)|rightarrow|Left(RightArrow|Arrow))|pf|wer(RightArrow|LeftArrow))|T|e(ss(Greater|SlantEqual|Tilde|EqualGreater|FullEqual|Less)|ft(Right(Vector|Arrow)|Ceiling|T(ee(Vector|Arrow)?|riangle(Bar|Equal)?)|Do(ubleBracket|wn(TeeVector|Vector(Bar)?))|Up(TeeVector|DownVector|Vector(Bar)?)|Vector(Bar)?|arrow|rightarrow|Floor|A(ngleBracket|rrow(RightArrow|Bar)?)))|Jcy|fr|l(eftarrow)?|a(ng|cute|placetrf|rr|mbda)|midot))\n\t\t\t\t\t\t  | (M(scr|cy|inusPlus|opf|u|e(diumSpace|llintrf)|fr|ap)|m(s(cr|tpos)|ho|nplus|c(y|omma)|i(nus(d(u)?|b)?|cro|d(cir|dot|ast)?)|o(dels|pf)|dash|u(ltimap|map)?|p|easuredangle|DDot|fr|l(cp|dr)|a(cr|p(sto(down|up|left)?)?|l(t(ese)?|e)|rker)))\n\t\t\t\t\t\t  | (n(s(hort(parallel|mid)|c(cue|e|r)?|im(e(q)?)?|u(cc(eq)?|p(set(eq(q)?)?|e|E)?|b(set(eq(q)?)?|e|E)?)|par|qsu(pe|be)|mid)|Rightarrow|h(par|arr|Arr)|G(t(v)?|g)|c(y|ong(dot)?|up|edil|a(p|ron))|t(ilde|lg|riangle(left(eq)?|right(eq)?)|gl)|i(s(d)?|v)?|o(t(ni(v(c|a|b))?|in(dot|v(c|a|b)|E)?)?|pf)|dash|u(m(sp|ero)?)?|jcy|p(olint|ar(sl|t|allel)?|r(cue|e(c(eq)?)?)?)|e(s(im|ear)|dot|quiv|ar(hk|r(ow)?)|xist(s)?|Arr)?|v(sim|infin|Harr|dash|Dash|l(t(rie)?|e|Arr)|ap|r(trie|Arr)|g(t|e))|fr|w(near|ar(hk|r(ow)?)|Arr)|V(dash|Dash)|l(sim|t(ri(e)?)?|dr|e(s(s)?|q(slant|q)?|ft(arrow|rightarrow))?|E|arr|Arr)|a(ng|cute|tur(al(s)?)?|p(id|os|prox|E)?|bla)|r(tri(e)?|ightarrow|arr(c|w)?|Arr)|g(sim|t(r)?|e(s|q(slant|q)?)?|E)|mid|L(t(v)?|eft(arrow|rightarrow)|l)|b(sp|ump(e)?))|N(scr|c(y|edil|aron)|tilde|o(nBreakingSpace|Break|t(R(ightTriangle(Bar|Equal)?|everseElement)|Greater(Greater|SlantEqual|Tilde|Equal|FullEqual|Less)?|S(u(cceeds(SlantEqual|Tilde|Equal)?|perset(Equal)?|bset(Equal)?)|quareSu(perset(Equal)?|bset(Equal)?))|Hump(DownHump|Equal)|Nested(GreaterGreater|LessLess)|C(ongruent|upCap)|Tilde(Tilde|Equal|FullEqual)?|DoubleVerticalBar|Precedes(SlantEqual|Equal)?|E(qual(Tilde)?|lement|xists)|VerticalBar|Le(ss(Greater|SlantEqual|Tilde|Equal|Less)?|ftTriangle(Bar|Equal)?))?|pf)|u|e(sted(GreaterGreater|LessLess)|wLine|gative(MediumSpace|Thi(nSpace|ckSpace)|VeryThinSpace))|Jcy|fr|acute))\n\t\t\t\t\t\t  | (o(s(cr|ol|lash)|h(m|bar)|c(y|ir(c)?)|ti(lde|mes(as)?)|S|int|opf|d(sold|iv|ot|ash|blac)|uml|p(erp|lus|ar)|elig|vbar|f(cir|r)|l(c(ir|ross)|t|ine|arr)|a(st|cute)|r(slope|igof|or|d(er(of)?|f|m)?|v|arr)?|g(t|on|rave)|m(i(nus|cron|d)|ega|acr))|O(s(cr|lash)|c(y|irc)|ti(lde|mes)|opf|dblac|uml|penCurly(DoubleQuote|Quote)|ver(B(ar|rac(e|ket))|Parenthesis)|fr|Elig|acute|r|grave|m(icron|ega|acr)))\n\t\t\t\t\t\t  | (p(s(cr|i)|h(i(v)?|one|mmat)|cy|i(tchfork|v)?|o(intint|und|pf)|uncsp|er(cnt|tenk|iod|p|mil)|fr|l(us(sim|cir|two|d(o|u)|e|acir|mn|b)?|an(ck(h)?|kv))|ar(s(im|l)|t|a(llel)?)?|r(sim|n(sim|E|ap)|cue|ime(s)?|o(d|p(to)?|f(surf|line|alar))|urel|e(c(sim|n(sim|eqq|approx)|curlyeq|eq|approx)?)?|E|ap)?|m)|P(s(cr|i)|hi|cy|i|o(incareplane|pf)|fr|lusMinus|artialD|r(ime|o(duct|portion(al)?)|ecedes(SlantEqual|Tilde|Equal)?)?))\n\t\t\t\t\t\t  | (q(scr|int|opf|u(ot|est(eq)?|at(int|ernions))|prime|fr)|Q(scr|opf|UOT|fr))\n\t\t\t\t\t\t  | (R(s(h|cr)|ho|c(y|edil|aron)|Barr|ight(Ceiling|T(ee(Vector|Arrow)?|riangle(Bar|Equal)?)|Do(ubleBracket|wn(TeeVector|Vector(Bar)?))|Up(TeeVector|DownVector|Vector(Bar)?)|Vector(Bar)?|arrow|Floor|A(ngleBracket|rrow(Bar|LeftArrow)?))|o(undImplies|pf)|uleDelayed|e(verse(UpEquilibrium|E(quilibrium|lement)))?|fr|EG|a(ng|cute|rr(tl)?)|rightarrow)|r(s(h|cr|q(uo(r)?|b)|aquo)|h(o(v)?|ar(d|u(l)?))|nmid|c(y|ub|e(il|dil)|aron)|Barr|t(hree|imes|ri(e|f|ltri)?)|i(singdotseq|ng|ght(squigarrow|harpoon(down|up)|threetimes|left(harpoons|arrows)|arrow(tail)?|rightarrows))|Har|o(times|p(f|lus|ar)|a(ng|rr)|brk)|d(sh|ca|quo(r)?|ldhar)|uluhar|p(polint|ar(gt)?)|e(ct|al(s|ine|part)?|g)|f(isht|loor|r)|l(har|arr|m)|a(ng(d|e|le)?|c(ute|e)|t(io(nals)?|ail)|dic|emptyv|quo|rr(sim|hk|c|tl|pl|fs|w|lp|ap|b(fs)?)?)|rarr|x|moust(ache)?|b(arr|r(k(sl(d|u)|e)|ac(e|k))|brk)|A(tail|arr|rr)))\n\t\t\t\t\t\t  | (s(s(cr|tarf|etmn|mile)|h(y|c(hcy|y)|ort(parallel|mid)|arp)|c(sim|y|n(sim|E|ap)|cue|irc|polint|e(dil)?|E|a(p|ron))?|t(ar(f)?|r(ns|aight(phi|epsilon)))|i(gma(v|f)?|m(ne|dot|plus|e(q)?|l(E)?|rarr|g(E)?)?)|zlig|o(pf|ftcy|l(b(ar)?)?)|dot(e|b)?|u(ng|cc(sim|n(sim|eqq|approx)|curlyeq|eq|approx)?|p(s(im|u(p|b)|et(neq(q)?|eq(q)?)?)|hs(ol|ub)|1|n(e|E)|2|d(sub|ot)|3|plus|e(dot)?|E|larr|mult)?|m|b(s(im|u(p|b)|et(neq(q)?|eq(q)?)?)|n(e|E)|dot|plus|e(dot)?|E|rarr|mult)?)|pa(des(uit)?|r)|e(swar|ct|tm(n|inus)|ar(hk|r(ow)?)|xt|mi|Arr)|q(su(p(set(eq)?|e)?|b(set(eq)?|e)?)|c(up(s)?|ap(s)?)|u(f|ar(e|f))?)|fr(own)?|w(nwar|ar(hk|r(ow)?)|Arr)|larr|acute|rarr|m(t(e(s)?)?|i(d|le)|eparsl|a(shp|llsetminus))|bquo)|S(scr|hort(RightArrow|DownArrow|UpArrow|LeftArrow)|c(y|irc|edil|aron)?|tar|igma|H(cy|CHcy)|opf|u(c(hThat|ceeds(SlantEqual|Tilde|Equal)?)|p(set|erset(Equal)?)?|m|b(set(Equal)?)?)|OFTcy|q(uare(Su(perset(Equal)?|bset(Equal)?)|Intersection|Union)?|rt)|fr|acute|mallCircle))\n\t\t\t\t\t\t  | (t(s(hcy|c(y|r)|trok)|h(i(nsp|ck(sim|approx))|orn|e(ta(sym|v)?|re(4|fore))|k(sim|ap))|c(y|edil|aron)|i(nt|lde|mes(d|b(ar)?)?)|o(sa|p(cir|f(ork)?|bot)?|ea)|dot|prime|elrec|fr|w(ixt|ohead(leftarrow|rightarrow))|a(u|rget)|r(i(sb|time|dot|plus|e|angle(down|q|left(eq)?|right(eq)?)?|minus)|pezium|ade)|brk)|T(s(cr|trok)|RADE|h(i(nSpace|ckSpace)|e(ta|refore))|c(y|edil|aron)|S(cy|Hcy)|ilde(Tilde|Equal|FullEqual)?|HORN|opf|fr|a(u|b)|ripleDot))\n\t\t\t\t\t\t  | (u(scr|h(ar(l|r)|blk)|c(y|irc)|t(ilde|dot|ri(f)?)|Har|o(pf|gon)|d(har|arr|blac)|u(arr|ml)|p(si(h|lon)?|harpoon(left|right)|downarrow|uparrows|lus|arrow)|f(isht|r)|wangle|l(c(orn(er)?|rop)|tri)|a(cute|rr)|r(c(orn(er)?|rop)|tri|ing)|grave|m(l|acr)|br(cy|eve)|Arr)|U(scr|n(ion(Plus)?|der(B(ar|rac(e|ket))|Parenthesis))|c(y|irc)|tilde|o(pf|gon)|dblac|uml|p(si(lon)?|downarrow|Tee(Arrow)?|per(RightArrow|LeftArrow)|DownArrow|Equilibrium|arrow|Arrow(Bar|DownArrow)?)|fr|a(cute|rr(ocir)?)|ring|grave|macr|br(cy|eve)))\n\t\t\t\t\t\t  | (v(s(cr|u(pn(e|E)|bn(e|E)))|nsu(p|b)|cy|Bar(v)?|zigzag|opf|dash|prop|e(e(eq|bar)?|llip|r(t|bar))|Dash|fr|ltri|a(ngrt|r(s(igma|u(psetneq(q)?|bsetneq(q)?))|nothing|t(heta|riangle(left|right))|p(hi|i|ropto)|epsilon|kappa|r(ho)?))|rtri|Arr)|V(scr|cy|opf|dash(l)?|e(e|r(yThinSpace|t(ical(Bar|Separator|Tilde|Line))?|bar))|Dash|vdash|fr|bar))\n\t\t\t\t\t\t  | (w(scr|circ|opf|p|e(ierp|d(ge(q)?|bar))|fr|r(eath)?)|W(scr|circ|opf|edge|fr))\n\t\t\t\t\t\t  | (X(scr|i|opf|fr)|x(s(cr|qcup)|h(arr|Arr)|nis|c(irc|up|ap)|i|o(time|dot|p(f|lus))|dtri|u(tri|plus)|vee|fr|wedge|l(arr|Arr)|r(arr|Arr)|map))\n\t\t\t\t\t\t  | (y(scr|c(y|irc)|icy|opf|u(cy|ml)|en|fr|ac(y|ute))|Y(scr|c(y|irc)|opf|uml|Icy|Ucy|fr|acute|Acy))\n\t\t\t\t\t\t  | (z(scr|hcy|c(y|aron)|igrarr|opf|dot|e(ta|etrf)|fr|w(nj|j)|acute)|Z(scr|c(y|aron)|Hcy|opf|dot|e(ta|roWidthSpace)|fr|acute))\n\t\t\t\t\t\t)\n\t\t\t\t\t\t(;)\n\t\t\t\t\t',
+          name: 'constant.character.entity.named.$2.html',
+        },
+        {
+          captures: {
+            1: {
+              name: 'punctuation.definition.entity.html',
+            },
+            3: {
+              name: 'punctuation.definition.entity.html',
+            },
+          },
+          match: '(&)#[0-9]+(;)',
+          name: 'constant.character.entity.numeric.decimal.html',
+        },
+        {
+          captures: {
+            1: {
+              name: 'punctuation.definition.entity.html',
+            },
+            3: {
+              name: 'punctuation.definition.entity.html',
+            },
+          },
+          match: '(&)#[xX][0-9a-fA-F]+(;)',
+          name: 'constant.character.entity.numeric.hexadecimal.html',
+        },
+        {
+          match: '&(?=[a-zA-Z0-9]+;)',
+          name: 'invalid.illegal.ambiguous-ampersand.html',
+        },
+      ],
+    },
+    'heading': {
+      match: '(?:^|\\G)[ ]*(#{1,6}\\s+(.*?)(\\s+#{1,6})?\\s*)$',
+      captures: {
+        1: {
+          patterns: [
+            {
+              match: '(#{6})\\s+(.*?)(?:\\s+(#+))?\\s*$',
+              name: 'heading.6.markdown',
+              captures: {
+                1: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+                2: {
+                  name: 'entity.name.section.markdown',
+                  patterns: [
+                    {
+                      include: 'text.html.markdown#inline',
+                    },
+                    {
+                      include: 'text.html.derivative',
+                    },
+                  ],
+                },
+                3: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+              },
+            },
+            {
+              match: '(#{5})\\s+(.*?)(?:\\s+(#+))?\\s*$',
+              name: 'heading.5.markdown',
+              captures: {
+                1: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+                2: {
+                  name: 'entity.name.section.markdown',
+                  patterns: [
+                    {
+                      include: 'text.html.markdown#inline',
+                    },
+                    {
+                      include: 'text.html.derivative',
+                    },
+                  ],
+                },
+                3: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+              },
+            },
+            {
+              match: '(#{4})\\s+(.*?)(?:\\s+(#+))?\\s*$',
+              name: 'heading.4.markdown',
+              captures: {
+                1: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+                2: {
+                  name: 'entity.name.section.markdown',
+                  patterns: [
+                    {
+                      include: 'text.html.markdown#inline',
+                    },
+                    {
+                      include: 'text.html.derivative',
+                    },
+                  ],
+                },
+                3: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+              },
+            },
+            {
+              match: '(#{3})\\s+(.*?)(?:\\s+(#+))?\\s*$',
+              name: 'heading.3.markdown',
+              captures: {
+                1: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+                2: {
+                  name: 'entity.name.section.markdown',
+                  patterns: [
+                    {
+                      include: 'text.html.markdown#inline',
+                    },
+                    {
+                      include: 'text.html.derivative',
+                    },
+                  ],
+                },
+                3: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+              },
+            },
+            {
+              match: '(#{2})\\s+(.*?)(?:\\s+(#+))?\\s*$',
+              name: 'heading.2.markdown',
+              captures: {
+                1: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+                2: {
+                  name: 'entity.name.section.markdown',
+                  patterns: [
+                    {
+                      include: 'text.html.markdown#inline',
+                    },
+                    {
+                      include: 'text.html.derivative',
+                    },
+                  ],
+                },
+                3: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+              },
+            },
+            {
+              match: '(#{1})\\s+(.*?)(?:\\s+(#+))?\\s*$',
+              name: 'heading.1.markdown',
+              captures: {
+                1: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+                2: {
+                  name: 'entity.name.section.markdown',
+                  patterns: [
+                    {
+                      include: 'text.html.markdown#inline',
+                    },
+                    {
+                      include: 'text.html.derivative',
+                    },
+                  ],
+                },
+                3: {
+                  name: 'punctuation.definition.heading.markdown',
+                },
+              },
+            },
+          ],
+        },
+      },
+      name: 'markup.heading.markdown',
+      patterns: [
+        {
+          include: 'text.html.markdown#inline',
+        },
+      ],
+    },
+    'heading-setext': {
+      patterns: [
+        {
+          match: '^(={3,})(?=[ \\t]*$\\n?)',
+          name: 'markup.heading.setext.1.markdown',
+        },
+        {
+          match: '^(-{3,})(?=[ \\t]*$\\n?)',
+          name: 'markup.heading.setext.2.markdown',
+        },
+      ],
+    },
+    'lists': {
+      patterns: [
+        {
+          begin: '(^|\\G)([ ]*)([*+-])([ \\t])',
+          beginCaptures: {
+            3: {
+              name: 'punctuation.definition.list.begin.markdown',
+            },
+          },
+          name: 'markup.list.unnumbered.markdown',
+          patterns: [
+            {
+              include: '#block',
+            },
+            {
+              include: 'text.html.markdown#list_paragraph',
+            },
+          ],
+          while: '((^|\\G)[ \\t]+)|(^[ \\t]*$)',
+        },
+        {
+          begin: '(^|\\G)([ ]*)([0-9]+\\.)([ \\t])',
+          beginCaptures: {
+            3: {
+              name: 'punctuation.definition.list.begin.markdown',
+            },
+          },
+          name: 'markup.list.numbered.markdown',
+          patterns: [
+            {
+              include: '#block',
+            },
+            {
+              include: 'text.html.markdown#list_paragraph',
+            },
+          ],
+          while: '((^|\\G)[ \\t]+)|(^[ \\t]*$)',
+        },
+      ],
+    },
+    'paragraph': {
+      begin: '(^|\\G)[ ]*(?=\\S)',
+      name: 'meta.paragraph.markdown',
+      patterns: [
+        {
+          include: '#inline',
+        },
+        {
+          include: 'text.html.derivative',
+        },
+        {
+          include: '#heading-setext',
+        },
+      ],
+      while: '(^|\\G)((?=\\s*[-=]{3,}\\s*$)|[ ]{4,}(?=\\S))',
+    },
+    'blockquote': {
+      begin: '(^|\\G)[ ]*(>) ?',
+      captures: {
+        2: {
+          name: 'punctuation.definition.quote.begin.markdown',
+        },
+      },
+      name: 'markup.quote.markdown',
+      patterns: [
+        {
+          include: '#block',
+        },
+      ],
+      while: '(^|\\G)\\s*(>) ?',
+    },
+  },
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

while working on the benchmark file, I noticed that our highlight plugin is significantly slower than others. this PR optimizes the plugin to eliminate overhead in the hot path brining from `~1.65 ms` down to `~175 µs` for small inputs



| Before | After |
|--------|--------|
| <img width="482" height="987" alt="Screenshot 2026-04-24 at 12 18 46 PM" src="https://github.com/user-attachments/assets/f8364871-df0c-4dd9-be74-f58759f07432" /> | <img width="482" height="987" alt="Screenshot 2026-04-24 at 12 16 30 PM" src="https://github.com/user-attachments/assets/5218df1c-c8b5-4e4f-b6c3-ab379535d7fc" /> | 



#### What changed

1. `getHighlighter()`
If the singleton highlighter is already there and we’re not passing custom themes/languages (which is most cases), we just return it.
Before, it would still go through registerDefaults() and await a bunch of dynamic imports + theme/language loads… even when everything was already loaded.


2. `hastToMinimarkNode()`: no more extra allocations
Got rid of the spread + .map() combo and replaced it with a pre-allocated array + simple for-loop.
Previously we were creating a mapped array and then spreading it into another array — so 2 allocations per node.

Also moved it out of highlightCode so it’s not recreated on every call.


3. `highlightCodeBlocks()`: no async overhead
codeToHast (from Shiki v4) is actually synchronous.
We were wrapping it in Promise.all(...map(async ...)), which just added unnecessary microtask overhead per block.

Now it’s just a plain loop.


4. `findCodeBlocks()`: zero-allocation traversal
The old recursion was creating a new path array and slicing children on every step.

Switched to a shared pathBuf with push/pop, and just iterating children starting from index 2.
No more extra arrays per recursion.


5. Highlight line lookup: using a Set
Swapped .includes() (O(n)) for a Set (O(1)).
Simple win since this runs per line.

6. Code node construction: pre-allocated array
Instead of spreading potentially hundreds of children (['code', attrs, ...children]),
we allocate once and fill it with a loop.

7. Class string building: simpler concat
Replaced the array + .filter().join() with direct string concatenation and a precomputed suffix.
Less work, same result.

8. Tree cloning — only copy what we touch
Got rid of JSON.parse(JSON.stringify(...)).

Now we only copy the path (spine) down to the modified `<pre>` nodes, and keep the rest of the tree shared.
Way less memory churn.


#### What didn’t change


- Public API: everything stays the same (highlightCode, highlightCodeBlocks, etc.)
- Output: exact same tree structure, tags, attrs, classes, ordering
- Line highlighting behaviuor: unchanged
- Theme/language loading: same defaults + lazy loading
- Error handling: still falls back to raw code if highlighting fails

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have run `pnpm verify` and it passes.
- [ ] I have updated the documentation accordingly.