### PR TITLE
docs: add README for each framework package

### DIFF
--- a/packages/comark-ansi/README.md
+++ b/packages/comark-ansi/README.md
@@ -1,0 +1,77 @@
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+
+# @comark/ansi
+
+[![npm version](https://img.shields.io/npm/v/@comark/ansi?color=black)](https://npmx.dev/@comark/ansi)
+[![npm downloads](https://img.shields.io/npm/dm/@comark/ansi?color=black)](https://npm.chart.dev/@comark/ansi)
+[![CI](https://img.shields.io/github/actions/workflow/status/comarkdown/comark/ci.yml?branch=main&color=black)](https://github.com/comarkdown/comark/actions/workflows/ci.yml)
+[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://comark.dev/rendering/ansi)
+[![license](https://img.shields.io/github/license/comarkdown/comark?color=black)](https://github.com/comarkdown/comark/blob/main/LICENSE)
+
+ANSI terminal renderer for [Comark](https://comark.dev). Render markdown as styled terminal output — perfect for CLIs, scripts, and developer tooling.
+
+## Features
+
+- 🎨 ANSI-styled output for the terminal
+- 🌈 Respects `NO_COLOR` automatically
+- 📐 Configurable terminal width for HR and code blocks
+- 🎯 Map any Comark tag to a custom render function
+- 🔌 Plugin ecosystem (math, mermaid, highlight, binding…)
+- 🎯 Full TypeScript support
+
+## Installation
+
+```bash
+npm install @comark/ansi
+# or
+pnpm add @comark/ansi
+```
+
+## Usage
+
+```ts
+import { render } from '@comark/ansi'
+
+const output = await render(`
+# Getting Started
+
+This is a **bold** statement with a [link](https://example.com).
+
+- Item 1
+- Item 2
+`)
+
+process.stdout.write(output)
+```
+
+### Options
+
+```ts
+await render(content, {
+  colors: true,   // emit ANSI escape codes (defaults to true, false when NO_COLOR is set)
+  width: 80,      // terminal width for HR and code block headers
+  plugins: [],
+  components: {},
+})
+```
+
+### Syntax highlighting
+
+```ts
+import { render } from '@comark/ansi'
+import highlight from '@comark/ansi/plugins/highlight'
+
+const output = await render('```ts\nconsole.log("hi")\n```', {
+  plugins: [highlight()],
+})
+```
+
+## Documentation
+
+Full guide and API reference at [comark.dev/rendering/ansi](https://comark.dev/rendering/ansi).
+
+## License
+
+Made with ❤️
+
+Published under [MIT License](https://github.com/comarkdown/comark/blob/main/LICENSE).

--- a/packages/comark-html/README.md
+++ b/packages/comark-html/README.md
@@ -1,0 +1,87 @@
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+
+# @comark/html
+
+[![npm version](https://img.shields.io/npm/v/@comark/html?color=black)](https://npmx.dev/@comark/html)
+[![npm downloads](https://img.shields.io/npm/dm/@comark/html?color=black)](https://npm.chart.dev/@comark/html)
+[![CI](https://img.shields.io/github/actions/workflow/status/comarkdown/comark/ci.yml?branch=main&color=black)](https://github.com/comarkdown/comark/actions/workflows/ci.yml)
+[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://comark.dev/rendering/html)
+[![license](https://img.shields.io/github/license/comarkdown/comark?color=black)](https://github.com/comarkdown/comark/blob/main/LICENSE)
+
+Framework-free HTML renderer for [Comark](https://comark.dev). Use it for SSR, static site generation, RSS feeds, emails, or anywhere you just need an HTML string.
+
+## Features
+
+- 📦 No framework dependencies — pure HTML output
+- 🎯 Map any Comark tag to a custom render function
+- 🌊 Stream API for buffered/incremental rendering
+- 🔌 Plugin ecosystem (math, mermaid, highlight, binding…)
+- 🎯 Full TypeScript support
+
+## Installation
+
+```bash
+npm install @comark/html
+# or
+pnpm add @comark/html
+```
+
+## Usage
+
+```ts
+import { render } from '@comark/html'
+
+const html = await render(`
+# Getting Started
+
+This is a **bold** statement with a [link](https://example.com).
+
+- Item 1
+- Item 2
+`)
+```
+
+```html
+<h1 id="getting-started">Getting Started</h1>
+<p>This is a <strong>bold</strong> statement with a <a href="https://example.com">link</a>.</p>
+<ul>
+<li>Item 1</li>
+<li>Item 2</li>
+</ul>
+```
+
+### Custom components
+
+```ts
+import { render } from '@comark/html'
+
+const html = await render(`::alert{type="warning"}\nHeads up!\n::`, {
+  components: {
+    alert: async ([, attrs, ...children], { render }) =>
+      `<div class="alert alert-${attrs.type}">${await render(children)}</div>`,
+  },
+})
+```
+
+### Plugins
+
+```ts
+import { render } from '@comark/html'
+import highlight from '@comark/html/plugins/highlight'
+import githubLight from '@shikijs/themes/github-light'
+import githubDark from '@shikijs/themes/github-dark'
+
+const html = await render(content, {
+  plugins: [highlight({ themes: { light: githubLight, dark: githubDark } })],
+})
+```
+
+## Documentation
+
+Full guide and API reference at [comark.dev/rendering/html](https://comark.dev/rendering/html).
+
+## License
+
+Made with ❤️
+
+Published under [MIT License](https://github.com/comarkdown/comark/blob/main/LICENSE).

--- a/packages/comark-nuxt/README.md
+++ b/packages/comark-nuxt/README.md
@@ -1,0 +1,127 @@
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+
+# @comark/nuxt
+
+[![npm version](https://img.shields.io/npm/v/@comark/nuxt?color=black)](https://npmx.dev/@comark/nuxt)
+[![npm downloads](https://img.shields.io/npm/dm/@comark/nuxt?color=black)](https://npm.chart.dev/@comark/nuxt)
+[![CI](https://img.shields.io/github/actions/workflow/status/comarkdown/comark/ci.yml?branch=main&color=black)](https://github.com/comarkdown/comark/actions/workflows/ci.yml)
+[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://comark.dev/rendering/nuxt)
+[![license](https://img.shields.io/github/license/comarkdown/comark?color=black)](https://github.com/comarkdown/comark/blob/main/LICENSE)
+
+Zero-config Nuxt module for [Comark](https://comark.dev) — a high-performance markdown parser and renderer.
+
+## Features
+
+- ⚡ Auto-imported `<Comark>` and `<ComarkRenderer>` components
+- 📁 `~/components/prose` directory for overriding HTML elements
+- 🎨 Automatic [Nuxt UI](https://ui.nuxt.com) prose integration
+- 🖥️ SSR, SSG, and prerendering support out of the box
+- 🧩 Re-exports of Comark plugins (binding, math, mermaid)
+- 🎯 Full TypeScript support
+
+## Installation
+
+```bash
+npm install @comark/nuxt
+# or
+pnpm add @comark/nuxt
+```
+
+Add the module to your `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@comark/nuxt'],
+})
+```
+
+## Usage
+
+The `<Comark>` component is available globally — no imports needed. Pass markdown via the default slot or the `markdown` prop:
+
+```vue
+<script setup lang="ts">
+const content = `# Hello Nuxt\n\nRendered with **Comark**.`
+</script>
+
+<template>
+  <Comark>{{ content }}</Comark>
+</template>
+```
+
+### Custom components
+
+Map Comark tags to your own Vue components:
+
+```vue
+<script setup lang="ts">
+import Alert from '~/components/Alert.vue'
+</script>
+
+<template>
+  <Comark :components="{ alert: Alert }">{{ content }}</Comark>
+</template>
+```
+
+```mdc
+::alert{type="warning"}
+This is a warning.
+::
+```
+
+### Overriding HTML elements
+
+Drop components into `~/components/prose` to override how native HTML elements render. They are auto-registered:
+
+```
+~/components/prose/
+  ProseH1.vue
+  ProsePre.vue
+  ProseA.vue
+```
+
+### Plugins
+
+```vue
+<script setup lang="ts">
+import math, { Math } from '@comark/nuxt/plugins/math'
+import mermaid, { Mermaid } from '@comark/nuxt/plugins/mermaid'
+</script>
+
+<template>
+  <Comark
+    :components="{ math: Math, mermaid: Mermaid }"
+    :plugins="[math(), mermaid()]"
+  >
+    {{ content }}
+  </Comark>
+</template>
+```
+
+### Nuxt UI
+
+When [`@nuxt/ui`](https://ui.nuxt.com) is installed, prose components are wired up automatically:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@comark/nuxt', '@nuxt/ui'],
+})
+```
+
+## Documentation
+
+Full guide and API reference at [comark.dev/rendering/nuxt](https://comark.dev/rendering/nuxt).
+
+## Agent skill
+
+Coding agents can install the Comark skill from the docs site:
+
+```bash
+npx skills add https://comark.dev
+```
+
+## License
+
+Made with ❤️
+
+Published under [MIT License](https://github.com/comarkdown/comark/blob/main/LICENSE).

--- a/packages/comark-react/README.md
+++ b/packages/comark-react/README.md
@@ -1,0 +1,78 @@
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+
+# @comark/react
+
+[![npm version](https://img.shields.io/npm/v/@comark/react?color=black)](https://npmx.dev/@comark/react)
+[![npm downloads](https://img.shields.io/npm/dm/@comark/react?color=black)](https://npm.chart.dev/@comark/react)
+[![CI](https://img.shields.io/github/actions/workflow/status/comarkdown/comark/ci.yml?branch=main&color=black)](https://github.com/comarkdown/comark/actions/workflows/ci.yml)
+[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://comark.dev/rendering/react)
+[![license](https://img.shields.io/github/license/comarkdown/comark?color=black)](https://github.com/comarkdown/comark/blob/main/LICENSE)
+
+React renderer for [Comark](https://comark.dev) — render markdown with custom React components, streaming support, and Server Components.
+
+## Features
+
+- 🧩 `<Comark>` component for one-shot markdown rendering
+- 🎯 Map any Comark tag to a custom React component
+- 🌊 Streaming-friendly with auto-close and caret support
+- 🖥️ Works with React Server Components and SSR
+- 🔌 Plugin ecosystem (math, mermaid, highlight, binding…)
+- 🎯 Full TypeScript support
+
+## Installation
+
+```bash
+npm install @comark/react
+# or
+pnpm add @comark/react
+```
+
+## Usage
+
+```tsx
+import { Comark } from '@comark/react'
+import math, { Math } from '@comark/react/plugins/math'
+
+const content = `# Hello\n\nThis is **Comark** in React.`
+
+export default function App() {
+  return (
+    <Comark components={{ math: Math }} plugins={[math()]}>
+      {content}
+    </Comark>
+  )
+}
+```
+
+### Custom components
+
+```tsx
+import { Comark } from '@comark/react'
+import { Alert } from './components/Alert'
+
+<Comark components={{ alert: Alert }}>{content}</Comark>
+```
+
+```mdc
+::alert{type="warning"}
+Heads up!
+::
+```
+
+### Streaming
+
+```tsx
+<Comark streaming={isStreaming} caret>
+  {content}
+</Comark>
+```
+
+## Documentation
+
+Full guide and API reference at [comark.dev/rendering/react](https://comark.dev/rendering/react).
+
+## License
+
+Made with ❤️
+
+Published under [MIT License](https://github.com/comarkdown/comark/blob/main/LICENSE).

--- a/packages/comark-svelte/README.md
+++ b/packages/comark-svelte/README.md
@@ -1,0 +1,74 @@
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+
+# @comark/svelte
+
+[![npm version](https://img.shields.io/npm/v/@comark/svelte?color=black)](https://npmx.dev/@comark/svelte)
+[![npm downloads](https://img.shields.io/npm/dm/@comark/svelte?color=black)](https://npm.chart.dev/@comark/svelte)
+[![CI](https://img.shields.io/github/actions/workflow/status/comarkdown/comark/ci.yml?branch=main&color=black)](https://github.com/comarkdown/comark/actions/workflows/ci.yml)
+[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://comark.dev/rendering/svelte)
+[![license](https://img.shields.io/github/license/comarkdown/comark?color=black)](https://github.com/comarkdown/comark/blob/main/LICENSE)
+
+Svelte renderer for [Comark](https://comark.dev) — render markdown with custom Svelte components, streaming support, and SvelteKit SSR.
+
+## Features
+
+- 🧩 `<Comark>` component for one-shot markdown rendering
+- 🎯 Map any Comark tag to a custom Svelte component
+- 🌊 Streaming-friendly with auto-close and caret support
+- 🖥️ SSR-safe, works in SvelteKit
+- 🔌 Plugin ecosystem (math, mermaid, highlight, binding…)
+- 🎯 Full TypeScript support
+
+## Installation
+
+```bash
+npm install @comark/svelte
+# or
+pnpm add @comark/svelte
+```
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { Comark } from '@comark/svelte'
+  import math, { Math } from '@comark/svelte/plugins/math'
+
+  const content = `# Hello\n\nThis is **Comark** in Svelte.`
+</script>
+
+<Comark markdown={content} components={{ math: Math }} plugins={[math()]} />
+```
+
+### Custom components
+
+```svelte
+<script lang="ts">
+  import { Comark } from '@comark/svelte'
+  import Alert from './Alert.svelte'
+</script>
+
+<Comark markdown={content} components={{ alert: Alert }} />
+```
+
+```mdc
+::alert{type="warning"}
+Heads up!
+::
+```
+
+### Streaming
+
+```svelte
+<Comark markdown={content} streaming={isStreaming} caret />
+```
+
+## Documentation
+
+Full guide and API reference at [comark.dev/rendering/svelte](https://comark.dev/rendering/svelte).
+
+## License
+
+Made with ❤️
+
+Published under [MIT License](https://github.com/comarkdown/comark/blob/main/LICENSE).

--- a/packages/comark-vue/README.md
+++ b/packages/comark-vue/README.md
@@ -1,0 +1,104 @@
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+
+# @comark/vue
+
+[![npm version](https://img.shields.io/npm/v/@comark/vue?color=black)](https://npmx.dev/@comark/vue)
+[![npm downloads](https://img.shields.io/npm/dm/@comark/vue?color=black)](https://npm.chart.dev/@comark/vue)
+[![CI](https://img.shields.io/github/actions/workflow/status/comarkdown/comark/ci.yml?branch=main&color=black)](https://github.com/comarkdown/comark/actions/workflows/ci.yml)
+[![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://comark.dev/rendering/vue)
+[![license](https://img.shields.io/github/license/comarkdown/comark?color=black)](https://github.com/comarkdown/comark/blob/main/LICENSE)
+
+Vue renderer for [Comark](https://comark.dev) — render markdown with custom Vue components, streaming support, and SSR.
+
+## Features
+
+- 🧩 `<Comark>` component for one-shot markdown rendering
+- 🎯 Map any Comark tag to a custom Vue component
+- 🌊 Streaming-friendly with auto-close and caret support
+- 🖥️ SSR-safe, works in Nuxt and Vite
+- 🎨 Optional Vite plugin for compile-time component resolution
+- 🔌 Plugin ecosystem (math, mermaid, highlight, binding…)
+
+## Installation
+
+```bash
+npm install @comark/vue
+# or
+pnpm add @comark/vue
+```
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { Comark } from '@comark/vue'
+import math, { Math } from '@comark/vue/plugins/math'
+
+const content = `# Hello\n\nThis is **Comark** in Vue.`
+</script>
+
+<template>
+  <Comark :components="{ math: Math }" :plugins="[math()]">
+    {{ content }}
+  </Comark>
+</template>
+```
+
+### Custom components
+
+```vue
+<script setup lang="ts">
+import { Comark } from '@comark/vue'
+import Alert from './components/Alert.vue'
+</script>
+
+<template>
+  <Comark :components="{ alert: Alert }">{{ content }}</Comark>
+</template>
+```
+
+```mdc
+::alert{type="warning"}
+Heads up!
+::
+```
+
+### Streaming
+
+```vue
+<Comark :streaming="isStreaming" caret>{{ content }}</Comark>
+```
+
+## Using with Vite
+
+`@comark/vue` ships an optional Vite plugin that:
+
+- Enables `<slot unwrap="...">` inside custom markdown components.
+- Auto-registers every `.vue` file under `src/components/prose` (or `components/prose`) as a global component.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import comark from '@comark/vue/vite'
+
+export default defineConfig({
+  plugins: [vue(), comark()],
+})
+```
+
+Pass `comark({ prose: false })` to opt out of the auto-registered prose components.
+
+## Using with Nuxt
+
+For Nuxt, use [`@comark/nuxt`](https://comark.dev/rendering/nuxt) which auto-imports the `<Comark>` component and wires up `~/components/prose` overrides.
+
+## Documentation
+
+Full guide and API reference at [comark.dev/rendering/vue](https://comark.dev/rendering/vue).
+
+## License
+
+Made with ❤️
+
+Published under [MIT License](https://github.com/comarkdown/comark/blob/main/LICENSE).


### PR DESCRIPTION
Adds a top-level README to each `@comark/*` package (ansi, html, nuxt, react, svelte, vue)