### PR TITLE
fix: stricter boolean prop guessing

### DIFF
--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -131,13 +131,7 @@ function processAttributes(
       }
 
       // Handle boolean attributes: {bool} -> {":bool": "true"}
-      if (
-        handleBoolean &&
-        !key.startsWith(':') &&
-        !key.startsWith('#') &&
-        !key.startsWith('.') &&
-        (!value || value === 'true' || value === '')
-      ) {
+      if (handleBoolean && !key.startsWith(':') && !key.startsWith('#') && !key.startsWith('.') && value === 'true') {
         attrs[`:${key}`] = 'true'
         continue
       }

--- a/packages/comark/test/streaming.test.ts
+++ b/packages/comark/test/streaming.test.ts
@@ -204,6 +204,25 @@ describe('streaming mode', () => {
       expect(alert[0]).toBe('alert')
     })
 
+    it('keeps auto-closed empty string attributes as strings', async () => {
+      const parse = createParse()
+      const result = await parse('::callout{color="info" icon', { streaming: true })
+      const callout = result.nodes[0] as ComarkElement
+
+      expect(callout[0]).toBe('callout')
+      expect(callout[1]).toMatchObject({ color: 'info', ':icon': 'true' })
+    })
+
+    it('keeps auto-closed empty string attributes as strings', async () => {
+      const parse = createParse()
+      const result = await parse('::callout{color="info" icon="', { streaming: true })
+      const callout = result.nodes[0] as ComarkElement
+
+      expect(callout[0]).toBe('callout')
+      expect(callout[1]).toMatchObject({ color: 'info', icon: '' })
+      expect(callout[1]).not.toHaveProperty(':icon')
+    })
+
     it('caches nodes before MDC components', async () => {
       const parse = createParse()
 


### PR DESCRIPTION
This should fix the error on landing page when streaming and icon prop is wrongly considered as boolean for the `::callout`

The `'true'` is added before to we can have a stricter check here