### PR TITLE
fix(vue): pass code prop to custom pre components for clipboard copy

### DIFF
--- a/packages/comark-vue/src/components/ComarkRenderer.ts
+++ b/packages/comark-vue/src/components/ComarkRenderer.ts
@@ -19,7 +19,7 @@ import {
   toRaw,
 } from 'vue'
 import { findLastTextNodeAndAppendNode, getCaret } from '../utils/caret.ts'
-import { pascalCase, resolveAttributes } from 'comark/utils'
+import { pascalCase, resolveAttributes, textContent } from 'comark/utils'
 
 // Cache for dynamically resolved components
 const asyncComponentCache = new Map<string, any>()
@@ -142,6 +142,11 @@ function renderNode(
     // @ts-expect-error - component might be a Vue component
     if (component?.props?.__node || component?.__asyncResolved?.props?.__node) {
       props.__node = node
+    }
+
+    // When a custom `pre` component is used (e.g. Nuxt UI ProsePre) pass the plain-text content as `code` so copy-to-clipboard works
+    if (tag === 'pre' && customComponent) {
+      props.code = textContent(node)
     }
 
     // Add key if provided


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #174

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

when `ComarkRenderer` renders a `pre` element with a custom component (e.g. Nuxt UI's ProsePre) the component's copy-to-clipboard button relies on a `code` prop containing the plain text. `ComarkRenderer` was not passing this prop, so the button animated but copied an empty string

this PR extracts the text content from the AST node via `textContent()` and pass it as the `code` prop whenever a custom component is resolved for `pre`


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have run `pnpm verify` and it passes.
- [ ] I have updated the documentation accordingly.
