### PR TITLE
fix(highlight): stop injecting `tabindex="0"` on pre blocks

### DIFF
--- a/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
@@ -30,8 +30,7 @@ const variable = "value"
         "language": "ts",
         "attr": "value",
         "class": "shiki shiki-themes min-light nord dark:nord . class",
-        "style": "background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9",
-        "tabindex": "0"
+        "style": "background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"
       },
       [
         "code",
@@ -96,7 +95,7 @@ const variable = "value"
 ## HTML
 
 ```html
-<pre language="ts" attr="value" class="shiki shiki-themes min-light nord dark:nord . class" tabindex="0" style="background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"><code class="language-ts"><span class="line" style="display: inline"><span style="color:#D32F2F;--shiki-dark:#81A1C1">const</span><span style="color:#1976D2;--shiki-dark:#D8DEE9"> variable</span><span style="color:#D32F2F;--shiki-dark:#81A1C1"> =</span><span style="color:#22863A;--shiki-dark:#ECEFF4"> "</span><span style="color:#22863A;--shiki-dark:#A3BE8C">value</span><span style="color:#22863A;--shiki-dark:#ECEFF4">"</span></span></code></pre>
+<pre language="ts" attr="value" class="shiki shiki-themes min-light nord dark:nord . class" style="background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"><code class="language-ts"><span class="line" style="display: inline"><span style="color:#D32F2F;--shiki-dark:#81A1C1">const</span><span style="color:#1976D2;--shiki-dark:#D8DEE9"> variable</span><span style="color:#D32F2F;--shiki-dark:#81A1C1"> =</span><span style="color:#22863A;--shiki-dark:#ECEFF4"> "</span><span style="color:#22863A;--shiki-dark:#A3BE8C">value</span><span style="color:#22863A;--shiki-dark:#ECEFF4">"</span></span></code></pre>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-dual-theme.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-dual-theme.md
@@ -32,7 +32,6 @@ console.log(greeting)
       {
         "language": "typescript",
         "class": "shiki shiki-themes min-light nord dark:nord",
-        "tabindex": "0",
         "style": "background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"
       },
       [
@@ -162,7 +161,7 @@ console.log(greeting)
 ## HTML
 
 ```html
-<pre language="typescript" class="shiki shiki-themes min-light nord dark:nord" tabindex="0" style="background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"><code class="language-typescript"><span class="line" style="display: inline"><span style="color:#D32F2F;--shiki-dark:#81A1C1">const</span><span style="color:#1976D2;--shiki-dark:#D8DEE9"> greeting</span><span style="color:#D32F2F;--shiki-dark:#81A1C1">:</span><span style="color:#1976D2;--shiki-dark:#8FBCBB"> string</span><span style="color:#D32F2F;--shiki-dark:#81A1C1"> =</span><span style="color:#22863A;--shiki-dark:#ECEFF4"> "</span><span style="color:#22863A;--shiki-dark:#A3BE8C">Hello, World!</span><span style="color:#22863A;--shiki-dark:#ECEFF4">"</span></span>
+<pre language="typescript" class="shiki shiki-themes min-light nord dark:nord" style="background-color:#ffffff;color:#212121;--shiki-dark-bg:#2e3440;--shiki-dark:#d8dee9"><code class="language-typescript"><span class="line" style="display: inline"><span style="color:#D32F2F;--shiki-dark:#81A1C1">const</span><span style="color:#1976D2;--shiki-dark:#D8DEE9"> greeting</span><span style="color:#D32F2F;--shiki-dark:#81A1C1">:</span><span style="color:#1976D2;--shiki-dark:#8FBCBB"> string</span><span style="color:#D32F2F;--shiki-dark:#81A1C1"> =</span><span style="color:#22863A;--shiki-dark:#ECEFF4"> "</span><span style="color:#22863A;--shiki-dark:#A3BE8C">Hello, World!</span><span style="color:#22863A;--shiki-dark:#ECEFF4">"</span></span>
 <span class="line" style="display: inline"><span style="color:#1976D2;--shiki-dark:#D8DEE9">console</span><span style="color:#6F42C1;--shiki-dark:#ECEFF4">.</span><span style="color:#6F42C1;--shiki-dark:#88C0D0">log</span><span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">(</span><span style="color:#24292EFF;--shiki-dark:#D8DEE9">greeting</span><span style="color:#24292EFF;--shiki-dark:#D8DEE9FF">)</span></span></code></pre>
 ```
 

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-highlight-complex.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-highlight-complex.md
@@ -48,7 +48,6 @@ func main() {
           10
         ],
         "class": "shiki shiki-themes github-dark dark:github-dark",
-        "tabindex": "0",
         "style": "background-color:#24292e;color:#e1e4e8"
       },
       [
@@ -397,7 +396,7 @@ func main() {
 ## HTML
 
 ```html
-<pre language="go" highlights="[1,3,5,6,7,10]" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-go"><span class="line highlight" style="display: inline-block"><span style="color:#F97583">package</span><span style="color:#B392F0"> main</span></span>
+<pre language="go" highlights="[1,3,5,6,7,10]" class="shiki shiki-themes github-dark dark:github-dark" style="background-color:#24292e;color:#e1e4e8"><code class="language-go"><span class="line highlight" style="display: inline-block"><span style="color:#F97583">package</span><span style="color:#B392F0"> main</span></span>
 <span class="line" style="display: inline"></span>
 <span class="line highlight" style="display: inline-block"><span style="color:#F97583">import</span><span style="color:#9ECBFF"> "</span><span style="color:#B392F0">fmt</span><span style="color:#9ECBFF">"</span></span>
 <span class="line" style="display: inline"></span>

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-language-meta.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-language-meta.md
@@ -37,7 +37,6 @@ console.log(greeting)
         ],
         "meta": "some meta",
         "class": "shiki shiki-themes github-dark dark:github-dark",
-        "tabindex": "0",
         "style": "background-color:#24292e;color:#e1e4e8"
       },
       [
@@ -132,7 +131,7 @@ console.log(greeting)
 ## HTML
 
 ```html
-<pre language="typescript" filename="filename" highlights="[1,2]" meta="some meta" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-typescript"><span class="line highlight" style="display: inline-block"><span style="color:#F97583">const</span><span style="color:#79B8FF"> greeting</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "Hello, World!"</span></span>
+<pre language="typescript" filename="filename" highlights="[1,2]" meta="some meta" class="shiki shiki-themes github-dark dark:github-dark" style="background-color:#24292e;color:#e1e4e8"><code class="language-typescript"><span class="line highlight" style="display: inline-block"><span style="color:#F97583">const</span><span style="color:#79B8FF"> greeting</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "Hello, World!"</span></span>
 <span class="line highlight" style="display: inline-block"><span style="color:#E1E4E8">console.</span><span style="color:#B392F0">log</span><span style="color:#E1E4E8">(greeting)</span></span></code></pre>
 ```
 

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-language-only.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-language-only.md
@@ -29,8 +29,7 @@ console.log(greeting)
       "pre",
       {
         "language": "typescript",
-        "class": "shiki shiki-themes github-dark dark:github-dark",
-        "tabindex": "0"
+        "class": "shiki shiki-themes github-dark dark:github-dark"
       },
       [
         "code",
@@ -124,7 +123,7 @@ console.log(greeting)
 ## HTML
 
 ```html
-<pre language="typescript" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0"><code class="language-typescript"><span class="line" style="display: inline"><span style="color:#F97583">const</span><span style="color:#79B8FF"> greeting</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "Hello, World!"</span></span>
+<pre language="typescript" class="shiki shiki-themes github-dark dark:github-dark"><code class="language-typescript"><span class="line" style="display: inline"><span style="color:#F97583">const</span><span style="color:#79B8FF"> greeting</span><span style="color:#F97583">:</span><span style="color:#79B8FF"> string</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> "Hello, World!"</span></span>
 <span class="line" style="display: inline"><span style="color:#E1E4E8">console.</span><span style="color:#B392F0">log</span><span style="color:#E1E4E8">(greeting)</span></span></code></pre>
 ```
 

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-no-language.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-no-language.md
@@ -30,7 +30,6 @@ No language specified
       "pre",
       {
         "class": "shiki shiki-themes github-dark dark:github-dark",
-        "tabindex": "0",
         "style": "background-color:#24292e;color:#e1e4e8"
       },
       [
@@ -70,7 +69,7 @@ No language specified
 ## HTML
 
 ```html
-<pre class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code><span class="line" style="display: inline"><span>Plain text code block</span></span>
+<pre class="shiki shiki-themes github-dark dark:github-dark" style="background-color:#24292e;color:#e1e4e8"><code><span class="line" style="display: inline"><span>Plain text code block</span></span>
 <span class="line" style="display: inline"><span>No language specified</span></span></code></pre>
 ```
 

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-rust-example.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-rust-example.md
@@ -41,7 +41,6 @@ fn main() {
           4
         ],
         "class": "shiki shiki-themes github-dark dark:github-dark",
-        "tabindex": "0",
         "style": "background-color:#24292e;color:#e1e4e8"
       },
       [
@@ -237,7 +236,7 @@ fn main() {
 ## HTML
 
 ```html
-<pre language="rust" filename="main.rs" highlights="[1,2,3,4]" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-rust"><span class="line highlight" style="display: inline-block"><span style="color:#F97583">fn</span><span style="color:#B392F0"> main</span><span style="color:#E1E4E8">() {</span></span>
+<pre language="rust" filename="main.rs" highlights="[1,2,3,4]" class="shiki shiki-themes github-dark dark:github-dark" style="background-color:#24292e;color:#e1e4e8"><code class="language-rust"><span class="line highlight" style="display: inline-block"><span style="color:#F97583">fn</span><span style="color:#B392F0"> main</span><span style="color:#E1E4E8">() {</span></span>
 <span class="line highlight" style="display: inline-block"><span style="color:#F97583">    let</span><span style="color:#E1E4E8"> x </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 5</span><span style="color:#E1E4E8">;</span></span>
 <span class="line highlight" style="display: inline-block"><span style="color:#F97583">    let</span><span style="color:#E1E4E8"> y </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 10</span><span style="color:#E1E4E8">;</span></span>
 <span class="line highlight" style="display: inline-block"><span style="color:#B392F0">    println!</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"Sum: {}"</span><span style="color:#E1E4E8">, x </span><span style="color:#F97583">+</span><span style="color:#E1E4E8"> y);</span></span>

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-special-chars.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-special-chars.md
@@ -35,7 +35,6 @@ options:
         "language": "html",
         "filename": "template.html",
         "class": "shiki shiki-themes github-dark dark:github-dark",
-        "tabindex": "0",
         "style": "background-color:#24292e;color:#e1e4e8"
       },
       [
@@ -287,7 +286,7 @@ options:
 ## HTML
 
 ```html
-<pre language="html" filename="template.html" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-html"><span class="line" style="display: inline"><span style="color:#E1E4E8">&lt;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> class</span><span style="color:#E1E4E8">=</span><span style="color:#9ECBFF">"container"</span><span style="color:#E1E4E8">&gt;</span></span>
+<pre language="html" filename="template.html" class="shiki shiki-themes github-dark dark:github-dark" style="background-color:#24292e;color:#e1e4e8"><code class="language-html"><span class="line" style="display: inline"><span style="color:#E1E4E8">&lt;</span><span style="color:#85E89D">div</span><span style="color:#B392F0"> class</span><span style="color:#E1E4E8">=</span><span style="color:#9ECBFF">"container"</span><span style="color:#E1E4E8">&gt;</span></span>
 <span class="line" style="display: inline"><span style="color:#E1E4E8">  &lt;</span><span style="color:#85E89D">h1</span><span style="color:#E1E4E8">&gt;Title & Subtitle&lt;/</span><span style="color:#85E89D">h1</span><span style="color:#E1E4E8">&gt;</span></span>
 <span class="line" style="display: inline"><span style="color:#E1E4E8">  &lt;</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">&gt;Text with "quotes" and 'apostrophes'&lt;/</span><span style="color:#85E89D">p</span><span style="color:#E1E4E8">&gt;</span></span>
 <span class="line" style="display: inline"><span style="color:#E1E4E8">  &lt;</span><span style="color:#85E89D">script</span><span style="color:#E1E4E8">&gt;</span><span style="color:#B392F0">alert</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">'XSS &lt; &gt; test'</span><span style="color:#E1E4E8">);&lt;/</span><span style="color:#85E89D">script</span><span style="color:#E1E4E8">&gt;</span></span>

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-twoslash.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-twoslash.md
@@ -32,8 +32,7 @@ const message = "Hello from twoslash"
       {
         "language": "ts",
         "meta": "twoslash",
-        "class": "shiki shiki-themes min-light twoslash lsp dark:min-light",
-        "tabindex": "0"
+        "class": "shiki shiki-themes min-light twoslash lsp dark:min-light"
       },
       [
         "code",
@@ -151,7 +150,7 @@ const message = "Hello from twoslash"
 ## HTML
 
 ```html
-<pre language="ts" meta="twoslash" class="shiki shiki-themes min-light twoslash lsp dark:min-light" tabindex="0"><code class="language-ts"><span class="line" style="display: inline"><span style="color:#D32F2F">const</span><span style="color:#1976D2"> </span><span style="color:#1976D2"><span class="twoslash-hover twoslash-query-persisted"><span class="twoslash-popup-container"><div class="twoslash-popup-arrow"></div>
+<pre language="ts" meta="twoslash" class="shiki shiki-themes min-light twoslash lsp dark:min-light"><code class="language-ts"><span class="line" style="display: inline"><span style="color:#D32F2F">const</span><span style="color:#1976D2"> </span><span style="color:#1976D2"><span class="twoslash-hover twoslash-query-persisted"><span class="twoslash-popup-container"><div class="twoslash-popup-arrow"></div>
 <code class="twoslash-popup-code"><span style="color:#D32F2F">const</span><span style="color:#1976D2"> message</span><span style="color:#D32F2F">:</span><span style="color:#22863A"> "Hello from twoslash"</span></code></span>message</span></span><span style="color:#D32F2F"> =</span><span style="color:#22863A"> "Hello from twoslash"</span></span>
 <span class="line" style="display: inline"></span></code></pre>
 ```

--- a/packages/comark/SPEC/COMARK/shiki-codeblock-with-empty-lines.md
+++ b/packages/comark/SPEC/COMARK/shiki-codeblock-with-empty-lines.md
@@ -37,7 +37,6 @@ More content here.
         "language": "markdown",
         "filename": "content.md",
         "class": "shiki shiki-themes github-dark dark:github-dark",
-        "tabindex": "0",
         "style": "background-color:#24292e;color:#e1e4e8"
       },
       [
@@ -137,7 +136,7 @@ More content here.
 ## HTML
 
 ```html
-<pre language="markdown" filename="content.md" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0" style="background-color:#24292e;color:#e1e4e8"><code class="language-markdown"><span class="line" style="display: inline"><span style="color:#79B8FF;--shiki-light-font-weight:bold"># My Page Title</span></span>
+<pre language="markdown" filename="content.md" class="shiki shiki-themes github-dark dark:github-dark" style="background-color:#24292e;color:#e1e4e8"><code class="language-markdown"><span class="line" style="display: inline"><span style="color:#79B8FF;--shiki-light-font-weight:bold"># My Page Title</span></span>
 <span class="line" style="display: inline"></span>
 <span class="line" style="display: inline"><span style="color:#E1E4E8">This is the opening paragraph used as the description.</span></span>
 <span class="line" style="display: inline"></span>

--- a/packages/comark/SPEC/COMARK/shiki-ordered-list-nested-codeblock.md
+++ b/packages/comark/SPEC/COMARK/shiki-ordered-list-nested-codeblock.md
@@ -41,8 +41,7 @@ options:
           "pre",
           {
             "language": "rust",
-            "class": "shiki shiki-themes github-dark dark:github-dark",
-            "tabindex": "0"
+            "class": "shiki shiki-themes github-dark dark:github-dark"
           },
           [
             "code",
@@ -105,7 +104,7 @@ options:
 <ol>
   <li>
     <p>Setup:</p>
-    <pre language="rust" class="shiki shiki-themes github-dark dark:github-dark" tabindex="0"><code class="language-rust"><span class="line" style="display: inline"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> x </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 1</span><span style="color:#E1E4E8">;</span></span></code></pre>
+    <pre language="rust" class="shiki shiki-themes github-dark dark:github-dark"><code class="language-rust"><span class="line" style="display: inline"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> x </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> 1</span><span style="color:#E1E4E8">;</span></span></code></pre>
   </li>
 </ol>
 ```

--- a/packages/comark/src/internal/stringify/attributes.ts
+++ b/packages/comark/src/internal/stringify/attributes.ts
@@ -100,11 +100,11 @@ const IMPLICIT_ATTRS: Record<string, { drop?: string[]; classBlocklist?: string[
   ul: { classBlocklist: ['contains-task-list'] },
   li: { classBlocklist: ['task-list-item'] },
   // `language`/`filename`/`highlights`/`meta` ride on the fence info string.
-  // `tabindex`/`style` come from render-time plugins (e.g. shiki) and have no
-  // markdown form. `class` is handled specially in userBlockAttrs because shiki
-  // merges its injected classes with the user's class — we need to strip just
-  // the highlighter portion.
-  pre: { drop: ['language', 'filename', 'highlights', 'meta', 'tabindex', 'style'] },
+  // `style` comes from render-time plugins (e.g. shiki) and has no markdown
+  // form. `class` is handled specially in userBlockAttrs because shiki merges
+  // its injected classes with the user's class — we need to strip just the
+  // highlighter portion.
+  pre: { drop: ['language', 'filename', 'highlights', 'meta', 'style'] },
 }
 
 /**

--- a/packages/comark/src/plugins/highlight.ts
+++ b/packages/comark/src/plugins/highlight.ts
@@ -369,7 +369,6 @@ export async function highlightCodeBlocks(tree: ComarkTree, options: HighlightOp
     const newPreAttrs: Record<string, any> = {
       ...preAttrs,
       class: userClass ? `${classStr} . ${userClass}` : classStr,
-      tabindex: '0',
     }
 
     if (options.preStyles) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- N/A -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The highlight plugin hardcoded `tabindex="0"` on every `<pre>` block, so it leaked into the output of every consumer whether they wanted it or not.

- Removed the `tabindex: '0'` injection in `highlightCodeBlocks` (`packages/comark/src/plugins/highlight.ts`).
- Dropped `tabindex` from the `pre` implicit-drop list in `attributes.ts` so a genuine user-supplied `{tabindex="0"}` now round-trips back to markdown instead of being silently stripped. `style` stays dropped since it's still injected by `preStyles`.
- Updated the 11 shiki SPEC fixtures to match (AST + HTML).

All `pnpm test` pass (1064 tests).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have run `pnpm verify` and it passes.
- [ ] I have updated the documentation accordingly.