### PR TITLE
fix(specs): nested codeblocks

### DIFF
--- a/packages/comark/SPEC/COMARK/codeblock-nested-4backtick.md
+++ b/packages/comark/SPEC/COMARK/codeblock-nested-4backtick.md
@@ -1,0 +1,66 @@
+## Input
+
+```md
+````mdc
+::code-preview
+`inline code`
+
+#code
+```mdc
+`inline code`
+```
+::
+````
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "pre",
+      {
+        "language": "mdc"
+      },
+      [
+        "code",
+        {
+          "class": "language-mdc"
+        },
+        "::code-preview\n`inline code`\n\n#code\n```mdc\n`inline code`\n```\n::"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<pre language="mdc"><code class="language-mdc">::code-preview
+`inline code`
+
+#code
+```mdc
+`inline code`
+```
+::</code></pre>
+```
+
+## Markdown
+
+```md
+~~~mdc
+::code-preview
+`inline code`
+
+#code
+```mdc
+`inline code`
+```
+::
+~~~
+```

--- a/packages/comark/SPEC/COMARK/codeblock-nested-tilde.md
+++ b/packages/comark/SPEC/COMARK/codeblock-nested-tilde.md
@@ -1,0 +1,66 @@
+## Input
+
+```md
+~~~mdc
+::code-preview
+`inline code`
+
+#code
+```mdc
+`inline code`
+```
+::
+~~~
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "pre",
+      {
+        "language": "mdc"
+      },
+      [
+        "code",
+        {
+          "class": "language-mdc"
+        },
+        "::code-preview\n`inline code`\n\n#code\n```mdc\n`inline code`\n```\n::"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<pre language="mdc"><code class="language-mdc">::code-preview
+`inline code`
+
+#code
+```mdc
+`inline code`
+```
+::</code></pre>
+```
+
+## Markdown
+
+```md
+~~~mdc
+::code-preview
+`inline code`
+
+#code
+```mdc
+`inline code`
+```
+::
+~~~
+```

--- a/packages/comark/src/internal/stringify/handlers/pre.ts
+++ b/packages/comark/src/internal/stringify/handlers/pre.ts
@@ -23,8 +23,10 @@ export function pre(node: ComarkElement, state: State) {
   // Meta always has a leading space
   const meta = attributes.meta ? ' ' + attributes.meta : ''
 
-  const result =
-    '```' + language + filename + highlights + meta + '\n' + String(node[1]?.code || textContent(node)).trim() + '\n```'
+  const code = String(node[1]?.code || textContent(node)).trim()
+  const fence = code.includes('```') ? '~~~' : '```'
+
+  const result = fence + language + filename + highlights + meta + '\n' + code + '\n' + fence
 
   return result + state.context.blockSeparator
 }


### PR DESCRIPTION
As discussed together, nested code blocks must enclosed by `~~~`