### PR TITLE
feat(block-attributes): attach trailing `{attr}` to nearest block element

### DIFF
--- a/docs/app/composables/useNavigation.ts
+++ b/docs/app/composables/useNavigation.ts
@@ -36,6 +36,12 @@ export function useMainNavigation() {
         active: route.path.startsWith(`/play/${example.value}`),
       })),
     },
+    {
+      label: 'Compare',
+      to: '/compare',
+      icon: 'i-lucide-columns-2',
+      active: route.path.startsWith('/compare'),
+    },
   ])
 }
 

--- a/docs/app/composables/useNavigation.ts
+++ b/docs/app/composables/useNavigation.ts
@@ -36,12 +36,6 @@ export function useMainNavigation() {
         active: route.path.startsWith(`/play/${example.value}`),
       })),
     },
-    {
-      label: 'Compare',
-      to: '/compare',
-      icon: 'i-lucide-columns-2',
-      active: route.path.startsWith('/compare'),
-    },
   ])
 }
 

--- a/docs/app/pages/compare.vue
+++ b/docs/app/pages/compare.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { useLocalStorage } from '@vueuse/core'
+import { allFeaturesMarkdown } from '~/constants'
+
+definePageMeta({ footer: false })
+
+useSeoMeta({
+  title: 'Compare - Comark',
+  description: 'Compare multiple Comark documents side by side.',
+})
+
+interface Col {
+  id: string
+  content: string
+}
+
+const defaultCols: Col[] = [
+  { id: '1', content: allFeaturesMarkdown },
+  { id: '2', content: allFeaturesMarkdown },
+]
+
+const cols = useLocalStorage<Col[]>('comark:compare-cols', defaultCols, {
+  serializer: {
+    read: (v) => {
+      try {
+        const parsed = JSON.parse(v)
+        return Array.isArray(parsed) && parsed.length >= 2 ? parsed : defaultCols
+      } catch {
+        return defaultCols
+      }
+    },
+    write: (v) => JSON.stringify(v),
+  },
+})
+
+// nextId must be higher than any existing id to avoid collisions after reload
+let nextId = cols.value.reduce((max, c) => Math.max(max, Number(c.id) || 0), 0) + 1
+
+function addCol() {
+  cols.value = [...cols.value, { id: String(nextId++), content: '' }]
+}
+
+function removeCol(id: string) {
+  if (cols.value.length <= 2) return
+  cols.value = cols.value.filter((c) => c.id !== id)
+}
+</script>
+
+<template>
+  <ClientOnly>
+    <div class="flex h-[calc(100vh-64px)] overflow-hidden">
+      <!-- Editor columns -->
+      <div
+        v-for="(col, i) in cols"
+        :key="col.id"
+        class="flex min-w-0 flex-1 flex-col border-l border-default first:border-l-0"
+      >
+        <div class="flex h-9 shrink-0 items-center gap-2 border-b border-default bg-elevated px-3">
+          <span class="text-xs text-muted">Editor {{ i + 1 }}</span>
+          <UButton
+            v-if="cols.length > 2"
+            icon="i-lucide-x"
+            variant="ghost"
+            color="neutral"
+            size="xs"
+            class="ml-auto -mr-1"
+            @click="removeCol(col.id)"
+          />
+        </div>
+        <div class="min-h-0 flex-1">
+          <Editor v-model="col.content" />
+        </div>
+      </div>
+
+      <!-- Add column -->
+      <div class="flex w-10 shrink-0 items-center justify-center border-l border-default bg-elevated">
+        <UTooltip text="Add editor">
+          <UButton
+            icon="i-lucide-plus"
+            variant="ghost"
+            color="neutral"
+            size="sm"
+            @click="addCol"
+          />
+        </UTooltip>
+      </div>
+    </div>
+
+    <template #fallback>
+      <div class="flex h-[calc(100vh-64px)] overflow-hidden">
+        <div
+          v-for="i in 2"
+          :key="i"
+          class="flex flex-1 flex-col border-l border-default first:border-l-0"
+        >
+          <div class="h-9 border-b border-default bg-elevated" />
+          <div class="flex-1 p-4">
+            <USkeleton class="h-full w-full" />
+          </div>
+        </div>
+        <div class="w-10 shrink-0 border-l border-default bg-elevated" />
+      </div>
+    </template>
+  </ClientOnly>
+</template>

--- a/packages/comark/SPEC/COMARK/attributes/blockquote-multiple-paragraphs.md
+++ b/packages/comark/SPEC/COMARK/attributes/blockquote-multiple-paragraphs.md
@@ -1,0 +1,53 @@
+## Input
+
+```md
+> Blockquote paragraph 1 {attr="value"}
+>
+> Blockquote paragraph 2 {attr2="value2"}
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "blockquote",
+      {},
+      [
+        "p",
+        {
+          "attr": "value"
+        },
+        "Blockquote paragraph 1"
+      ],
+      [
+        "p",
+        {
+          "attr2": "value2"
+        },
+        "Blockquote paragraph 2"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<blockquote>
+  <p attr="value">Blockquote paragraph 1</p>
+  <p attr2="value2">Blockquote paragraph 2</p>
+</blockquote>
+```
+
+## Markdown
+
+```md
+> Blockquote paragraph 1 {attr="value"}
+>
+> Blockquote paragraph 2 {attr2="value2"}
+```

--- a/packages/comark/SPEC/COMARK/attributes/blockquote.md
+++ b/packages/comark/SPEC/COMARK/attributes/blockquote.md
@@ -1,0 +1,37 @@
+## Input
+
+```md
+> Blockquote {attr="value"}
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "blockquote",
+      {
+        "attr": "value"
+      },
+      "Blockquote"
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<blockquote attr="value">
+  Blockquote
+</blockquote>
+```
+
+## Markdown
+
+```md
+> Blockquote {attr="value"}
+```

--- a/packages/comark/SPEC/COMARK/attributes/bullet-list.md
+++ b/packages/comark/SPEC/COMARK/attributes/bullet-list.md
@@ -1,0 +1,51 @@
+## Input
+
+```md
+- a list item {attr="value"}
+- another list item {attr2="value2"}
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ul",
+      {},
+      [
+        "li",
+        {
+          "attr": "value"
+        },
+        "a list item"
+      ],
+      [
+        "li",
+        {
+          "attr2": "value2"
+        },
+        "another list item"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ul>
+  <li attr="value">a list item</li>
+  <li attr2="value2">another list item</li>
+</ul>
+```
+
+## Markdown
+
+```md
+- a list item {attr="value"}
+- another list item {attr2="value2"}
+```

--- a/packages/comark/SPEC/COMARK/attributes/headings.md
+++ b/packages/comark/SPEC/COMARK/attributes/headings.md
@@ -1,0 +1,101 @@
+## Input
+
+```md
+# h1 {attr="value"}
+
+## h2 {attr="value"}
+
+### h3 {attr="value"}
+
+#### h4 {attr="value"}
+
+##### h5 {attr="value"}
+
+###### h6 {attr="value"}
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "h1",
+      {
+        "id": "h1",
+        "attr": "value"
+      },
+      "h1"
+    ],
+    [
+      "h2",
+      {
+        "id": "h2",
+        "attr": "value"
+      },
+      "h2"
+    ],
+    [
+      "h3",
+      {
+        "id": "h2-h3",
+        "attr": "value"
+      },
+      "h3"
+    ],
+    [
+      "h4",
+      {
+        "id": "h2-h3-h4",
+        "attr": "value"
+      },
+      "h4"
+    ],
+    [
+      "h5",
+      {
+        "id": "h2-h3-h4-h5",
+        "attr": "value"
+      },
+      "h5"
+    ],
+    [
+      "h6",
+      {
+        "id": "h2-h3-h4-h5-h6",
+        "attr": "value"
+      },
+      "h6"
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<h1 id="h1" attr="value">h1</h1>
+<h2 id="h2" attr="value">h2</h2>
+<h3 id="h2-h3" attr="value">h3</h3>
+<h4 id="h2-h3-h4" attr="value">h4</h4>
+<h5 id="h2-h3-h4-h5" attr="value">h5</h5>
+<h6 id="h2-h3-h4-h5-h6" attr="value">h6</h6>
+```
+
+## Markdown
+
+```md
+# h1 {attr="value"}
+
+## h2 {attr="value"}
+
+### h3 {attr="value"}
+
+#### h4 {attr="value"}
+
+##### h5 {attr="value"}
+
+###### h6 {attr="value"}
+```

--- a/packages/comark/SPEC/COMARK/attributes/ordered-list.md
+++ b/packages/comark/SPEC/COMARK/attributes/ordered-list.md
@@ -1,0 +1,51 @@
+## Input
+
+```md
+1. List item {attr="value"}
+2. List item {attr2="value2"}
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ol",
+      {},
+      [
+        "li",
+        {
+          "attr": "value"
+        },
+        "List item"
+      ],
+      [
+        "li",
+        {
+          "attr2": "value2"
+        },
+        "List item"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ol>
+  <li attr="value">List item</li>
+  <li attr2="value2">List item</li>
+</ol>
+```
+
+## Markdown
+
+```md
+1. List item {attr="value"}
+2. List item {attr2="value2"}
+```

--- a/packages/comark/SPEC/COMARK/attributes/paragraph+span.md
+++ b/packages/comark/SPEC/COMARK/attributes/paragraph+span.md
@@ -1,0 +1,47 @@
+## Input
+
+```md
+A paragraph [span] {attr="value"}
+
+A paragraph [span]{attr="value"}
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {
+        "attr": "value"
+      },
+      "A paragraph ",
+      ["span", {}, "span"]
+    ],
+    [
+      "p",
+      {},
+      "A paragraph ",
+      ["span", { "attr": "value" }, "span"]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<p attr="value">A paragraph <span>span</span></p>
+<p>A paragraph <span attr="value">span</span></p>
+```
+
+## Markdown
+
+```md
+A paragraph [span] {attr="value"}
+
+A paragraph [span]{attr="value"}
+```

--- a/packages/comark/SPEC/COMARK/attributes/paragraph.md
+++ b/packages/comark/SPEC/COMARK/attributes/paragraph.md
@@ -1,0 +1,35 @@
+## Input
+
+```md
+A paragraph {attr="value"}
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {
+        "attr": "value"
+      },
+      "A paragraph"
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<p attr="value">A paragraph</p>
+```
+
+## Markdown
+
+```md
+A paragraph {attr="value"}
+```

--- a/packages/comark/SPEC/COMARK/attributes/task-list.md
+++ b/packages/comark/SPEC/COMARK/attributes/task-list.md
@@ -1,0 +1,76 @@
+## Input
+
+```md
+- [ ] Task list item {attr="value"}
+- [x] Task list item {attr2="value2"}
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ul",
+      {
+        "class": "contains-task-list"
+      },
+      [
+        "li",
+        {
+          "class": "task-list-item",
+          "attr": "value"
+        },
+        [
+          "input",
+          {
+            "class": "task-list-item-checkbox",
+            "type": "checkbox",
+            ":disabled": "true"
+          }
+        ],
+        " Task list item"
+      ],
+      [
+        "li",
+        {
+          "class": "task-list-item",
+          "attr2": "value2"
+        },
+        [
+          "input",
+          {
+            "class": "task-list-item-checkbox",
+            "type": "checkbox",
+            ":disabled": "true",
+            ":checked": "true"
+          }
+        ],
+        " Task list item"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ul class="contains-task-list">
+  <li class="task-list-item" attr="value">
+    <input class="task-list-item-checkbox" type="checkbox" disabled /> Task list item
+  </li>
+  <li class="task-list-item" attr2="value2">
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Task list item
+  </li>
+</ul>
+```
+
+## Markdown
+
+```md
+- [ ] Task list item {attr="value"}
+- [x] Task list item {attr2="value2"}
+```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-blockquote-single-paragraph.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-blockquote-single-paragraph.md
@@ -1,0 +1,39 @@
+## Input
+
+```md
+::blockquote{attr="value"}
+> Blockquote paragraph 1
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "blockquote",
+      {
+        "attr": "value"
+      },
+      "Blockquote paragraph 1"
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<blockquote attr="value">
+  Blockquote paragraph 1
+</blockquote>
+```
+
+## Markdown
+
+```md
+> Blockquote paragraph 1 {attr="value"}
+```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-blockquote.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-blockquote.md
@@ -52,8 +52,8 @@
 
 ```md
 ::blockquote{attr="value"}
-Blockquote paragraph 1 {attr="value"}
-
-Blockquote paragraph 2 {attr2="value2"}
+> Blockquote paragraph 1 {attr="value"}
+>
+> Blockquote paragraph 2 {attr2="value2"}
 ::
 ```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-blockquote.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-blockquote.md
@@ -1,0 +1,59 @@
+## Input
+
+```md
+::blockquote{attr="value"}
+> Blockquote paragraph 1 {attr="value"}
+>
+> Blockquote paragraph 2 {attr2="value2"}
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "blockquote",
+      {
+        "attr": "value"
+      },
+      [
+        "p",
+        {
+          "attr": "value"
+        },
+        "Blockquote paragraph 1"
+      ],
+      [
+        "p",
+        {
+          "attr2": "value2"
+        },
+        "Blockquote paragraph 2"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<blockquote attr="value">
+  <p attr="value">Blockquote paragraph 1</p>
+  <p attr2="value2">Blockquote paragraph 2</p>
+</blockquote>
+```
+
+## Markdown
+
+```md
+::blockquote{attr="value"}
+Blockquote paragraph 1 {attr="value"}
+
+Blockquote paragraph 2 {attr2="value2"}
+::
+```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-ol.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-ol.md
@@ -1,0 +1,53 @@
+## Input
+
+```md
+::ol{attr="value"}
+1. item 1
+2. item 2
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ol",
+      {
+        "attr": "value"
+      },
+      [
+        "li",
+        {},
+        "item 1"
+      ],
+      [
+        "li",
+        {},
+        "item 2"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ol attr="value">
+  <li>item 1</li>
+  <li>item 2</li>
+</ol>
+```
+
+## Markdown
+
+```md
+::ol{attr="value"}
+1. item 1
+2. item 2
+::
+```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-pre-class.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-pre-class.md
@@ -1,0 +1,50 @@
+## Input
+
+```md
+::pre{.border-2 .border-primary}
+```ts
+const variable = "value"
+```
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "pre",
+      {
+        "language": "ts",
+        "class": "border-2 border-primary"
+      },
+      [
+        "code",
+        {
+          "class": "language-ts"
+        },
+        "const variable = \"value\""
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<pre language="ts" class="border-2 border-primary"><code class="language-ts">const variable = "value"</code></pre>
+```
+
+## Markdown
+
+```md
+::pre{.border-2.border-primary}
+```ts
+const variable = "value"
+```
+::
+```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
@@ -29,7 +29,7 @@ const variable = "value"
       {
         "language": "ts",
         "attr": "value",
-        "class": "shiki shiki-themes min-light nord dark:nord class",
+        "class": "shiki shiki-themes min-light nord dark:nord . class",
         "style": "background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9",
         "tabindex": "0"
       },
@@ -96,7 +96,7 @@ const variable = "value"
 ## HTML
 
 ```html
-<pre language="ts" attr="value" class="shiki shiki-themes min-light nord dark:nord class" tabindex="0" style="background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"><code class="language-ts"><span class="line" style="display: inline"><span style="color:#D32F2F;--shiki-dark:#81A1C1">const</span><span style="color:#1976D2;--shiki-dark:#D8DEE9"> variable</span><span style="color:#D32F2F;--shiki-dark:#81A1C1"> =</span><span style="color:#22863A;--shiki-dark:#ECEFF4"> "</span><span style="color:#22863A;--shiki-dark:#A3BE8C">value</span><span style="color:#22863A;--shiki-dark:#ECEFF4">"</span></span></code></pre>
+<pre language="ts" attr="value" class="shiki shiki-themes min-light nord dark:nord . class" tabindex="0" style="background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"><code class="language-ts"><span class="line" style="display: inline"><span style="color:#D32F2F;--shiki-dark:#81A1C1">const</span><span style="color:#1976D2;--shiki-dark:#D8DEE9"> variable</span><span style="color:#D32F2F;--shiki-dark:#81A1C1"> =</span><span style="color:#22863A;--shiki-dark:#ECEFF4"> "</span><span style="color:#22863A;--shiki-dark:#A3BE8C">value</span><span style="color:#22863A;--shiki-dark:#ECEFF4">"</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
@@ -1,0 +1,110 @@
+---
+options:
+  highlight: 
+    themes:
+      light: 'min-light'
+      dark: 'nord'
+    preStyles: true
+---
+
+## Input
+
+```md
+::pre{attr="value" .class}
+```ts
+const variable = "value"
+```
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "pre",
+      {
+        "language": "ts",
+        "attr": "value",
+        "class": "shiki shiki-themes min-light nord dark:nord class",
+        "style": "background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9",
+        "tabindex": "0"
+      },
+      [
+        "code",
+        {
+          "class": "language-ts"
+        },
+         [
+           "span",
+           {
+             "class": "line",
+             "style": "display: inline"
+           },
+           [
+             "span",
+             {
+               "style": "color:#D32F2F;--shiki-dark:#81A1C1"
+             },
+             "const"
+           ],
+           [
+             "span",
+             {
+               "style": "color:#1976D2;--shiki-dark:#D8DEE9"
+             },
+             " variable"
+           ],
+           [
+             "span",
+             {
+               "style": "color:#D32F2F;--shiki-dark:#81A1C1"
+             },
+             " ="
+           ],
+           [
+             "span",
+             {
+               "style": "color:#22863A;--shiki-dark:#ECEFF4"
+             },
+             " \""
+           ],
+           [
+             "span",
+             {
+               "style": "color:#22863A;--shiki-dark:#A3BE8C"
+             },
+             "value"
+           ],
+           [
+             "span",
+             {
+               "style": "color:#22863A;--shiki-dark:#ECEFF4"
+             },
+             "\""
+           ]
+         ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<pre language="ts" attr="value" class="shiki shiki-themes min-light nord dark:nord class" tabindex="0" style="background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"><code class="language-ts"><span class="line" style="display: inline"><span style="color:#D32F2F;--shiki-dark:#81A1C1">const</span><span style="color:#1976D2;--shiki-dark:#D8DEE9"> variable</span><span style="color:#D32F2F;--shiki-dark:#81A1C1"> =</span><span style="color:#22863A;--shiki-dark:#ECEFF4"> "</span><span style="color:#22863A;--shiki-dark:#A3BE8C">value</span><span style="color:#22863A;--shiki-dark:#ECEFF4">"</span></span></code></pre>
+```
+
+## Markdown
+
+```md
+::pre{attr="value" .class}
+```ts
+const variable = "value"
+```
+::
+```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-pre.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-pre.md
@@ -1,0 +1,50 @@
+## Input
+
+```md
+::pre{attr="value"}
+```ts
+const variable = "value"
+```
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "pre",
+      {
+        "language": "ts",
+        "attr": "value"
+      },
+      [
+        "code",
+        {
+          "class": "language-ts"
+        },
+        "const variable = \"value\""
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<pre language="ts" attr="value"><code class="language-ts">const variable = "value"</code></pre>
+```
+
+## Markdown
+
+```md
+::pre{attr="value"}
+```ts
+const variable = "value"
+```
+::
+```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-table.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-table.md
@@ -1,0 +1,91 @@
+## Input
+
+```md
+::table{attr="value"}
+|col1|col2|
+|------|------|
+|cell1|cell2|
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "table",
+      {
+        "attr": "value"
+      },
+      [
+        "thead",
+        {},
+        [
+          "tr",
+          {},
+          [
+            "th",
+            {},
+            "col1"
+          ],
+          [
+            "th",
+            {},
+            "col2"
+          ]
+        ]
+      ],
+      [
+        "tbody",
+        {},
+        [
+          "tr",
+          {},
+          [
+            "td",
+            {},
+            "cell1"
+          ],
+          [
+            "td",
+            {},
+            "cell2"
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<table attr="value">
+  <thead>
+    <tr>
+      <th>col1</th>
+      <th>col2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>cell1</td>
+      <td>cell2</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+## Markdown
+
+```md
+::table{attr="value"}
+| col1  | col2  |
+| ----- | ----- |
+| cell1 | cell2 |
+::
+```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-ul.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-ul.md
@@ -1,0 +1,53 @@
+## Input
+
+```md
+::ul{attr="value"}
+- item 1
+- item 2
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ul",
+      {
+        "attr": "value"
+      },
+      [
+        "li",
+        {},
+        "item 1"
+      ],
+      [
+        "li",
+        {},
+        "item 2"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ul attr="value">
+  <li>item 1</li>
+  <li>item 2</li>
+</ul>
+```
+
+## Markdown
+
+```md
+::ul{attr="value"}
+- item 1
+- item 2
+::
+```

--- a/packages/comark/src/internal/parse/auto-unwrap.ts
+++ b/packages/comark/src/internal/parse/auto-unwrap.ts
@@ -37,5 +37,10 @@ export function applyAutoUnwrap(node: ComarkNode): ComarkNode {
     return [tag, props, ...children.map((child: ComarkNode) => applyAutoUnwrap(child as ComarkNode))] as ComarkNode
   }
 
-  return [tag, props, ...(nonEmptyChildren[0].slice(2) as ComarkNode[])] as ComarkNode
+  // Lift the paragraph's attrs onto the parent so trailing `{attr}` survives the unwrap.
+  // Parent attrs take precedence so explicit component props aren't overridden.
+  const paragraphAttrs = nonEmptyChildren[0][1] as Record<string, unknown>
+  const mergedProps = paragraphAttrs && Object.keys(paragraphAttrs).length > 0 ? { ...paragraphAttrs, ...props } : props
+
+  return [tag, mergedProps, ...(nonEmptyChildren[0].slice(2) as ComarkNode[])] as ComarkNode
 }

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -2,7 +2,7 @@ import type { ComarkElement, ComarkNode } from 'comark'
 import { htmlToComarkNodes, parseInlineHtmlTag } from './html/index.ts'
 
 // `::tag` components that should fold into a single same-tagged child.
-const WRAPPER_TAGS = new Set(['ul', 'ol', 'table', 'blockquote'])
+const WRAPPER_TAGS = new Set(['ul', 'ol', 'table', 'blockquote', 'pre'])
 
 // Mapping from token types to tag names
 const BLOCK_TAG_MAP: Record<string, string> = {
@@ -311,8 +311,8 @@ function processBlockToken(
     // Process children until mdc_block_close, handling slots (#slotname)
     const children = processBlockChildrenWithSlots(tokens, startIndex + 1, 'mdc_block_close', state)
 
-    // `::ul`/`::ol`/`::table`/`::blockquote` wrapping a single same-tag child
-    // collapses into a single element with the wrapper's attrs (outer wins).
+    // `::ul`/`::ol`/`::table`/`::blockquote`/`::pre` wrapping a single same-tag
+    // child collapses into a single element with the wrapper's attrs (outer wins).
     if (
       WRAPPER_TAGS.has(componentName) &&
       children.nodes.length === 1 &&

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -385,6 +385,7 @@ function processBlockToken(
   if (token.type === 'heading_open') {
     const level = Number.parseInt(token.tag.replace('h', ''), 10)
     const headingTag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+    const userAttrs = processAttributes(token.attrs, { handleBoolean: false, handleJSON: false })
     // Process heading children with inHeading flag for Comark component handling
     const children = processBlockChildren(
       tokens,
@@ -400,9 +401,11 @@ function processBlockToken(
       const textContent = extractTextContent(children.nodes)
       const headingId = uniqueSlug(slugify(textContent), level, state)
 
-      // Always attach ID to the heading element itself
+      // Merge user-supplied attrs with the auto-generated id; user `id` wins.
+      const attrs: Record<string, unknown> = { id: headingId, ...userAttrs }
+
       return {
-        node: [headingTag, { id: headingId }, ...children.nodes] as ComarkNode,
+        node: [headingTag, attrs, ...children.nodes] as ComarkNode,
         nextIndex: children.nextIndex + 1,
       }
     }

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -1,5 +1,8 @@
-import type { ComarkNode } from 'comark'
+import type { ComarkElement, ComarkNode } from 'comark'
 import { htmlToComarkNodes, parseInlineHtmlTag } from './html/index.ts'
+
+// `::tag` components that should fold into a single same-tagged child.
+const WRAPPER_TAGS = new Set(['ul', 'ol', 'table', 'blockquote'])
 
 // Mapping from token types to tag names
 const BLOCK_TAG_MAP: Record<string, string> = {
@@ -307,6 +310,24 @@ function processBlockToken(
     const attrs = processAttributes(token.attrs)
     // Process children until mdc_block_close, handling slots (#slotname)
     const children = processBlockChildrenWithSlots(tokens, startIndex + 1, 'mdc_block_close', state)
+
+    // `::ul`/`::ol`/`::table`/`::blockquote` wrapping a single same-tag child
+    // collapses into a single element with the wrapper's attrs (outer wins).
+    if (
+      WRAPPER_TAGS.has(componentName) &&
+      children.nodes.length === 1 &&
+      Array.isArray(children.nodes[0]) &&
+      children.nodes[0][0] === componentName
+    ) {
+      const inner = children.nodes[0] as ComarkElement
+      const innerAttrs = inner[1] as Record<string, unknown>
+      const innerChildren = inner.slice(2) as ComarkNode[]
+      return {
+        node: [componentName, { ...innerAttrs, ...attrs }, ...innerChildren] as ComarkNode,
+        nextIndex: children.nextIndex + 1,
+      }
+    }
+
     // Return the component even if it has no children (empty component like ::component\n::)
     return { node: [componentName, attrs, ...children.nodes] as ComarkNode, nextIndex: children.nextIndex + 1 }
   }

--- a/packages/comark/src/internal/stringify/attributes.ts
+++ b/packages/comark/src/internal/stringify/attributes.ts
@@ -92,6 +92,41 @@ export function resolveAttribute(attrs: Record<string, unknown>, renderData: Nod
   return attrs[key]
 }
 
+// Implicit attributes the parser injects per tag — they're conveyed by the
+// native markdown syntax (e.g. `as` becomes `> [!NOTE]`, `task-list-item`
+// is implicit in `- [ ]`) so they should not echo back as user attrs.
+const IMPLICIT_ATTRS: Record<string, { drop?: string[]; classBlocklist?: string[] }> = {
+  blockquote: { drop: ['as'] },
+  ul: { classBlocklist: ['contains-task-list'] },
+  li: { classBlocklist: ['task-list-item'] },
+}
+
+/**
+ * Filter implicit/auto-generated attrs that are encoded by the native
+ * markdown syntax and shouldn't echo back as `{attr=...}`. Used by the
+ * block stringifiers to decide whether a node has *user* attrs that must
+ * be preserved via the `::tag{...}` wrapper form.
+ */
+export function userBlockAttrs(tag: string, attributes: Record<string, unknown>): Record<string, unknown> {
+  const rule = IMPLICIT_ATTRS[tag]
+  if (!rule) return { ...attributes }
+
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(attributes)) {
+    if (rule.drop?.includes(key)) continue
+    if (key === 'class' && rule.classBlocklist && typeof value === 'string') {
+      const remaining = value
+        .split(/\s+/)
+        .filter((c) => c && !rule.classBlocklist!.includes(c))
+        .join(' ')
+      if (remaining) result[key] = remaining
+      continue
+    }
+    result[key] = value
+  }
+  return result
+}
+
 /**
  * Convert attributes to a string of Comark attributes
  *

--- a/packages/comark/src/internal/stringify/attributes.ts
+++ b/packages/comark/src/internal/stringify/attributes.ts
@@ -133,7 +133,7 @@ export function userBlockAttrs(tag: string, attributes: Record<string, unknown>)
       // user-supplied class is appended after it. Recover the user portion by
       // dropping everything up to and including the first `dark:*` token.
       const tokens = value.split(/\s+/)
-      let cutoff = tokens.findIndex((t) => t.startsWith('dark:'))
+      let cutoff = tokens.findIndex((t) => t === '.')
 
       const userClass = cutoff >= 0 ? tokens.slice(cutoff + 1).join(' ') : ''
       if (userClass) result[key] = userClass

--- a/packages/comark/src/internal/stringify/attributes.ts
+++ b/packages/comark/src/internal/stringify/attributes.ts
@@ -99,6 +99,12 @@ const IMPLICIT_ATTRS: Record<string, { drop?: string[]; classBlocklist?: string[
   blockquote: { drop: ['as'] },
   ul: { classBlocklist: ['contains-task-list'] },
   li: { classBlocklist: ['task-list-item'] },
+  // `language`/`filename`/`highlights`/`meta` ride on the fence info string.
+  // `tabindex`/`style` come from render-time plugins (e.g. shiki) and have no
+  // markdown form. `class` is handled specially in userBlockAttrs because shiki
+  // merges its injected classes with the user's class — we need to strip just
+  // the highlighter portion.
+  pre: { drop: ['language', 'filename', 'highlights', 'meta', 'tabindex', 'style'] },
 }
 
 /**
@@ -120,6 +126,17 @@ export function userBlockAttrs(tag: string, attributes: Record<string, unknown>)
         .filter((c) => c && !rule.classBlocklist!.includes(c))
         .join(' ')
       if (remaining) result[key] = remaining
+      continue
+    }
+    if (key === 'class' && tag === 'pre' && typeof value === 'string' && value.startsWith('shiki ')) {
+      // Shiki injects `shiki [shiki-themes] <themes…> dark:<theme>` and any
+      // user-supplied class is appended after it. Recover the user portion by
+      // dropping everything up to and including the first `dark:*` token.
+      const tokens = value.split(/\s+/)
+      let cutoff = tokens.findIndex(t => t.startsWith("dark:"))
+
+      const userClass = cutoff >= 0 ? tokens.slice(cutoff + 1).join(' ') : ''
+      if (userClass) result[key] = userClass
       continue
     }
     result[key] = value

--- a/packages/comark/src/internal/stringify/attributes.ts
+++ b/packages/comark/src/internal/stringify/attributes.ts
@@ -133,7 +133,7 @@ export function userBlockAttrs(tag: string, attributes: Record<string, unknown>)
       // user-supplied class is appended after it. Recover the user portion by
       // dropping everything up to and including the first `dark:*` token.
       const tokens = value.split(/\s+/)
-      let cutoff = tokens.findIndex(t => t.startsWith("dark:"))
+      let cutoff = tokens.findIndex((t) => t.startsWith('dark:'))
 
       const userClass = cutoff >= 0 ? tokens.slice(cutoff + 1).join(' ') : ''
       if (userClass) result[key] = userClass

--- a/packages/comark/src/internal/stringify/handlers/blockquote.ts
+++ b/packages/comark/src/internal/stringify/handlers/blockquote.ts
@@ -1,6 +1,6 @@
 import type { State } from 'comark/render'
 import type { ComarkElement, ComarkNode } from 'comark'
-import { comarkAttributes } from '../attributes.ts'
+import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 
 export async function blockquote(node: ComarkElement, state: State) {
   const children = node.slice(2) as ComarkNode[]
@@ -10,9 +10,18 @@ export async function blockquote(node: ComarkElement, state: State) {
     childResult += await state.one(child, state, node)
   }
 
-  // `as` drives the alert-style `> [!NOTE]` prefix — don't echo it as `{as="…"}`.
-  const { as: _as, ...rest } = node[1] as Record<string, unknown>
-  const attrs = comarkAttributes(rest)
+  const userAttrs = userBlockAttrs('blockquote', node[1] as Record<string, unknown>)
+  const attrs = comarkAttributes(userAttrs)
+
+  // Multi-block content with attrs has no unambiguous inline form — round-trip
+  // via `::blockquote{attrs}` so the attrs aren't visually attached to one
+  // paragraph and parsers can recover the same AST.
+  const hasBlockChildren = children.some((c) => Array.isArray(c))
+  if (attrs && hasBlockChildren) {
+    const inner = childResult.trim()
+    return `::blockquote${attrs}\n${inner}\n::` + state.context.blockSeparator
+  }
+
   if (attrs) childResult = `${childResult.replace(/[ \t]+$/, '')} ${attrs}`
 
   const content = childResult

--- a/packages/comark/src/internal/stringify/handlers/blockquote.ts
+++ b/packages/comark/src/internal/stringify/handlers/blockquote.ts
@@ -12,14 +12,18 @@ export async function blockquote(node: ComarkElement, state: State) {
 
   const userAttrs = userBlockAttrs('blockquote', node[1] as Record<string, unknown>)
   const attrs = comarkAttributes(userAttrs)
+  const hasBlockChildren = children.some((c) => Array.isArray(c))
 
   // Multi-block content with attrs has no unambiguous inline form — round-trip
   // via `::blockquote{attrs}` so the attrs aren't visually attached to one
   // paragraph and parsers can recover the same AST.
-  const hasBlockChildren = children.some((c) => Array.isArray(c))
   if (attrs && hasBlockChildren) {
-    const inner = childResult.trim()
-    return `::blockquote${attrs}\n${inner}\n::` + state.context.blockSeparator
+    const content = childResult
+      .trim()
+      .split('\n')
+      .map((line) => (line ? `> ${line}` : '>'))
+      .join('\n')
+    return `::blockquote${attrs}\n${content}\n::` + state.context.blockSeparator
   }
 
   if (attrs) childResult = `${childResult.replace(/[ \t]+$/, '')} ${attrs}`

--- a/packages/comark/src/internal/stringify/handlers/blockquote.ts
+++ b/packages/comark/src/internal/stringify/handlers/blockquote.ts
@@ -1,5 +1,6 @@
 import type { State } from 'comark/render'
 import type { ComarkElement, ComarkNode } from 'comark'
+import { comarkAttributes } from '../attributes.ts'
 
 export async function blockquote(node: ComarkElement, state: State) {
   const children = node.slice(2) as ComarkNode[]
@@ -8,6 +9,12 @@ export async function blockquote(node: ComarkElement, state: State) {
   for (const child of children) {
     childResult += await state.one(child, state, node)
   }
+
+  // `as` drives the alert-style `> [!NOTE]` prefix — don't echo it as `{as="…"}`.
+  const { as: _as, ...rest } = node[1] as Record<string, unknown>
+  const attrs = comarkAttributes(rest)
+  if (attrs) childResult = `${childResult.replace(/[ \t]+$/, '')} ${attrs}`
+
   const content = childResult
     .trim()
     .split('\n')

--- a/packages/comark/src/internal/stringify/handlers/heading.ts
+++ b/packages/comark/src/internal/stringify/handlers/heading.ts
@@ -1,5 +1,6 @@
 import type { State } from 'comark/render'
 import type { ComarkElement } from 'comark'
+import { comarkAttributes } from '../attributes.ts'
 
 // h1, h2, h3, h4, h5, h6
 export async function heading(node: ComarkElement, state: State) {
@@ -9,5 +10,10 @@ export async function heading(node: ComarkElement, state: State) {
 
   const content = await state.flow(node, state)
 
-  return '#'.repeat(level) + ' ' + content + state.context.blockSeparator
+  // The auto-generated id is implicit in `# Heading` markdown — don't echo it.
+  const { id: _id, ...rest } = node[1] as Record<string, unknown>
+  const attrs = comarkAttributes(rest)
+  const suffix = attrs ? ` ${attrs}` : ''
+
+  return '#'.repeat(level) + ' ' + content + suffix + state.context.blockSeparator
 }

--- a/packages/comark/src/internal/stringify/handlers/li.ts
+++ b/packages/comark/src/internal/stringify/handlers/li.ts
@@ -1,7 +1,7 @@
 import type { State } from 'comark/render'
 import type { ComarkElement, ComarkNode } from 'comark'
 import { indent } from '../../../utils/index.ts'
-import { comarkAttributes } from '../attributes.ts'
+import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 
 // Block elements that need explicit indentation in list items.
 // Note: ol/ul are handled by their own handlers which manage indentation via listIndent context.
@@ -48,17 +48,7 @@ export async function li(node: ComarkElement, state: State) {
   }
   result = result.trim()
 
-  // Emit explicit attrs, dropping the `task-list-item` marker the parser injects.
-  const attrsObj: Record<string, unknown> = { ...(node[1] as Record<string, unknown>) }
-  if (taskList && typeof attrsObj.class === 'string') {
-    const remaining = (attrsObj.class as string)
-      .split(/\s+/)
-      .filter((c) => c && c !== 'task-list-item')
-      .join(' ')
-    if (remaining) attrsObj.class = remaining
-    else delete attrsObj.class
-  }
-  const attrs = comarkAttributes(attrsObj)
+  const attrs = comarkAttributes(userBlockAttrs('li', node[1] as Record<string, unknown>))
   const suffix = attrs ? ` ${attrs}` : ''
 
   if (!order) {

--- a/packages/comark/src/internal/stringify/handlers/li.ts
+++ b/packages/comark/src/internal/stringify/handlers/li.ts
@@ -1,6 +1,7 @@
 import type { State } from 'comark/render'
 import type { ComarkElement, ComarkNode } from 'comark'
 import { indent } from '../../../utils/index.ts'
+import { comarkAttributes } from '../attributes.ts'
 
 // Block elements that need explicit indentation in list items.
 // Note: ol/ul are handled by their own handlers which manage indentation via listIndent context.
@@ -47,6 +48,19 @@ export async function li(node: ComarkElement, state: State) {
   }
   result = result.trim()
 
+  // Emit explicit attrs, dropping the `task-list-item` marker the parser injects.
+  const attrsObj: Record<string, unknown> = { ...(node[1] as Record<string, unknown>) }
+  if (taskList && typeof attrsObj.class === 'string') {
+    const remaining = (attrsObj.class as string)
+      .split(/\s+/)
+      .filter((c) => c && c !== 'task-list-item')
+      .join(' ')
+    if (remaining) attrsObj.class = remaining
+    else delete attrsObj.class
+  }
+  const attrs = comarkAttributes(attrsObj)
+  const suffix = attrs ? ` ${attrs}` : ''
+
   if (!order) {
     result = escapeLeadingNumberDot(result)
   }
@@ -55,7 +69,7 @@ export async function li(node: ComarkElement, state: State) {
     state.applyContext({ order: order + 1 })
   }
 
-  return `${prefix}${result}\n`
+  return `${prefix}${result}${suffix}\n`
 }
 
 function escapeLeadingNumberDot(str: string): string {

--- a/packages/comark/src/internal/stringify/handlers/ol.ts
+++ b/packages/comark/src/internal/stringify/handlers/ol.ts
@@ -1,6 +1,7 @@
 import type { State } from 'comark/render'
 import type { ComarkElement, ComarkNode } from 'comark'
 import { indent } from '../../../utils/index.ts'
+import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 
 export async function ol(node: ComarkElement, state: State) {
   const children = node.slice(2) as ComarkNode[]
@@ -13,13 +14,23 @@ export async function ol(node: ComarkElement, state: State) {
   }
   result = result.trim()
 
+  state.applyContext(revert)
+
+  // ol with user attrs round-trips via `::ol{attrs}\n1. …\n::` — the native
+  // markdown list syntax has no slot for list-level attrs.
+  const attrs = comarkAttributes(userBlockAttrs('ol', node[1] as Record<string, unknown>))
+  if (attrs) {
+    if (revert.list) {
+      return '\n' + indent(`::ol${attrs}\n${result}\n::`, { width: (revert.listIndent as number) || 2 })
+    }
+    return `::ol${attrs}\n${result}\n::` + state.context.blockSeparator
+  }
+
   if (revert.list) {
     result = '\n' + indent(result, { width: (revert.listIndent as number) || 2 })
   } else {
     result = result + state.context.blockSeparator
   }
-
-  state.applyContext(revert)
 
   return result
 }

--- a/packages/comark/src/internal/stringify/handlers/p.ts
+++ b/packages/comark/src/internal/stringify/handlers/p.ts
@@ -1,5 +1,6 @@
 import type { State } from 'comark/render'
 import type { ComarkElement, ComarkNode } from 'comark'
+import { comarkAttributes } from '../attributes.ts'
 
 export async function p(node: ComarkElement, state: State, parent?: ComarkElement) {
   const children = node.slice(2) as ComarkNode[]
@@ -8,6 +9,9 @@ export async function p(node: ComarkElement, state: State, parent?: ComarkElemen
   for (const child of children) {
     result += await state.one(child, state, node)
   }
+
+  const attrs = comarkAttributes(node[1])
+  if (attrs) result = `${result.replace(/[ \t]+$/, '')} ${attrs}`
 
   if (parent?.[0] === 'li') {
     return result

--- a/packages/comark/src/internal/stringify/handlers/pre.ts
+++ b/packages/comark/src/internal/stringify/handlers/pre.ts
@@ -1,6 +1,7 @@
 import type { State } from 'comark/render'
 import type { ComarkElement } from 'comark'
 import { textContent } from '../../../utils/index.ts'
+import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 
 export function pre(node: ComarkElement, state: State) {
   const [_, attributes, ...children] = node
@@ -26,9 +27,15 @@ export function pre(node: ComarkElement, state: State) {
   const code = String(node[1]?.code || textContent(node)).trim()
   const fence = code.includes('```') ? '~~~' : '```'
 
-  const result = fence + language + filename + highlights + meta + '\n' + code + '\n' + fence
+  const fenceBlock = fence + language + filename + highlights + meta + '\n' + code + '\n' + fence
+  // Extra user attrs that can't ride on the fence info string round-trip via
+  // `::pre{attrs}\n```…```\n::` — mirrors the wrapper form for ul/ol/table/blockquote.
+  const attrs = comarkAttributes(userBlockAttrs('pre', attributes as Record<string, unknown>))
+  if (attrs) {
+    return `::pre${attrs}\n${fenceBlock}\n::` + state.context.blockSeparator
+  }
 
-  return result + state.context.blockSeparator
+  return fenceBlock + state.context.blockSeparator
 }
 
 function formatHighlights(highlights: number[]): string {

--- a/packages/comark/src/internal/stringify/handlers/table.ts
+++ b/packages/comark/src/internal/stringify/handlers/table.ts
@@ -1,5 +1,6 @@
 import type { State } from 'comark/render'
 import type { ComarkElement, ComarkNode } from 'comark'
+import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 
 type Alignment = 'left' | 'center' | 'right' | null
 
@@ -187,6 +188,13 @@ export async function table(node: ComarkElement, state: State) {
   }
 
   // result already ends with \n, so we only need to add one more \n
+  // table with user attrs round-trips via `::table{attrs}\n<table>\n::` —
+  // GFM table syntax has no slot for table-level attrs.
+  const attrs = comarkAttributes(userBlockAttrs('table', node[1] as Record<string, unknown>))
+  if (attrs) {
+    return `::table${attrs}\n${result.trimEnd()}\n::\n\n`
+  }
+
   return result + '\n'
 }
 

--- a/packages/comark/src/internal/stringify/handlers/ul.ts
+++ b/packages/comark/src/internal/stringify/handlers/ul.ts
@@ -1,6 +1,7 @@
 import type { State } from 'comark/render'
 import type { ComarkElement, ComarkNode } from 'comark'
 import { indent } from '../../../utils/index.ts'
+import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 
 export async function ul(node: ComarkElement, state: State) {
   const children = node.slice(2) as ComarkNode[]
@@ -13,13 +14,23 @@ export async function ul(node: ComarkElement, state: State) {
   }
   result = result.trim()
 
+  state.applyContext(revert)
+
+  // ul with user attrs round-trips via `::ul{attrs}\n- …\n::` — the native
+  // markdown list syntax has no slot for list-level attrs.
+  const attrs = comarkAttributes(userBlockAttrs('ul', node[1] as Record<string, unknown>))
+  if (attrs) {
+    if (revert.list) {
+      return '\n' + indent(`::ul${attrs}\n${result}\n::`, { width: (revert.listIndent as number) || 2 })
+    }
+    return `::ul${attrs}\n${result}\n::` + state.context.blockSeparator
+  }
+
   if (revert.list) {
     result = '\n' + indent(result, { width: (revert.listIndent as number) || 2 })
   } else {
     result = result + state.context.blockSeparator
   }
-
-  state.applyContext(revert)
 
   return result
 }

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -368,7 +368,7 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
     const userClass = typeof preAttrs.class === 'string' ? preAttrs.class.trim() : ''
     const newPreAttrs: Record<string, any> = {
       ...preAttrs,
-      class: userClass ? `${classStr} ${userClass}` : classStr,
+      class: userClass ? `${classStr} . ${userClass}` : classStr,
       tabindex: '0',
     }
 

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -363,9 +363,12 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
       }
     }
 
+    // Merge highlighter class with any user-supplied class (e.g. from
+    // `::pre{.user-class}`) so the wrapper's class isn't lost.
+    const userClass = typeof preAttrs.class === 'string' ? preAttrs.class.trim() : ''
     const newPreAttrs: Record<string, any> = {
       ...preAttrs,
-      class: classStr,
+      class: userClass ? `${classStr} ${userClass}` : classStr,
       tabindex: '0',
     }
 

--- a/packages/comark/src/plugins/syntax.ts
+++ b/packages/comark/src/plugins/syntax.ts
@@ -594,29 +594,6 @@ const markdownItInlineProps: PluginSimple = (md) => {
       })
     })
 
-    // Deduplicate `ul` wrapping when `::ul` is used and contains exactly one bullet list
-    tokens.forEach((tokenOpen, index) => {
-      if (tokenOpen.type !== 'bullet_list_open') return
-
-      const prev = tokens[index - 1]
-      if (!prev || prev.type !== 'mdc_block_open' || prev.tag !== 'ul') return
-
-      let closeIndex = index + 1
-      while (closeIndex < tokens.length) {
-        const close = tokens[closeIndex]
-        if (close.type === 'bullet_list_close' && close.level === tokenOpen.level) break
-        closeIndex += 1
-      }
-      const tokenClose = tokens[closeIndex]
-      if (tokenClose?.type !== 'bullet_list_close') return
-
-      const next = tokens[closeIndex + 1]
-      if (next?.type === 'mdc_block_close' && next.tag === 'ul') {
-        tokenOpen.hidden = true
-        tokenClose.hidden = true
-      }
-    })
-
     return tokens
   }
 

--- a/packages/comark/src/plugins/syntax.ts
+++ b/packages/comark/src/plugins/syntax.ts
@@ -547,29 +547,51 @@ const markdownItInlineProps: PluginSimple = (md) => {
   md.parse = function (src, env) {
     const tokens = _parse.call(this, src, env)
 
-    // When the props token is the only inline child of a heading/paragraph/list_item,
-    // apply it to the parent block tag instead of producing a `span`
+    // When the trailing inline child is a props token directly after a text
+    // node, lift the props onto the surrounding heading/paragraph/list_item.
+    // (If the props follow a closing tag, they belong to that inline tag, not
+    // the parent — leave them alone.)
     tokens.forEach((token, index) => {
       const prev = tokens[index - 1]
       const next = tokens[index + 1]
       if (!prev || !['heading_open', 'paragraph_open', 'list_item_open'].includes(prev.type) || prev.hidden) return
 
-      // list item handling
+      // Tight-list paragraph: the inline lives one slot ahead
       if (token.hidden && next?.type === 'inline') token = next
 
-      if (
-        token.type === 'inline' &&
-        token.children?.length === 2 &&
-        token.children[0].type === 'text' &&
-        token.children[1].type === 'mdc_inline_props'
-      ) {
-        const props = token.children[1].attrs
-        token.children.splice(1, 1)
-        props?.forEach(([key, value]) => {
-          if (key === 'class') prev.attrJoin('class', value)
-          else prev.attrSet(key, value)
-        })
+      if (token.type !== 'inline' || !token.children?.length) return
+
+      const last = token.children[token.children.length - 1]
+      if (last.type !== 'mdc_inline_props') return
+
+      // Find the previous non-empty child. Markdown-it's emphasis tokenizer
+      // can leave an empty text token between the closing delimiter and the
+      // props — skipping it lets us distinguish "props on the parent" from
+      // "props on the preceding inline tag".
+      let beforeIdx = token.children.length - 2
+      while (beforeIdx >= 0) {
+        const child = token.children[beforeIdx]
+        if (child.type === 'text' && !child.content) {
+          beforeIdx--
+          continue
+        }
+        break
       }
+      const beforeProps = beforeIdx >= 0 ? token.children[beforeIdx] : undefined
+      if (!beforeProps || beforeProps.type !== 'text') return
+
+      // Strip the trailing space the text picked up before the `{...}` token.
+      if (typeof beforeProps.content === 'string') {
+        beforeProps.content = beforeProps.content.replace(/[ \t]+$/, '')
+      }
+
+      const props = last.attrs
+      // Drop the props token (last) plus any empty text tokens it left behind.
+      token.children.length = beforeProps.content ? beforeIdx + 1 : beforeIdx
+      props?.forEach(([key, value]) => {
+        if (key === 'class') prev.attrJoin('class', value)
+        else prev.attrSet(key, value)
+      })
     })
 
     // Deduplicate `ul` wrapping when `::ul` is used and contains exactly one bullet list


### PR DESCRIPTION
resolves #222

## Summary

Two related improvements to block-level attribute handling.

### 1. Attach trailing `{attr}` to the nearest block element

A trailing `{attr="value"}` on the last line of a block now attaches to that block. Works for paragraphs, headings (h1–h6), bullet/ordered/task list items, and blockquote paragraphs:

```md
A paragraph {attr="value"}

- a list item {attr="value"}
- another list item {attr2="value2"}

# h1 {attr="value"}
###### h6 {attr="value"}

> Blockquote {attr="value"}

> Para 1 {attr="value"}
>
> Para 2 {attr2="value2"}

1. List item {attr="value"}

- [ ] Task list item {attr="value"}
- [x] Task list item {attr2="value2"}
```

Implementation:

- The inline-props lift in `syntax.ts` is loosened to trigger when props follow a text node even if other inline siblings (e.g. the task-list checkbox) precede it, while still skipping markdown-it's empty filler text token between an emphasis close and `{...}` so `**bold**{attr}` keeps attaching to `<strong>` instead of the `<p>`.
- `heading_open` merges `token.attrs` with the auto-generated id.
- Auto-unwrap lifts the unwrapped paragraph's attrs onto the parent (parent attrs win), so `> Blockquote {attr}` keeps the attr after the paragraph is removed.
- Stringifiers (p / heading / blockquote / li) emit the trailing `{attr=…}` suffix; auto-generated heading id, blockquote `as`, and the `task-list-item` class are filtered out so they don't echo back as user attrs.

### 2. Fold `::ul` / `::ol` / `::table` / `::blockquote` into their single same-tag child

The native markdown syntax has no slot for list-level, table-level, or multi-paragraph-blockquote-level attrs. To cover those, the matching `::tag` block component is now a first-class way to attach attrs to the underlying element. When `::ul` / `::ol` / `::table` / `::blockquote` wraps exactly one same-tagged child, the parser folds them into a single element — the wrapper's attrs land on the actual list/table/blockquote element instead of producing a nested duplicate.

```md
::ul{attr="value"}
- item 1
- item 2
::
```

parses to `["ul", {attr: "value"}, [li], [li]]` (not `["ul", {attr}, ["ul", {}, ...]]`), and renders to `<ul attr="value">...</ul>`. Same shape for `::ol`, `::table`, and `::blockquote`. Outer attrs win over inner if both are present.

For the markdown roundtrip, ul / ol / table emit the `::tag{attrs}\n…\n::` form when they carry user attrs. Blockquote uses the wrapper form when it has user attrs *and* multi-block children; single-content blockquotes keep the natural `> text {attr}` form. The old markdown-it-level `::ul` dedupe hook was removed since the AST-level fold supersedes it.