### PR TITLE
docs: block attributes syntax guide

### DIFF
--- a/docs/content/2.syntax/3.attributes.md
+++ b/docs/content/2.syntax/3.attributes.md
@@ -186,7 +186,175 @@ Span syntax supports nested markdown formatting:
 ```
 ::
 
-::callout{color="info" icon="i-lucide-info"}
-Spans work within any paragraph or inline context, and support all standard HTML attributes. For block-level customization, use [Components](/syntax/components) instead.
+## Block Attributes
+
+A trailing `{...}` on the last line of a block-level element attaches the attributes to that block. This works on paragraphs, headings, list items (bullet, ordered, and task list), and blockquote paragraphs.
+
+### Paragraph
+
+::code-group
+```mdc [Syntax]
+A paragraph {attr="value"}
+```
+
+```html [Output]
+<p attr="value">A paragraph</p>
+```
 ::
 
+### Headings
+
+`{...}` after a heading attaches to that heading (alongside its auto-generated id):
+
+::code-group
+```mdc [Syntax]
+# Heading 1 {.intro data-section="hero"}
+
+## Heading 2 {attr="value"}
+```
+
+```html [Output]
+<h1 id="heading-1" class="intro" data-section="hero">Heading 1</h1>
+<h2 id="heading-2" attr="value">Heading 2</h2>
+```
+::
+
+### List items
+
+Bullet, ordered, and task-list items all accept trailing attributes:
+
+::code-group
+```mdc [Syntax]
+- a list item {attr="value"}
+- another list item {attr2="value2"}
+
+1. List item {attr="value"}
+2. List item {attr2="value2"}
+
+- [ ] Task list item {attr="value"}
+- [x] Task list item {attr2="value2"}
+```
+
+```html [Output]
+<ul>
+  <li attr="value">a list item</li>
+  <li attr2="value2">another list item</li>
+</ul>
+<ol>
+  <li attr="value">List item</li>
+  <li attr2="value2">List item</li>
+</ol>
+<ul class="contains-task-list">
+  <li class="task-list-item" attr="value"><input ... /> Task list item</li>
+  <li class="task-list-item" attr2="value2"><input ... /> Task list item</li>
+</ul>
+```
+::
+
+### Blockquote
+
+A single-line blockquote attaches the attributes to the blockquote element:
+
+::code-group
+```mdc [Syntax]
+> Blockquote {attr="value"}
+```
+
+```html [Output]
+<blockquote attr="value">Blockquote</blockquote>
+```
+::
+
+When a blockquote has multiple paragraphs, each paragraph's trailing `{...}` attaches to that paragraph:
+
+::code-group
+```mdc [Syntax]
+> Blockquote paragraph 1 {attr="value"}
+>
+> Blockquote paragraph 2 {attr2="value2"}
+```
+
+```html [Output]
+<blockquote>
+  <p attr="value">Blockquote paragraph 1</p>
+  <p attr2="value2">Blockquote paragraph 2</p>
+</blockquote>
+```
+::
+
+### Span vs paragraph
+
+Whether the attributes attach to a span or to the surrounding paragraph depends on whether there is a space between the closing `]` and `{`:
+
+::code-group
+```mdc [Syntax]
+A paragraph [span] {attr="value"}
+
+A paragraph [span]{attr="value"}
+```
+
+```html [Output]
+<p attr="value">A paragraph <span>span</span></p>
+<p>A paragraph <span attr="value">span</span></p>
+```
+::
+
+### Wrapping a list, table, blockquote, or code block
+
+For attributes that don't have a natural slot in the native syntax (lists, tables, multi-paragraph blockquotes, and fenced code blocks), use the matching `::tag` block component. When a `::ul`, `::ol`, `::table`, `::blockquote`, or `::pre` wraps a single same-tagged child, Comark folds them into one element — the wrapper's attributes land on the actual list/table/blockquote/pre.
+
+::code-group
+~~~mdc [Syntax]
+::ul{attr="value"}
+- item 1
+- item 2
+::
+
+::ol{attr="value"}
+1. item 1
+2. item 2
+::
+
+::table{attr="value"}
+| col1 | col2 |
+| ---- | ---- |
+| a    | b    |
+::
+
+::blockquote{attr="value"}
+> Paragraph 1
+>
+> Paragraph 2
+::
+
+::pre{attr="value"}
+```ts
+const variable = "value"
+```
+::
+~~~
+
+```html [Output]
+<ul attr="value">
+  <li>item 1</li>
+  <li>item 2</li>
+</ul>
+<ol attr="value">
+  <li>item 1</li>
+  <li>item 2</li>
+</ol>
+<table attr="value">
+  <thead><tr><th>col1</th><th>col2</th></tr></thead>
+  <tbody><tr><td>a</td><td>b</td></tr></tbody>
+</table>
+<blockquote attr="value">
+  <p>Paragraph 1</p>
+  <p>Paragraph 2</p>
+</blockquote>
+<pre language="ts" attr="value"><code class="language-ts">const variable = "value"</code></pre>
+```
+::
+
+::callout{color="info" icon="i-lucide-info"}
+Block attributes work on the standard Markdown elements above. For larger custom block content, use [Components](/syntax/components) instead.
+::


### PR DESCRIPTION
Adds documentation for the new block-level attribute syntax — paragraphs, headings, list items, blockquotes, code blocks, and the `::tag{attr}` wrapper form for lists/tables.