### PR TITLE
perf(plugins): optimize highlight to use codeToTokens fast path to skip hast intermediary

### DIFF
--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -283,8 +283,7 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
         const cls = (preNode[1] as ComarkElementAttributes).class
         classStr = Array.isArray(cls) ? cls.join(' ') : String(cls)
         codeChildren = (preNode[2] as ComarkElement).slice(2) as ComarkNode[]
-      }
-      else {
+      } else {
         // Fast path: build ComarkNodes directly from tokens, skipping hast
         const result = codeToTokens(hl, code, {
           lang: language,
@@ -305,22 +304,22 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
           const spans: ComarkNode[] = []
           for (let t = 0; t < spanCount; t++) {
             const tk = line[t]
-            const canMerge = !(tk.fontStyle && (tk.fontStyle & 8 /* Strikethrough */ || tk.fontStyle & 4 /* Underline */))
+            const canMerge = !(
+              tk.fontStyle &&
+              (tk.fontStyle & 8 /* Strikethrough */ || tk.fontStyle & 4) /* Underline */
+            )
             if (canMerge && /^\s+$/.test(tk.content) && t + 1 < spanCount) {
               carry += tk.content
-            }
-            else if (carry) {
+            } else if (carry) {
               const style = stringifyTokenStyle(tk.htmlStyle || getTokenStyleObject(tk))
               if (canMerge) {
                 spans.push(style ? ['span', { style }, carry + tk.content] : ['span', {}, carry + tk.content])
-              }
-              else {
+              } else {
                 spans.push(['span', {}, carry])
                 spans.push(style ? ['span', { style }, tk.content] : ['span', {}, tk.content])
               }
               carry = ''
-            }
-            else {
+            } else {
               const style = stringifyTokenStyle(tk.htmlStyle || getTokenStyleObject(tk))
               spans.push(style ? ['span', { style }, tk.content] : ['span', {}, tk.content])
             }
@@ -340,8 +339,7 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
           if (li < tokenLines.length - 1) codeChildren.push('\n')
         }
       }
-    }
-    catch {
+    } catch {
       classStr = 'shiki'
       codeChildren = [code]
     }
@@ -357,8 +355,7 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
           child[1].class = `${child[1].class ?? ''} highlight`.trim()
           // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
           child[1].style = 'display: inline-block'
-        }
-        else {
+        } else {
           // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
           child[1].style = 'display: inline'
         }

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -3,7 +3,7 @@ import type { ComarkElement, ComarkNode, ComarkTree, ComarkElementAttributes } f
 import { defineComarkPlugin } from '../utils/helpers.ts'
 import { createShikiPrimitive } from 'shiki'
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
-import { codeToHast } from 'shiki/core'
+import { codeToHast, codeToTokens, getTokenStyleObject, stringifyTokenStyle } from 'shiki/core'
 import comakLanguage from '../utils/comark.tmLanguage.ts'
 
 export interface HighlightOptions {
@@ -255,69 +255,115 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
     dark: lightTheme !== darkTheme ? darkTheme : undefined,
   }
 
-  // eslint-disable-next-line unicorn/no-new-array -- pre-allocated for perf
-  const highlightedResults: Array<{ nodes: ComarkNode[]; language: string }> = new Array(codeBlocks.length)
-  for (let i = 0; i < codeBlocks.length; i++) {
-    const { node } = codeBlocks[i]
-    const code = (node[2] as any)[2] as string
-    const attrs = node[1] as CodeBlockAttributes
-    const language: string = (attrs as any)?.language
-    try {
-      const result = codeToHast(hl, code, {
-        lang: language,
-        transformers: options.transformers,
-        themes: themeOptions,
-        meta: {
-          __raw: attrs.meta,
-        },
-      })
-      highlightedResults[i] = {
-        nodes: result.children.map(hastToComarkNode) as ComarkNode[],
-        language,
-      }
-    } catch {
-      highlightedResults[i] = { nodes: [code], language }
-    }
-  }
-
+  const hasTransformers = options.transformers && options.transformers.length > 0
   const darkClassSuffix = options.themes?.dark?.name ? ` dark:${options.themes.dark.name}` : ''
 
   // Build new nodes array, spine-copying only paths to modified <pre> nodes
   const newNodes = [...tree.nodes] as ComarkNode[]
   for (let i = 0; i < codeBlocks.length; i++) {
     const { node, path } = codeBlocks[i]
-    const preAttrs = node[1] as Record<string, any>
-    const result = highlightedResults[i]
+    const code = (node[2] as any)[2] as string
+    const attrs = node[1] as CodeBlockAttributes
+    const preAttrs = attrs as Record<string, any>
+    const language: string = (attrs as any)?.language
 
-    const preNode = result.nodes[0]
     let classStr: string
-    if (typeof preNode === 'string') {
-      classStr = 'shiki' + (options.themes?.light?.name ? ` ${options.themes.light.name}` : '')
-    } else {
-      const cls = (preNode[1] as ComarkElementAttributes).class
-      classStr = Array.isArray(cls) ? cls.join(' ') : String(cls)
-    }
-    if (darkClassSuffix) classStr += darkClassSuffix
+    let codeChildren: ComarkNode[]
 
-    const codeChildren =
-      typeof preNode === 'string' ? preNode : ((preNode[2] as ComarkElement).slice(2) as ComarkNode[])
+    try {
+      if (hasTransformers) {
+        // Transformers operate on hast, so we must go through codeToHast
+        const result = codeToHast(hl, code, {
+          lang: language,
+          transformers: options.transformers,
+          themes: themeOptions,
+          meta: { __raw: attrs.meta },
+        })
+        const preNode = result.children.map(hastToComarkNode)[0] as ComarkElement
+        const cls = (preNode[1] as ComarkElementAttributes).class
+        classStr = Array.isArray(cls) ? cls.join(' ') : String(cls)
+        codeChildren = (preNode[2] as ComarkElement).slice(2) as ComarkNode[]
+      }
+      else {
+        // Fast path: build ComarkNodes directly from tokens, skipping hast
+        const result = codeToTokens(hl, code, {
+          lang: language,
+          themes: themeOptions,
+        })
+        classStr = `shiki ${result.themeName || ''}`
 
-    if (Array.isArray(codeChildren)) {
-      const highlightSet = Array.isArray(preAttrs.highlights) ? new Set<number>(preAttrs.highlights) : null
-      let line = 1
-      for (const child of codeChildren) {
-        if (Array.isArray(child)) {
-          if (highlightSet !== null && highlightSet.has(line)) {
-            child[1].class = `${child[1].class ?? ''} highlight`.trim()
-            // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
-            child[1].style = 'display: inline-block'
-          } else {
-            // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
-            child[1].style = 'display: inline'
+        // Replicate shiki's mergeWhitespaceTokens: merge pure-whitespace tokens
+        // into the following token (unless underline/strikethrough styled)
+        const tokenLines = result.tokens
+        codeChildren = []
+        for (let li = 0; li < tokenLines.length; li++) {
+          const line = tokenLines[li]
+          const spanCount = line.length
+
+          // Merge whitespace tokens inline while building spans
+          let carry = ''
+          const spans: ComarkNode[] = []
+          for (let t = 0; t < spanCount; t++) {
+            const tk = line[t]
+            const canMerge = !(tk.fontStyle && (tk.fontStyle & 8 /* Strikethrough */ || tk.fontStyle & 4 /* Underline */))
+            if (canMerge && /^\s+$/.test(tk.content) && t + 1 < spanCount) {
+              carry += tk.content
+            }
+            else if (carry) {
+              const style = stringifyTokenStyle(tk.htmlStyle || getTokenStyleObject(tk))
+              if (canMerge) {
+                spans.push(style ? ['span', { style }, carry + tk.content] : ['span', {}, carry + tk.content])
+              }
+              else {
+                spans.push(['span', {}, carry])
+                spans.push(style ? ['span', { style }, tk.content] : ['span', {}, tk.content])
+              }
+              carry = ''
+            }
+            else {
+              const style = stringifyTokenStyle(tk.htmlStyle || getTokenStyleObject(tk))
+              spans.push(style ? ['span', { style }, tk.content] : ['span', {}, tk.content])
+            }
+          }
+          // If trailing whitespace wasn't merged, emit it
+          if (carry) {
+            spans.push(['span', {}, carry])
           }
 
-          line += 1
+          // eslint-disable-next-line unicorn/no-new-array -- pre-allocated for perf
+          const lineNode = new Array(spans.length + 2) as ComarkElement
+          lineNode[0] = 'span'
+          lineNode[1] = { class: 'line' }
+          for (let s = 0; s < spans.length; s++) lineNode[s + 2] = spans[s]
+
+          codeChildren.push(lineNode as ComarkNode)
+          if (li < tokenLines.length - 1) codeChildren.push('\n')
         }
+      }
+    }
+    catch {
+      classStr = 'shiki'
+      codeChildren = [code]
+    }
+
+    if (darkClassSuffix) classStr += darkClassSuffix
+
+    // Apply line highlights
+    const highlightSet = Array.isArray(preAttrs.highlights) ? new Set<number>(preAttrs.highlights) : null
+    let line = 1
+    for (const child of codeChildren) {
+      if (Array.isArray(child)) {
+        if (highlightSet !== null && highlightSet.has(line)) {
+          child[1].class = `${child[1].class ?? ''} highlight`.trim()
+          // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
+          child[1].style = 'display: inline-block'
+        }
+        else {
+          // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
+          child[1].style = 'display: inline'
+        }
+
+        line += 1
       }
     }
 
@@ -351,17 +397,12 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
 
     const codeEl = node[2] as ComarkElement
     const codeAttrs = (codeEl[1] as Record<string, any>) || {}
-    let newPreNode: ComarkNode
-    if (Array.isArray(codeChildren)) {
-      // eslint-disable-next-line unicorn/no-new-array -- pre-allocated for perf
-      const codeNode = new Array(codeChildren.length + 2) as ComarkElement
-      codeNode[0] = 'code'
-      codeNode[1] = codeAttrs
-      for (let j = 0; j < codeChildren.length; j++) codeNode[j + 2] = codeChildren[j]
-      newPreNode = ['pre', newPreAttrs, codeNode]
-    } else {
-      newPreNode = ['pre', newPreAttrs, ['code', codeAttrs, codeChildren]]
-    }
+    // eslint-disable-next-line unicorn/no-new-array -- pre-allocated for perf
+    const codeNode = new Array(codeChildren.length + 2) as ComarkElement
+    codeNode[0] = 'code'
+    codeNode[1] = codeAttrs
+    for (let j = 0; j < codeChildren.length; j++) codeNode[j + 2] = codeChildren[j]
+    const newPreNode: ComarkNode = ['pre', newPreAttrs, codeNode]
 
     if (path.length === 1) {
       newNodes[path[0]] = newPreNode

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -305,8 +305,7 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
           for (let t = 0; t < spanCount; t++) {
             const tk = line[t]
             const canMerge = !(
-              tk.fontStyle &&
-              (tk.fontStyle & 8 /* Strikethrough */ || tk.fontStyle & 4) /* Underline */
+              (tk.fontStyle && (tk.fontStyle & 8 /* Strikethrough */ || tk.fontStyle & 4)) /* Underline */
             )
             if (canMerge && /^\s+$/.test(tk.content) && t + 1 < spanCount) {
               carry += tk.content

--- a/packages/comark/test/utils/index.ts
+++ b/packages/comark/test/utils/index.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error - ignore @nuxtjs/mdc types
 import type { MDCRoot } from '@nuxtjs/mdc'
 import type { ComarkTree } from 'comark'
 import remarkGFM from 'remark-gfm'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this PR optimizes the highlight plugin further by using shiki's `codeToTokens` API directly instead of `codeToHast` when no transformers are configured. this skips the entire hast tree construction and the subsequent `hast => ComarkNode` conversion, building ComarkNodes directly from the flat token array in a single pass



<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

| Before | After |
|--------|--------|
| <img width="852" height="948" alt="Screenshot 2026-04-28 at 11 43 52 AM" src="https://github.com/user-attachments/assets/48dd7048-7ff5-4a4f-bfe5-405f44706bba" /> | <img width="852" height="948" alt="Screenshot 2026-04-28 at 11 45 49 AM" src="https://github.com/user-attachments/assets/b3dae941-1278-4b83-9942-af8aff21a1b3" /> | 


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have run `pnpm verify` and it passes.
- [ ] I have updated the documentation accordingly.