### PR TITLE
feat(parse): infer typed meta/frontmatter from plugins

### DIFF
--- a/docs/content/4.plugins/2.custom/1.plugin-api.md
+++ b/docs/content/4.plugins/2.custom/1.plugin-api.md
@@ -24,7 +24,15 @@ Wraps a plugin factory function to provide type safety for both options and the 
 
 - `factory` - A function `(options?: O) => ComarkPlugin` where `O` is an optional options type. When the plugin is instantiated, `options` receives the values passed by the caller. See [`ComarkPlugin`](#code-comarkplugin) for the full shape of the returned object.
 
-**Returns:** A typed plugin factory `(options?: O) => ComarkPlugin`
+**Type parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `Options` | `unknown` | Shape of the options the factory accepts. |
+| `TMeta` | `{}` | Keys this plugin contributes to `tree.meta`. Surfaces on the `parse` result and constrains writes inside `post`. |
+| `TFrontmatter` | `{}` | Keys this plugin contributes to `tree.frontmatter`. This is experimental and may change in future versions. |
+
+**Returns:** A typed plugin factory `(options?: O) => ComarkPlugin<TMeta, TFrontmatter>`
 
 **Example:**
 
@@ -51,6 +59,82 @@ export default defineComarkPlugin((options: MyOptions = {}) => ({
   name: 'my-plugin',
   post(state) {
     // options.prefix is typed
+  },
+}))
+```
+
+---
+
+## Typed contributions
+
+Plugins that write to `tree.meta` can declare what they contribute via the second and third type parameters of `defineComarkPlugin`. Two things follow from that declaration:
+
+1. **Inside `post(state)`**, `state.tree.meta` and `state.tree.frontmatter` are typed as the declared shape, so writes are checked against it.
+2. **At the `parse` callsite**, the contribution is intersected into the resulting `tree.meta` / `tree.frontmatter` — `result.meta.toc` reads back as the declared type instead of `any`.
+
+### Declaring a contribution
+
+```typescript
+import { defineComarkPlugin } from 'comark/parse'
+
+interface TocTree {
+  title: string
+  depth: number
+  links: { id: string; text: string }[]
+}
+
+export default defineComarkPlugin<{}, { toc: TocTree }>(() => ({
+  name: 'toc',
+  post(state) {
+    state.tree.meta.toc = { title: 'Contents', depth: 2, links: [] }
+
+    // @ts-expect-error — wrong value type for the declared key
+    state.tree.meta.toc = 123
+
+    // @ts-expect-error — `summary` was not declared in the contribution
+    state.tree.meta.summary = []
+  },
+}))
+```
+
+A plugin that contributes more than one key lists them all in the same object literal:
+
+```typescript
+defineComarkPlugin<HeadingsOptions, { title?: string; description?: string }>(() => ({
+  name: 'headings',
+  post(state) {
+    state.tree.meta.title = 'Hello'
+    state.tree.meta.description = undefined
+  },
+}))
+```
+
+### Inference at the `parse` callsite
+
+`parse` and `createParse` infer the plugins tuple and intersect each plugin's contribution into the result type. No explicit generic argument is needed:
+
+```typescript
+import { parse } from 'comark'
+import toc from 'comark/plugins/toc'
+import summary from 'comark/plugins/summary'
+
+const tree = await parse(content, { plugins: [toc(), summary()] })
+
+tree.meta.toc       // Toc
+tree.meta.summary   // ComarkNode[]
+tree.meta.something // unknown — undeclared keys are typed as unknown
+```
+
+### Back-compat for unannotated plugins
+
+Plugins that omit the meta/frontmatter type parameters keep the pre-typed free-form behavior — `state.tree.meta` is `Record<string, any>` and any key can be written. The result type on the `parse` callsite also stays `Record<string, any>` when no plugin declared a contribution (or when `plugins` is passed as a widened `ComarkPlugin[]` variable rather than an inline array).
+
+```typescript
+// Old style — still works, no narrowing
+defineComarkPlugin(() => ({
+  name: 'wordcount',
+  post(state) {
+    state.tree.meta.wordCount = 42 // ok — no declared contribution
   },
 }))
 ```
@@ -124,12 +208,12 @@ export default defineComarkPlugin(() => ({
 }))
 ```
 
-**`ComarkParsePostState`:**
+**`ComarkParsePostState<TMeta, TFrontmatter>`:**
 
 | Field | Type | Description |
 |---|---|---|
 | `markdown` | `string` | The original markdown input |
-| `tree` | [`ComarkTree`](/syntax/comark-ast#comarktree) | The parsed AST — modify to transform output |
+| `tree` | [`ComarkTree<TMeta, TFrontmatter>`](/syntax/comark-ast#comarktree) | The parsed AST — modify to transform output. `tree.meta` / `tree.frontmatter` are typed against the plugin's declared contribution. |
 | `options` | [`ParseOptions`](/api/parse#options) | The parser configuration |
 | `tokens` | `unknown[]` | The raw markdown-it tokens |
 
@@ -139,14 +223,14 @@ To traverse and transform `tree` nodes, see the AST API page for the `visit()` u
 
 ---
 
-## `ComarkPlugin`
+## `ComarkPlugin<TMeta, TFrontmatter>`
 
 | Property | Type | Description |
 |---|---|---|
 | `name` | `string` | A unique identifier for the plugin |
 | `markdownItPlugins` | [`MarkdownItPlugin[]`](https://markdown-it.github.io/markdown-it/#MarkdownIt) | markdown-it plugins to register on the parser — see [Markdown-it Plugins](/plugins/custom/markdown-it) |
 | `pre` | `(state: ComarkParsePreState) => void` | Hook called before parsing |
-| `post` | `(state: ComarkParsePostState) => void` | Hook called after the AST is built |
+| `post` | `(state: ComarkParsePostState<TMeta, TFrontmatter>) => void` | Hook called after the AST is built. `state.tree.meta` / `state.tree.frontmatter` are typed as the declared contribution — see [Typed contributions](#typed-contributions). |
 
 ---
 

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -222,9 +222,7 @@ export function createParse<const TPlugins extends readonly ComarkPlugin<any, an
 export async function parse<const TPlugins extends readonly ComarkPlugin<any, any>[] = []>(
   markdown: string,
   options: ParseOptions<TPlugins> = {} as ParseOptions<TPlugins>
-): Promise<
-  ComarkTree<ResolvedMeta<MergePluginMeta<TPlugins>>, ResolvedFrontmatter<MergePluginFrontmatter<TPlugins>>>
-> {
+): Promise<ComarkTree<ResolvedMeta<MergePluginMeta<TPlugins>>, ResolvedFrontmatter<MergePluginFrontmatter<TPlugins>>>> {
   const parse = createParse(options)
 
   return await parse(markdown)

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -1,8 +1,13 @@
 import type {
   ComarkParseFn,
   ComarkParsePostState,
+  ComarkPlugin,
   MarkdownExitPlugin,
+  MergePluginFrontmatter,
+  MergePluginMeta,
   ParseOptions,
+  ResolvedFrontmatter,
+  ResolvedMeta,
   ComarkTree,
   ComarkNode,
 } from './types.ts'
@@ -54,8 +59,13 @@ export { defineComarkPlugin } from './utils/helpers.ts'
  * const parseNoHtml = createParse({ html: false })
  * ```
  */
-export function createParse(options: ParseOptions = {}): ComarkParseFn {
-  const { autoUnwrap = true, autoClose = true, plugins = [] } = options
+export function createParse<const TPlugins extends readonly ComarkPlugin<any, any>[] = []>(
+  options: ParseOptions<TPlugins> = {} as ParseOptions<TPlugins>
+): ComarkParseFn<ResolvedMeta<MergePluginMeta<TPlugins>>, ResolvedFrontmatter<MergePluginFrontmatter<TPlugins>>> {
+  const { autoUnwrap = true, autoClose = true } = options
+  // Make a mutable working copy so the inferred (possibly readonly) user tuple
+  // isn't mutated by the unshift calls below.
+  const plugins: ComarkPlugin<any, any>[] = options.plugins ? [...options.plugins] : []
 
   plugins.unshift(syntax())
   plugins.unshift(taskList())
@@ -82,7 +92,7 @@ export function createParse(options: ParseOptions = {}): ComarkParseFn {
   let lastOutput: ComarkTree | null = null
   let lastInput: string | null = null
 
-  return async (markdown, opts = {}) => {
+  const parseFn: ComarkParseFn = async (markdown, opts = {}) => {
     const state = {
       options,
       tokens: [] as unknown[],
@@ -169,6 +179,11 @@ export function createParse(options: ParseOptions = {}): ComarkParseFn {
 
     return state.tree
   }
+
+  return parseFn as ComarkParseFn<
+    ResolvedMeta<MergePluginMeta<TPlugins>>,
+    ResolvedFrontmatter<MergePluginFrontmatter<TPlugins>>
+  >
 }
 
 /**
@@ -204,7 +219,12 @@ export function createParse(options: ParseOptions = {}): ComarkParseFn {
  * const tree2 = await parse(content, { autoUnwrap: false })
  * ```
  */
-export async function parse(markdown: string, options: ParseOptions = {}): Promise<ComarkTree> {
+export async function parse<const TPlugins extends readonly ComarkPlugin<any, any>[] = []>(
+  markdown: string,
+  options: ParseOptions<TPlugins> = {} as ParseOptions<TPlugins>
+): Promise<
+  ComarkTree<ResolvedMeta<MergePluginMeta<TPlugins>>, ResolvedFrontmatter<MergePluginFrontmatter<TPlugins>>>
+> {
   const parse = createParse(options)
 
   return await parse(markdown)
@@ -225,6 +245,8 @@ export async function parse(markdown: string, options: ParseOptions = {}): Promi
  * const tree = await parse(content)
  * console.log(tree.nodes)
  */
-export function createSerializedParse(options: ParseOptions = {}): ComarkParseFn {
+export function createSerializedParse<const TPlugins extends readonly ComarkPlugin<any, any>[] = []>(
+  options: ParseOptions<TPlugins> = {} as ParseOptions<TPlugins>
+): ComarkParseFn<ResolvedMeta<MergePluginMeta<TPlugins>>, ResolvedFrontmatter<MergePluginFrontmatter<TPlugins>>> {
   return createSerializedTask(createParse(options))
 }

--- a/packages/comark/src/plugins/headings.ts
+++ b/packages/comark/src/plugins/headings.ts
@@ -82,7 +82,7 @@ function flattenNodeText(node: ComarkNode): string {
  * headings({ descriptionTag: false })
  * ```
  */
-export default defineComarkPlugin((options: HeadingsOptions = {}) => {
+export default defineComarkPlugin<HeadingsOptions, { title?: string; description?: string }>((options = {}) => {
   const { titleTag = 'h1', descriptionTag = 'p', remove = false } = options
 
   return {

--- a/packages/comark/src/plugins/summary.ts
+++ b/packages/comark/src/plugins/summary.ts
@@ -3,7 +3,7 @@ import { applyAutoUnwrap } from '../internal/parse/auto-unwrap.ts'
 import { marmdownItTokensToComarkTree } from '../internal/parse/token-processor.ts'
 import { defineComarkPlugin } from '../utils/helpers.ts'
 
-export default defineComarkPlugin((options: { delimiter?: string } = {}) => {
+export default defineComarkPlugin<{ delimiter?: string }, { summary: ComarkNode[] }>((options = {}) => {
   const { delimiter = '<!-- more -->' } = options
   return {
     name: 'summary',

--- a/packages/comark/src/plugins/toc.ts
+++ b/packages/comark/src/plugins/toc.ts
@@ -136,7 +136,7 @@ export function generateFlatToc(body: ComarkTree, options: Toc): Toc {
   }
 }
 
-export default defineComarkPlugin((options: Partial<Toc> = {}) => {
+export default defineComarkPlugin<Partial<Toc>, { toc: Toc }>((options: Partial<Toc> = {}) => {
   const { title = '', depth = 2, searchDepth = 2, links = [] } = options
   return {
     name: 'toc',

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -52,11 +52,14 @@ export type ComarkNode = ComarkElement | ComarkText | ComarkComment
  * @param nodes - The nodes of the tree
  * @param frontmatter - The frontmatter data which is the data at the top of the file
  * @param meta - The meta data of tree, it can be used to store additional data for the tree
+ *
+ * The `TMeta` and `TFrontmatter` type parameters allow `parse` / `createParse`
+ * to surface plugin-contributed keys with narrow types (see `MergePluginMeta`).
  */
-export interface ComarkTree {
+export interface ComarkTree<TMeta = Record<string, any>, TFrontmatter = Record<string, any>> {
   nodes: ComarkNode[]
-  frontmatter: Record<string, any>
-  meta: Record<string, any>
+  frontmatter: TFrontmatter
+  meta: TMeta
 }
 
 // #endregion
@@ -291,13 +294,64 @@ export type ComarkParsePostState = {
   [key: string]: any
 }
 
-export type ComarkPlugin = {
+/**
+ * A Comark plugin.
+ *
+ * `TMeta` / `TFrontmatter` are phantom type parameters that record what this
+ * plugin contributes to `tree.meta` / `tree.frontmatter`. They are surfaced
+ * only via the optional `__meta` / `__frontmatter` markers — implementations
+ * never set these at runtime; they exist purely so the contribution survives
+ * `ReturnType<typeof factory>` inference and can be merged in `createParse`.
+ */
+export type ComarkPlugin<TMeta = {}, TFrontmatter = {}> = {
   name: string
   markdownItPlugins?: MarkdownItPlugin[]
   pre?: (state: ComarkParsePreState) => Promise<void> | void
   post?: (state: ComarkParsePostState) => Promise<void> | void
+  /** Phantom — used for type inference only. Never set at runtime. */
+  __meta?: TMeta
+  /** Phantom — used for type inference only. Never set at runtime. */
+  __frontmatter?: TFrontmatter
 }
-export type ComarkPluginFactory<Options> = (opts?: Options) => ComarkPlugin
+export type ComarkPluginFactory<Options, TMeta = {}, TFrontmatter = {}> = (
+  opts?: Options
+) => ComarkPlugin<TMeta, TFrontmatter>
+
+// #region Plugin type inference helpers
+
+type PluginMetaOf<P> = P extends ComarkPlugin<infer M, any> ? M : {}
+type PluginFrontmatterOf<P> = P extends ComarkPlugin<any, infer F> ? F : {}
+
+/**
+ * Walk a tuple of plugins and intersect their meta contributions.
+ * Returns `{}` when the tuple is empty or when nothing was contributed.
+ */
+export type MergePluginMeta<TPlugins extends readonly unknown[]> = TPlugins extends readonly [
+  infer Head,
+  ...infer Rest,
+]
+  ? PluginMetaOf<Head> & MergePluginMeta<Rest extends readonly unknown[] ? Rest : []>
+  : {}
+
+/**
+ * Walk a tuple of plugins and intersect their frontmatter contributions.
+ */
+export type MergePluginFrontmatter<TPlugins extends readonly unknown[]> = TPlugins extends readonly [
+  infer Head,
+  ...infer Rest,
+]
+  ? PluginFrontmatterOf<Head> & MergePluginFrontmatter<Rest extends readonly unknown[] ? Rest : []>
+  : {}
+
+/**
+ * When no plugin contributed meta keys, fall back to the permissive
+ * `Record<string, any>` (backwards-compatible). Otherwise, preserve narrow
+ * keys and type unknown accesses as `unknown` (safer than `any`).
+ */
+export type ResolvedMeta<T> = [keyof T] extends [never] ? Record<string, any> : T & Record<string, unknown>
+export type ResolvedFrontmatter<T> = [keyof T] extends [never] ? Record<string, any> : T & Record<string, unknown>
+
+// #endregion
 
 export type ComponentManifest = (name: string) => Promise<unknown> | undefined | null
 export interface ComarkContextProvider {
@@ -305,7 +359,9 @@ export interface ComarkContextProvider {
   componentManifest: ComponentManifest
 }
 
-export interface ParseOptions {
+export interface ParseOptions<
+  TPlugins extends readonly ComarkPlugin<any, any>[] = readonly ComarkPlugin<any, any>[],
+> {
   /**
    * Whether to automatically unwrap single paragraphs in container components.
    * When enabled, if a container component (alert, card, callout, note, warning, tip, info)
@@ -355,7 +411,7 @@ export interface ParseOptions {
    * Additional plugins to use
    * @default []
    */
-  plugins?: ComarkPlugin[]
+  plugins?: TPlugins
 }
 
 /**
@@ -367,4 +423,7 @@ export type ComarkParseFnOptions = { streaming?: boolean }
  * Type signature for the async Comark parser function returned by createParse().
  * Accepts a markdown string and optional parsing options, and returns a Promise of ComarkTree.
  */
-export type ComarkParseFn = (markdown: string, opts?: ComarkParseFnOptions) => Promise<ComarkTree>
+export type ComarkParseFn<TMeta = Record<string, any>, TFrontmatter = Record<string, any>> = (
+  markdown: string,
+  opts?: ComarkParseFnOptions
+) => Promise<ComarkTree<TMeta, TFrontmatter>>

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -326,10 +326,7 @@ type PluginFrontmatterOf<P> = P extends ComarkPlugin<any, infer F> ? F : {}
  * Walk a tuple of plugins and intersect their meta contributions.
  * Returns `{}` when the tuple is empty or when nothing was contributed.
  */
-export type MergePluginMeta<TPlugins extends readonly unknown[]> = TPlugins extends readonly [
-  infer Head,
-  ...infer Rest,
-]
+export type MergePluginMeta<TPlugins extends readonly unknown[]> = TPlugins extends readonly [infer Head, ...infer Rest]
   ? PluginMetaOf<Head> & MergePluginMeta<Rest extends readonly unknown[] ? Rest : []>
   : {}
 
@@ -359,9 +356,7 @@ export interface ComarkContextProvider {
   componentManifest: ComponentManifest
 }
 
-export interface ParseOptions<
-  TPlugins extends readonly ComarkPlugin<any, any>[] = readonly ComarkPlugin<any, any>[],
-> {
+export interface ParseOptions<TPlugins extends readonly ComarkPlugin<any, any>[] = readonly ComarkPlugin<any, any>[]> {
   /**
    * Whether to automatically unwrap single paragraphs in container components.
    * When enabled, if a container component (alert, card, callout, note, warning, tip, info)

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -2,6 +2,15 @@ import type { DumpOptions } from 'js-yaml'
 import type MarkdownExit from 'markdown-exit'
 import type MarkdownIt from 'markdown-it'
 
+// #region Utility Types
+/**
+ * The `[keyof T] extends [never]` form (rather than `keyof T extends never`)
+ * is the standard trick to prevent TS from distributing the check over a
+ * union — we want to test "is T's keyset empty?" as one yes/no question.
+ */
+type Writable<T> = [keyof T] extends [never] ? Record<string, any> : T
+// #endregion Utility Types
+
 // #region ComarkTree
 
 /**
@@ -285,9 +294,9 @@ export type ComarkParsePreState = {
   [key: string]: any
 }
 
-export type ComarkParsePostState = {
+export type ComarkParsePostState<TMeta = Record<string, any>, TFrontmatter = Record<string, any>> = {
   markdown: string
-  tree: ComarkTree
+  tree: ComarkTree<TMeta, TFrontmatter>
   options: ParseOptions
   tokens: unknown[]
 
@@ -307,7 +316,7 @@ export type ComarkPlugin<TMeta = {}, TFrontmatter = {}> = {
   name: string
   markdownItPlugins?: MarkdownItPlugin[]
   pre?: (state: ComarkParsePreState) => Promise<void> | void
-  post?: (state: ComarkParsePostState) => Promise<void> | void
+  post?: (state: ComarkParsePostState<Writable<TMeta>, Writable<TFrontmatter>>) => Promise<void> | void
   /** Phantom — used for type inference only. Never set at runtime. */
   __meta?: TMeta
   /** Phantom — used for type inference only. Never set at runtime. */

--- a/packages/comark/src/utils/helpers.ts
+++ b/packages/comark/src/utils/helpers.ts
@@ -17,11 +17,25 @@ export function createSerializedTask<TArgs extends unknown[], TResult>(
 // #region define plugin
 
 /**
- * Define a Comark plugin
- * @param fn - The plugin factory function
- * @returns The defined plugin
+ * Define a Comark plugin.
+ *
+ * `TMeta` and `TFrontmatter` declare what the plugin contributes to
+ * `tree.meta` / `tree.frontmatter`. They are inferred from the factory's
+ * return type when set via the `__meta` / `__frontmatter` phantom markers,
+ * or can be passed explicitly. Plugins that don't contribute typed keys can
+ * omit them entirely.
+ *
+ * @example
+ * ```ts
+ * defineComarkPlugin<Options, { toc: Toc }>((opts) => ({
+ *   name: 'toc',
+ *   post(state) { state.tree.meta.toc = ... },
+ * }))
+ * ```
  */
-export function defineComarkPlugin<Options>(fn: ComarkPluginFactory<Options>): ComarkPluginFactory<Options> {
+export function defineComarkPlugin<Options, TMeta = {}, TFrontmatter = {}>(
+  fn: ComarkPluginFactory<Options, TMeta, TFrontmatter>
+): ComarkPluginFactory<Options, TMeta, TFrontmatter> {
   return fn
 }
 

--- a/packages/comark/test/_types/_plugin-declare.ts
+++ b/packages/comark/test/_types/_plugin-declare.ts
@@ -1,0 +1,79 @@
+/**
+ * Compile-only — NOT a runtime test (no .test.ts suffix).
+ * Verifies the plugin's declared contribution is enforced inside post().
+ *
+ * Run: `pnpm verify` from the repo root. The @ts-expect-error
+ * directives must all be active.
+ */
+import { defineComarkPlugin } from '../../src/utils/helpers.ts'
+import type { Toc } from '../../src/plugins/toc.ts'
+import type { ComarkNode } from '../../src/types.ts'
+
+// 1. Wrong value type — must error.
+defineComarkPlugin<{}, { toc: Toc }>(() => ({
+  name: 'wrong-value-type',
+  post(state) {
+    // @ts-expect-error — `123` is not assignable to `Toc`.
+    state.tree.meta.toc = 123
+  },
+}))
+
+// 2. Undeclared key — must error (strict surface).
+defineComarkPlugin<{}, { toc: Toc }>(() => ({
+  name: 'undeclared-key',
+  post(state) {
+    // @ts-expect-error — `summary` is not in the declared contribution.
+    state.tree.meta.summary = []
+  },
+}))
+
+// 3. Correct value type — must compile clean.
+defineComarkPlugin<{}, { toc: Toc }>(() => ({
+  name: 'correct-write',
+  post(state) {
+    state.tree.meta.toc = { title: '', depth: 1, searchDepth: 1, links: [] }
+  },
+}))
+
+// 4. Multi-key contribution — both writes allowed, mismatches caught.
+defineComarkPlugin<{}, { title?: string; description?: string }>(() => ({
+  name: 'multi-key',
+  post(state) {
+    state.tree.meta.title = 'ok'
+    state.tree.meta.description = undefined
+    // @ts-expect-error — number not assignable to string.
+    state.tree.meta.title = 42
+  },
+}))
+
+// 5. Unannotated plugin — writable surface stays permissive (back-compat).
+defineComarkPlugin<{}>(() => ({
+  name: 'unannotated',
+  post(state) {
+    state.tree.meta.anything = 'works'
+    state.tree.meta.alsoThis = { nested: 1 }
+  },
+}))
+
+// 6. Frontmatter contribution gets the same treatment.
+defineComarkPlugin<{}, {}, { author: string }>(() => ({
+  name: 'frontmatter-author',
+  post(state) {
+    state.tree.frontmatter.author = 'Ada'
+    // @ts-expect-error — number not assignable to string.
+    state.tree.frontmatter.author = 1
+    // @ts-expect-error — undeclared frontmatter key.
+    state.tree.frontmatter.year = 1815
+  },
+}))
+
+// 7. ComarkNode[] vs other shapes for `summary`.
+defineComarkPlugin<{}, { summary: ComarkNode[] }>(() => ({
+  name: 'summary-shape',
+  post(state) {
+    state.tree.meta.summary = []
+    state.tree.meta.summary = [['p', {}, 'hi']]
+    // @ts-expect-error — string is not ComarkNode[].
+    state.tree.meta.summary = 'just text'
+  },
+}))

--- a/packages/comark/test/plugins/headings.test.ts
+++ b/packages/comark/test/plugins/headings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { parse } from '../../src/parse'
+import headings from '../../src/plugins/headings'
+
+const CONTENT = `# My Page Title
+
+This is the description paragraph.
+
+## Section One
+`
+
+describe('headings plugin', () => {
+  it('writes title and description to tree.meta', async () => {
+    const tree = await parse(CONTENT, { plugins: [headings()] })
+
+    expect(tree.meta.title).toBe('My Page Title')
+    expect(tree.meta.description).toBe('This is the description paragraph.')
+  })
+
+  it('narrows tree.meta.title and tree.meta.description to (string | undefined)', async () => {
+    const tree = await parse(CONTENT, { plugins: [headings()] })
+
+    expectTypeOf(tree.meta.title).toEqualTypeOf<string | undefined>()
+    expectTypeOf(tree.meta.description).toEqualTypeOf<string | undefined>()
+  })
+})
+
+describe('headings plugin — combined with toc/summary', () => {
+  it('narrows all three plugins meta keys when used together', async () => {
+    const tocMod = (await import('../../src/plugins/toc')).default
+    const summaryMod = (await import('../../src/plugins/summary')).default
+
+    const tree = await parse('# Title\n\nIntro.\n', {
+      plugins: [headings(), tocMod(), summaryMod()],
+    })
+
+    expectTypeOf(tree.meta.title).toEqualTypeOf<string | undefined>()
+    expectTypeOf(tree.meta.description).toEqualTypeOf<string | undefined>()
+    expectTypeOf(tree.meta.toc).toEqualTypeOf<import('../../src/plugins/toc').Toc>()
+    expectTypeOf(tree.meta.summary).toEqualTypeOf<import('../../src/types').ComarkNode[]>()
+
+    // Unknown keys still accessible but typed as `unknown` (safer than the
+    // old default of `any`).
+    expectTypeOf(tree.meta.somethingElse).toEqualTypeOf<unknown>()
+  })
+})

--- a/packages/comark/test/plugins/summary.test.ts
+++ b/packages/comark/test/plugins/summary.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { parse } from '../../src/parse'
+import summary from '../../src/plugins/summary'
+import type { ComarkNode } from '../../src/types'
+
+const CONTENT = `Intro paragraph.
+
+<!-- more -->
+
+After the fold.
+`
+
+describe('summary plugin', () => {
+  it('writes the nodes before the delimiter to tree.meta.summary', async () => {
+    const tree = await parse(CONTENT, { plugins: [summary()] })
+
+    expect(tree.meta.summary).toEqual([['p', {}, 'Intro paragraph.']])
+  })
+
+  it('leaves tree.meta.summary undefined when no delimiter is present', async () => {
+    const tree = await parse('No fold here.', { plugins: [summary()] })
+
+    expect(tree.meta.summary).toBeUndefined()
+  })
+
+  it('narrows tree.meta.summary to ComarkNode[] at the type level', async () => {
+    const tree = await parse(CONTENT, { plugins: [summary()] })
+
+    expectTypeOf(tree.meta.summary).toEqualTypeOf<ComarkNode[]>()
+  })
+})

--- a/packages/comark/test/plugins/toc.test.ts
+++ b/packages/comark/test/plugins/toc.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { parse } from '../../src/parse'
+import toc, { type Toc } from '../../src/plugins/toc'
+
+const CONTENT = `# Page Title
+
+## Section One
+
+Some text.
+
+### Subsection
+
+More text.
+
+## Section Two
+
+Even more.
+`
+
+describe('toc plugin', () => {
+  it('writes a nested table of contents to tree.meta.toc', async () => {
+    const tree = await parse(CONTENT, { plugins: [toc({ depth: 3, searchDepth: 3 })] })
+
+    expect(tree.meta.toc.links.map((l) => l.text)).toEqual(['Section One', 'Section Two'])
+    expect(tree.meta.toc.links[0].children?.map((l) => l.text)).toEqual(['Subsection'])
+  })
+
+  it('narrows tree.meta.toc to Toc at the type level', async () => {
+    const tree = await parse(CONTENT, { plugins: [toc()] })
+
+    expectTypeOf(tree.meta.toc).toEqualTypeOf<Toc>()
+    expectTypeOf(tree.meta.toc.links).toEqualTypeOf<Toc['links']>()
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #196

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Plugins can extend the type

```ts
// headings plugin
export default defineComarkPlugin<HeadingsOptions, { title?: string; description?: string }>((options = {}) => {
}
```
And you can see result type in the image
<img width="731" height="176" alt="Screenshot 2026-05-18 at 16 20 16" src="https://github.com/user-attachments/assets/c842bd99-786e-4953-aae5-c5609625b34a" />
<img width="768" height="146" alt="Screenshot 2026-05-18 at 16 22 41" src="https://github.com/user-attachments/assets/4a5d51db-30a7-49da-bc88-363e0681a283" />



<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have run `pnpm verify` and it passes.
- [ ] I have updated the documentation accordingly.
