### PR TITLE
fix: prevent void HTML elements from swallowing subsequent content

### DIFF
--- a/packages/comark/SPEC/common-mark/html-block-void-br.md
+++ b/packages/comark/SPEC/common-mark/html-block-void-br.md
@@ -1,0 +1,49 @@
+## Input
+
+```md
+<br>
+
+# After br
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "br",
+      {
+        "$": {
+          "html": 1,
+          "block": 1
+        }
+      }
+    ],
+    [
+      "h1",
+      {
+        "id": "after-br"
+      },
+      "After br"
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<br />
+<h1 id="after-br">After br</h1>
+```
+
+## Markdown
+
+```md
+<br />
+
+# After br
+```

--- a/packages/comark/SPEC/common-mark/html-block-void-element.md
+++ b/packages/comark/SPEC/common-mark/html-block-void-element.md
@@ -1,0 +1,62 @@
+## Input
+
+```md
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+
+# comark
+
+A high-performance markdown parser and renderer.
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "img",
+      {
+        "$": {
+          "html": 1,
+          "block": 1
+        },
+        "src": "https://github.com/comarkdown/comark/blob/main/assets/banner.jpg",
+        "width": "100%",
+        "alt": "Comark banner"
+      }
+    ],
+    [
+      "h1",
+      {
+        "id": "comark"
+      },
+      "comark"
+    ],
+    [
+      "p",
+      {},
+      "A high-performance markdown parser and renderer."
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+<h1 id="comark">comark</h1>
+<p>A high-performance markdown parser and renderer.</p>
+```
+
+## Markdown
+
+```md
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+
+# comark
+
+A high-performance markdown parser and renderer.
+```

--- a/packages/comark/src/internal/parse/html/index.ts
+++ b/packages/comark/src/internal/parse/html/index.ts
@@ -1,7 +1,7 @@
 import { Parser } from 'htmlparser2'
 import type { ComarkNode } from 'comark'
 
-const VOID_ELEMENTS = new Set([
+export const VOID_ELEMENTS = new Set([
   'area',
   'base',
   'br',

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -1,5 +1,5 @@
 import type { ComarkElementAttributes, ComarkNode } from 'comark'
-import { htmlToComarkNodes, parseInlineHtmlTag } from './html/index.ts'
+import { htmlToComarkNodes, parseInlineHtmlTag, VOID_ELEMENTS } from './html/index.ts'
 
 // Mapping from token types to tag names
 const BLOCK_TAG_MAP: Record<string, string> = {
@@ -289,11 +289,18 @@ function processBlockToken(
       return { node: [null, {}, inner] as unknown as ComarkNode, nextIndex: startIndex + 1 }
     }
 
-    const children = processBlockChildren(tokens, startIndex + 1, 'html_block_close', false, false, false, state)
-    const [node1] = htmlToComarkNodes(content)
+    const htmlNodes = htmlToComarkNodes(content)
+    const [node1] = htmlNodes
     if (!node1) {
       return { node: null, nextIndex: startIndex + 1 }
     }
+
+    const isVoid = Array.isArray(node1) && VOID_ELEMENTS.has(node1[0] as string)
+    if (isVoid) {
+      return { node: node1, nextIndex: startIndex + 1 }
+    }
+
+    const children = processBlockChildren(tokens, startIndex + 1, 'html_block_close', false, false, false, state)
     const node = [node1[0]!, node1[1]! as ComarkElementAttributes, ...children.nodes] as ComarkNode
 
     return { node, nextIndex: children.nextIndex + 1 }


### PR DESCRIPTION
## Summary

- Block-level void HTML elements (`<img>`, `<br>`, `<input>`, etc.) were incorrectly treated as opening tags by the token processor, causing all subsequent content to be nested as their children
- The fix checks if a parsed `html_block` is a void element and returns it immediately without scanning for a matching `html_block_close` token

## Test plan

- [x] Added SPEC tests for `<img>` and `<br>` block-level void elements followed by other content
- [x] Verified non-void elements like `<div>` still correctly nest their children
- [x] All existing tests pass