### PR TITLE
docs: align framework landing examples with tab labels

### DIFF
--- a/docs/app/components/landing/LandingFeatureFrameworks.vue
+++ b/docs/app/components/landing/LandingFeatureFrameworks.vue
@@ -71,7 +71,7 @@ ${'<'}/script>
 
 const { data: highlighted } = await useAsyncData('fw-highlight', async () => {
   const themes = { light: 'github-light', dark: 'github-dark' } as const
-  const [vue, react, svelte] = await Promise.all([
+  const [react, svelte, vue] = await Promise.all([
     codeToHtml(reactCode, { lang: 'tsx', themes }),
     codeToHtml(svelteCode, { lang: 'svelte', themes }),
     codeToHtml(vueCode, { lang: 'vue', themes }),


### PR DESCRIPTION
## Summary
- fix the Promise.all destructuring order in LandingFeatureFrameworks.vue
- keep each rendered snippet matched to its React, Svelte, and Vue tab

## Validation
- git diff --check

Closes #215
