### PR TITLE
ci: check package bundle size on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       - run: pnpm dev:prepare
       - run: pnpm lint
       - run: pnpm prepack
+      - name: Check package bundle size
+        run: pnpm vitest run bundle
       - run: pnpm test
 
       - name: Publish

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "scule": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "unified": "catalog:"
+    "unified": "catalog:",
+    "vitest": "catalog:"
   },
   "resolutions": {
     "@comark/ansi": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,9 @@ importers:
       unified:
         specifier: 'catalog:'
         version: 11.0.5
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   docs:
     dependencies:
@@ -413,7 +416,7 @@ importers:
         version: link:../packages/comark
       docus:
         specifier: 'catalog:'
-        version: 5.11.0(74ee29d33d657417505a312867d0c688)
+        version: 5.11.0(0da8f29d2c1b30f3236603fb4435c54f)
       markdown-it-math:
         specifier: 'catalog:'
         version: 5.2.1
@@ -15446,7 +15449,7 @@ snapshots:
 
   diff@8.0.4: {}
 
-  docus@5.11.0(74ee29d33d657417505a312867d0c688):
+  docus@5.11.0(0da8f29d2c1b30f3236603fb4435c54f):
     dependencies:
       '@ai-sdk/gateway': 3.0.121(zod@4.4.3)
       '@ai-sdk/mcp': 1.0.45(zod@4.4.3)
@@ -15476,7 +15479,7 @@ snapshots:
       motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.35(typescript@5.9.3)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.35(typescript@5.9.3))
       nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.67.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.0))(rollup@4.61.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0)
       nuxt-llms: 0.2.0(magicast@0.5.3)
-      nuxt-og-image: 6.5.1(0fc0fff6a943e2791372df63d8031ef0)
+      nuxt-og-image: 6.5.1(d5ad580cd7f01f25d491e841976a4640)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -17535,112 +17538,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(srvx@0.11.16):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@rollup/plugin-alias': 6.0.0(rollup@4.61.0)
-      '@rollup/plugin-commonjs': 29.0.3(rollup@4.61.0)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.61.0)
-      '@rollup/plugin-json': 6.1.0(rollup@4.61.0)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.61.0)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.61.0)
-      '@rollup/plugin-terser': 1.0.0(rollup@4.61.0)
-      '@vercel/nft': 1.10.2(rollup@4.61.0)
-      archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.3)
-      chokidar: 5.0.0
-      citty: 0.2.2
-      compatx: 0.2.0
-      confbox: 0.2.4
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      croner: 10.0.1
-      crossws: 0.3.5
-      db0: 0.3.4(better-sqlite3@12.10.0)
-      defu: 6.1.7
-      destr: 2.0.5
-      dot-prop: 10.1.0
-      esbuild: 0.28.0
-      escape-string-regexp: 5.0.0
-      etag: 1.8.1
-      exsolve: 1.0.8
-      globby: 16.2.0
-      gzip-size: 7.0.0
-      h3: 1.15.11
-      hookable: 5.5.3
-      httpxy: 0.5.3
-      ioredis: 5.11.0
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      listhen: 1.10.0(srvx@0.11.16)
-      magic-string: 0.30.21
-      magicast: 0.5.3
-      mime: 4.1.0
-      mlly: 1.8.2
-      node-fetch-native: 1.6.7
-      node-mock-http: 1.0.4
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.1
-      pretty-bytes: 7.1.0
-      radix3: 1.1.2
-      rollup: 4.61.0
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.3)(rollup@4.61.0)
-      scule: 1.3.0
-      semver: 7.8.1
-      serve-placeholder: 2.0.2
-      serve-static: 2.2.1
-      source-map: 0.7.6
-      std-env: 4.1.0
-      ufo: 1.6.4
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unenv: 2.0.0-rc.24
-      unimport: 6.3.0(oxc-parser@0.128.0)(rolldown@1.0.3)
-      unplugin-utils: 0.3.1
-      unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.11.0)
-      untyped: 2.0.0
-      unwasm: 0.5.3
-      youch: 4.1.1
-      youch-core: 0.3.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - srvx
-      - supports-color
-      - uploadthing
-    optional: true
-
   nitropack@2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.131.0)(rolldown@1.0.3)(srvx@0.11.16):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
@@ -17746,6 +17643,112 @@ snapshots:
       - supports-color
       - uploadthing
 
+  nitropack@2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.132.0)(rolldown@1.0.3)(srvx@0.11.16):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@rollup/plugin-alias': 6.0.0(rollup@4.61.0)
+      '@rollup/plugin-commonjs': 29.0.3(rollup@4.61.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.61.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.61.0)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.61.0)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.61.0)
+      '@rollup/plugin-terser': 1.0.0(rollup@4.61.0)
+      '@vercel/nft': 1.10.2(rollup@4.61.0)
+      archiver: 7.0.1
+      c12: 3.3.4(magicast@0.5.3)
+      chokidar: 5.0.0
+      citty: 0.2.2
+      compatx: 0.2.0
+      confbox: 0.2.4
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      croner: 10.0.1
+      crossws: 0.3.5
+      db0: 0.3.4(better-sqlite3@12.10.0)
+      defu: 6.1.7
+      destr: 2.0.5
+      dot-prop: 10.1.0
+      esbuild: 0.28.0
+      escape-string-regexp: 5.0.0
+      etag: 1.8.1
+      exsolve: 1.0.8
+      globby: 16.2.0
+      gzip-size: 7.0.0
+      h3: 1.15.11
+      hookable: 5.5.3
+      httpxy: 0.5.3
+      ioredis: 5.11.0
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      listhen: 1.10.0(srvx@0.11.16)
+      magic-string: 0.30.21
+      magicast: 0.5.3
+      mime: 4.1.0
+      mlly: 1.8.2
+      node-fetch-native: 1.6.7
+      node-mock-http: 1.0.4
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      pretty-bytes: 7.1.0
+      radix3: 1.1.2
+      rollup: 4.61.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.3)(rollup@4.61.0)
+      scule: 1.3.0
+      semver: 7.8.1
+      serve-placeholder: 2.0.2
+      serve-static: 2.2.1
+      source-map: 0.7.6
+      std-env: 4.1.0
+      ufo: 1.6.4
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unenv: 2.0.0-rc.24
+      unimport: 6.3.0(oxc-parser@0.132.0)(rolldown@1.0.3)
+      unplugin-utils: 0.3.1
+      unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.11.0)
+      untyped: 2.0.0
+      unwasm: 0.5.3
+      youch: 4.1.1
+      youch-core: 0.3.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - srvx
+      - supports-color
+      - uploadthing
+    optional: true
+
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -17823,7 +17826,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.5.1(0fc0fff6a943e2791372df63d8031ef0):
+  nuxt-og-image@6.5.1(d5ad580cd7f01f25d491e841976a4640):
     dependencies:
       '@clack/prompts': 1.5.0
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -17863,7 +17866,7 @@ snapshots:
     optionalDependencies:
       '@takumi-rs/core': 1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fontless: 0.2.1(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.11.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      nitropack: 2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.128.0)(rolldown@1.0.3)(srvx@0.11.16)
+      nitropack: 2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.132.0)(rolldown@1.0.3)(srvx@0.11.16)
       playwright-core: 1.60.0
       satori: 0.26.0
       sharp: 0.34.5
@@ -20022,27 +20025,6 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
 
-  unimport@6.3.0(oxc-parser@0.128.0)(rolldown@1.0.3):
-    dependencies:
-      acorn: 8.16.0
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      pkg-types: 2.3.1
-      scule: 1.3.0
-      strip-literal: 3.1.0
-      tinyglobby: 0.2.17
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      oxc-parser: 0.128.0
-      rolldown: 1.0.3
-    optional: true
-
   unimport@6.3.0(oxc-parser@0.131.0)(rolldown@1.0.3):
     dependencies:
       acorn: 8.16.0
@@ -20062,6 +20044,27 @@ snapshots:
     optionalDependencies:
       oxc-parser: 0.131.0
       rolldown: 1.0.3
+
+  unimport@6.3.0(oxc-parser@0.132.0)(rolldown@1.0.3):
+    dependencies:
+      acorn: 8.16.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      pkg-types: 2.3.1
+      scule: 1.3.0
+      strip-literal: 3.1.0
+      tinyglobby: 0.2.17
+      unplugin: 3.0.0
+      unplugin-utils: 0.3.1
+    optionalDependencies:
+      oxc-parser: 0.132.0
+      rolldown: 1.0.3
+    optional: true
 
   unist-builder@4.0.0:
     dependencies:

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -70,13 +70,13 @@ describe.skipIf(stubbed || process.env.SKIP_BUNDLE_SIZE === 'true')('package bun
 
     expect(report).toMatchInlineSnapshot(`
       {
-        "@comark/ansi": "37.4k (132 files)",
+        "@comark/ansi": "34.3k (82 files)",
         "@comark/html": "16.2k (42 files)",
-        "@comark/nuxt": "10.2k (44 files)",
-        "@comark/react": "37.0k (58 files)",
+        "@comark/nuxt": "10.1k (42 files)",
+        "@comark/react": "36.9k (56 files)",
         "@comark/svelte": "39.0k (66 files)",
-        "@comark/vue": "54.6k (64 files)",
-        "comark": "405k (172 files)",
+        "@comark/vue": "54.5k (62 files)",
+        "comark": "344k (132 files)",
       }
     `)
   })

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -1,0 +1,91 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const packagesDir = fileURLToPath(new URL('../packages', import.meta.url))
+
+interface Package {
+  name: string
+  dir: string
+  main: string
+}
+
+// Discover every publishable workspace package (has a name, not private).
+const packages: Package[] = readdirSync(packagesDir)
+  .map((name) => join(packagesDir, name))
+  .filter((dir) => existsSync(join(dir, 'package.json')))
+  .map((dir) => {
+    const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'))
+    return { name: pkg.name, dir, main: pkg.main ?? 'dist/index.js', private: !!pkg.private }
+  })
+  .filter((pkg): pkg is Package & { private: boolean } => Boolean(pkg.name) && !pkg.private)
+  .sort((a, b) => a.name.localeCompare(b.name))
+
+// `postinstall` runs `pnpm stub`, which fills `dist/` with files that just
+// re-export from `src/`. Bundle sizes are only meaningful after a real build
+// (`pnpm prepack`), so skip when we detect the dev stubs.
+function isStubbed(pkg: Package): boolean {
+  const entry = join(pkg.dir, pkg.main)
+  if (!existsSync(entry)) return true
+  return readFileSync(entry, 'utf-8').includes('/src/')
+}
+
+const stubbed = packages.some(isStubbed)
+
+// `npm pack --dry-run --json` reports exactly what would be published (honouring
+// the `files` field and `.npmignore`), so we measure the real shipped size.
+// Memoised because spawning `npm pack` is slow (~3s) and both tests reuse it.
+const packCache = new Map<string, { size: number; unpackedSize: number; entryCount: number }>()
+function pack(pkg: Package) {
+  let report = packCache.get(pkg.name)
+  if (!report) {
+    ;[report] = JSON.parse(
+      execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+        cwd: pkg.dir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+    )
+    packCache.set(pkg.name, report!)
+  }
+  return report!
+}
+
+function roundToKilobytes(bytes: number): string {
+  return (bytes / 1024).toFixed(bytes > 100 * 1024 ? 0 : 1) + 'k'
+}
+
+describe.skipIf(stubbed || process.env.SKIP_BUNDLE_SIZE === 'true')('package bundle size', { timeout: 60_000 }, () => {
+  // The unpacked size (raw bytes) is fully deterministic, so it is what we snapshot.
+  // A PR that changes the published output of any package must update this snapshot,
+  // surfacing the size diff in review.
+  it('published size of each package', () => {
+    const report: Record<string, string> = {}
+    for (const pkg of packages) {
+      const { unpackedSize, entryCount } = pack(pkg)
+      report[pkg.name] = `${roundToKilobytes(unpackedSize)} (${entryCount} files)`
+    }
+
+    expect(report).toMatchInlineSnapshot(`
+      {
+        "@comark/ansi": "37.4k (132 files)",
+        "@comark/html": "16.2k (42 files)",
+        "@comark/nuxt": "10.2k (44 files)",
+        "@comark/react": "37.0k (58 files)",
+        "@comark/svelte": "39.0k (66 files)",
+        "@comark/vue": "54.6k (64 files)",
+        "comark": "405k (172 files)",
+      }
+    `)
+  })
+
+  // Guards against a broken `prepack` shipping an empty or stub-only package.
+  it('every package ships a built dist', () => {
+    for (const pkg of packages) {
+      const { entryCount } = pack(pkg)
+      expect(entryCount, `${pkg.name} has no published files`).toBeGreaterThan(0)
+    }
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+// Root-level test suite (currently just the bundle-size check).
+// Scoped to `test/` so it does not pick up the per-package test files.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['test/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
Adds a vitest suite (`test/bundle.test.ts`) that measures the published `npm pack` size of every package in `packages/` and snapshots it. Runs in CI after `prepack`, so any change to a package's shipped output fails the snapshot and surfaces the size diff in review.

Skips automatically when `dist/` is stubbed (or via `SKIP_BUNDLE_SIZE=true`).