### PR TITLE
fix(syntax): nested codeblock inside slots

### DIFF
--- a/packages/comark/SPEC/COMARK/component-nested-codeblock.md
+++ b/packages/comark/SPEC/COMARK/component-nested-codeblock.md
@@ -2,7 +2,6 @@
 
 ```md
 ::component
-#code
 ```mdc
 ::alert
 hello
@@ -22,22 +21,16 @@ hello
       "component",
       {},
       [
-        "template",
+        "pre",
         {
-          "name": "code"
+          "language": "mdc"
         },
         [
-          "pre",
+          "code",
           {
-            "language": "mdc"
+            "class": "language-mdc"
           },
-          [
-            "code",
-            {
-              "class": "language-mdc"
-            },
-            "::alert\nhello\n::"
-          ]
+          "::alert\nhello\n::"
         ]
       ]
     ]
@@ -49,11 +42,9 @@ hello
 
 ```html
 <component>
-  <template name="code">
-    <pre language="mdc"><code class="language-mdc">::alert
-    hello
-    ::</code></pre>
-  </template>
+  <pre language="mdc"><code class="language-mdc">::alert
+  hello
+  ::</code></pre>
 </component>
 ```
 
@@ -61,7 +52,6 @@ hello
 
 ```md
 ::component
-#code
 ```mdc
 ::alert
 hello

--- a/packages/comark/SPEC/COMARK/component-slot-nested-codeblock.md
+++ b/packages/comark/SPEC/COMARK/component-slot-nested-codeblock.md
@@ -1,0 +1,71 @@
+## Input
+
+```md
+::code-preview
+#code
+```mdc
+::alert
+hello
+::
+```
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "code-preview",
+      {},
+      [
+        "template",
+        {
+          "name": "code"
+        },
+        [
+          "pre",
+          {
+            "language": "mdc"
+          },
+          [
+            "code",
+            {
+              "class": "language-mdc"
+            },
+            "::alert\nhello\n::"
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<code-preview>
+  <template name="code">
+    <pre language="mdc"><code class="language-mdc">::alert
+    hello
+    ::</code></pre>
+  </template>
+</code-preview>
+```
+
+## Markdown
+
+```md
+::code-preview
+#code
+```mdc
+::alert
+hello
+::
+```
+::
+```

--- a/packages/comark/src/plugins/syntax.ts
+++ b/packages/comark/src/plugins/syntax.ts
@@ -329,8 +329,39 @@ const markdownItComarkBlock: PluginSimple = (md) => {
     const { name, props } = parseBlockParams(line.slice(1))
 
     let lineEnd = startLine + 1
+    let inCodeFence = false
+    let codeFenceChar = ''
+    let codeFenceCount = 0
     while (lineEnd < endLine) {
       const inner = state.src.slice(state.bMarks[lineEnd] + state.tShift[startLine], state.eMarks[lineEnd])
+
+      if (inCodeFence) {
+        // Look for matching closing fence (same char, >= opening count, nothing but spaces after)
+        if (inner[0] === codeFenceChar) {
+          let fencePos = 1
+          while (fencePos < inner.length && inner[fencePos] === codeFenceChar) fencePos++
+          if (fencePos >= codeFenceCount && inner.slice(fencePos).trim() === '') {
+            inCodeFence = false
+          }
+        }
+        lineEnd += 1
+        continue
+      }
+
+      // Detect opening code fence (``` or ~~~, length >= 3)
+      if (inner[0] === '`' || inner[0] === '~') {
+        const ch = inner[0]
+        let fencePos = 1
+        while (fencePos < inner.length && inner[fencePos] === ch) fencePos++
+        if (fencePos >= 3) {
+          inCodeFence = true
+          codeFenceChar = ch
+          codeFenceCount = fencePos
+          lineEnd += 1
+          continue
+        }
+      }
+
       if (/^#\w+/.test(inner) || inner.startsWith('::')) break
       lineEnd += 1
     }


### PR DESCRIPTION
Closing `::` inside a fenced code block in a **slotted** parent component was ending the parent component prematurely, causing the code block content to be re-parsed as component. 

`comark_block_slots` now mirrors the fence tracking already present in `comark_block` (`component-nested-codeblock.md` SPEC has been added to test the already working case without slot).


