### PR TITLE
fix(syntax): thematic breaks in component slots

### DIFF
--- a/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break-named-slot.md
+++ b/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break-named-slot.md
@@ -1,0 +1,71 @@
+## Input
+
+```md
+::card
+#description
+Line one
+
+---
+
+Middle line
+
+---
+
+Line three
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "card",
+      {},
+      [
+        "template",
+        { "name": "description" },
+        ["p", {}, "Line one"],
+        ["hr", {}],
+        ["p", {}, "Middle line"],
+        ["hr", {}],
+        ["p", {}, "Line three"]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<card>
+  <template name="description">
+    <p>Line one</p>
+    <hr />
+    <p>Middle line</p>
+    <hr />
+    <p>Line three</p>
+  </template>
+</card>
+```
+
+## Markdown
+
+```md
+::card
+#description
+Line one
+
+---
+
+Middle line
+
+---
+
+Line three
+::
+```

--- a/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break.md
+++ b/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break.md
@@ -1,0 +1,63 @@
+## Input
+
+```md
+::card
+Above
+
+---
+
+Middle text
+
+---
+
+Below
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "card",
+      {},
+      ["p", {}, "Above"],
+      ["hr", {}],
+      ["p", {}, "Middle text"],
+      ["hr", {}],
+      ["p", {}, "Below"]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<card>
+  <p>Above</p>
+  <hr />
+  <p>Middle text</p>
+  <hr />
+  <p>Below</p>
+</card>
+```
+
+## Markdown
+
+```md
+::card
+Above
+
+---
+
+Middle text
+
+---
+
+Below
+::
+```

--- a/packages/comark/src/plugins/syntax.ts
+++ b/packages/comark/src/plugins/syntax.ts
@@ -283,6 +283,12 @@ const markdownItComarkBlock: PluginSimple = (md) => {
 
     if (!blockAttributesClosingFence) return false
 
+    // The `---` fence is only valid on the line immediately after the component opener. Any other `---` is a thematic break.
+    if (line === '---') {
+      const parentOpenLine = state.env.comarkBlockTokens[0].map?.[0]
+      if (parentOpenLine === undefined || startLine !== parentOpenLine + 1) return false
+    }
+
     let lineEnd = startLine + 1
     let found = false
     while (lineEnd < endLine) {


### PR DESCRIPTION
Fix `---` inside block components being parsed as YAML props.

Only treat `---` as props when it directly follows the component opener, otherwise it's a thematic break.

