### PR TITLE
chore: add sideEffects false to all packages, move katex CSS import to consumer

### DIFF
--- a/docs/content/3.rendering/3.vue.md
+++ b/docs/content/3.rendering/3.vue.md
@@ -155,6 +155,7 @@ For math and mermaid plugins, also pass the companion components:
 import { Comark } from '@comark/vue'
 import math, { Math } from '@comark/vue/plugins/math'
 import mermaid, { Mermaid } from '@comark/vue/plugins/mermaid'
+import 'katex/dist/katex.min.css'
 </script>
 
 <template>

--- a/docs/content/3.rendering/4.nuxt.md
+++ b/docs/content/3.rendering/4.nuxt.md
@@ -145,6 +145,7 @@ For math and mermaid plugins, also pass the companion components:
 <script setup lang="ts">
 import math, { Math } from '@comark/vue/plugins/math'
 import mermaid, { Mermaid } from '@comark/vue/plugins/mermaid'
+import 'katex/dist/katex.min.css'
 </script>
 
 <template>

--- a/docs/content/3.rendering/5.react.md
+++ b/docs/content/3.rendering/5.react.md
@@ -130,6 +130,7 @@ For math and mermaid plugins, also pass the companion components:
 import { Comark } from '@comark/react'
 import math, { Math } from '@comark/react/plugins/math'
 import mermaid, { Mermaid } from '@comark/react/plugins/mermaid'
+import 'katex/dist/katex.min.css'
 
 export default function App() {
   return (

--- a/docs/content/3.rendering/6.svelte.md
+++ b/docs/content/3.rendering/6.svelte.md
@@ -109,6 +109,7 @@ For math and mermaid plugins, also pass the companion components:
   import { Comark } from '@comark/svelte'
   import math, { Math } from '@comark/svelte/plugins/math'
   import mermaid, { Mermaid } from '@comark/svelte/plugins/mermaid'
+  import 'katex/dist/katex.min.css'
 </script>
 
 <Comark

--- a/docs/content/4.plugins/1.built-in/math.md
+++ b/docs/content/4.plugins/1.built-in/math.md
@@ -26,6 +26,12 @@ The `comark/plugins/math` plugin renders LaTeX math formulas using [KaTeX](https
 npm install katex
 ```
 
+KaTeX requires its stylesheet to render correctly. Import it once in your app entry point:
+
+```ts
+import 'katex/dist/katex.min.css'
+```
+
 ## Usage
 
 ```typescript

--- a/examples/3.plugins/vue-vite-math/src/App.vue
+++ b/examples/3.plugins/vue-vite-math/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Comark } from '@comark/vue'
 import math, { Math } from '@comark/vue/plugins/math'
+import 'katex/dist/katex.min.css'
 
 const markdown = `
 # Math Formula Examples

--- a/packages/comark-ansi/package.json
+++ b/packages/comark-ansi/package.json
@@ -24,6 +24,7 @@
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/comark-html/package.json
+++ b/packages/comark-html/package.json
@@ -23,6 +23,7 @@
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/comark-nuxt/package.json
+++ b/packages/comark-nuxt/package.json
@@ -24,6 +24,7 @@
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/module.js",
   "module": "./dist/module.js",
   "types": "./dist/module.d.ts",

--- a/packages/comark-react/package.json
+++ b/packages/comark-react/package.json
@@ -22,6 +22,7 @@
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/comark-react/src/components/Math.tsx
+++ b/packages/comark-react/src/components/Math.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 import katex from 'katex'
-import 'katex/dist/katex.min.css'
 
 export interface MathProps {
   content: string

--- a/packages/comark-svelte/package.json
+++ b/packages/comark-svelte/package.json
@@ -25,6 +25,7 @@
     "!dist/**/*.spec.*"
   ],
   "type": "module",
+  "sideEffects": false,
   "types": "./dist/index.d.ts",
   "svelte": "./dist/index.js",
   "exports": {

--- a/packages/comark-svelte/src/components/Math.svelte
+++ b/packages/comark-svelte/src/components/Math.svelte
@@ -17,7 +17,6 @@ determines inline vs display mode (display when class does NOT contain "inline")
 -->
 <script lang="ts">
   import katex from 'katex'
-  import 'katex/dist/katex.min.css'
 
   let {
     content,

--- a/packages/comark-vue/package.json
+++ b/packages/comark-vue/package.json
@@ -22,6 +22,7 @@
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/comark-vue/src/components/Math.ts
+++ b/packages/comark-vue/src/components/Math.ts
@@ -1,6 +1,5 @@
 import { defineComponent, h, computed, watch, ref } from 'vue'
 import katex from 'katex'
-import 'katex/dist/katex.min.css'
 
 export const Math = defineComponent({
   name: 'Math',

--- a/packages/comark/package.json
+++ b/packages/comark/package.json
@@ -25,6 +25,7 @@
     "skills"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Adds `"sideEffects": false` to all seven packages so bundlers can tree-shake unused exports.

The React, Vue, and Svelte Math components previously imported `katex/dist/katex.min.css` at module level, which blocked this and caused issues in SSR environments. That import has been removed — consumers should now add it once in their project.