### PR TITLE
fix(stringify): render block component children of list items on their own line

### DIFF
--- a/packages/comark/SPEC/COMARK/component-block-in-list-item.md
+++ b/packages/comark/SPEC/COMARK/component-block-in-list-item.md
@@ -1,0 +1,79 @@
+## Input
+
+```md
+- *item one*
+  ::block
+  #body
+  ### Heading
+  ::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ul",
+      {},
+      [
+        "li",
+        {},
+        [
+          "p",
+          {},
+          [
+            "em",
+            {},
+            "item one"
+          ]
+        ],
+        [
+          "block",
+          {},
+          [
+            "template",
+            {
+              "name": "body"
+            },
+            [
+              "h3",
+              {
+                "id": "heading"
+              },
+              "Heading"
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ul>
+  <li>
+    <p><em>item one</em></p>
+    <block>
+      <template name="body">
+        <h3 id="heading">Heading</h3>
+      </template>
+    </block>
+  </li>
+</ul>
+```
+
+## Markdown
+
+```md
+- *item one*
+  ::block
+  #body
+  ### Heading
+  ::
+```

--- a/packages/comark/src/internal/stringify/handlers/li.ts
+++ b/packages/comark/src/internal/stringify/handlers/li.ts
@@ -3,7 +3,8 @@ import type { ComarkElement, ComarkNode } from 'comark'
 import { indent } from '../../../utils/index.ts'
 import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 
-// ol/ul indent themselves via the listIndent context.
+// Block elements that need explicit indentation in list items.
+// Note: ol/ul are handled by their own handlers which manage indentation via listIndent context.
 const blockElements = new Set(['pre', 'blockquote', 'table'])
 
 export async function li(node: ComarkElement, state: State) {
@@ -77,7 +78,7 @@ function escapeLeadingNumberDot(str: string): string {
 
   const len = str.length
   const firstChar = str.charCodeAt(0)
-  if (firstChar < 48 || firstChar > 57) return str
+  if (firstChar < 48 || firstChar > 57) return str // Not a digit
 
   let i = 1
   for (; i < len; i++) {

--- a/packages/comark/src/internal/stringify/handlers/li.ts
+++ b/packages/comark/src/internal/stringify/handlers/li.ts
@@ -3,8 +3,7 @@ import type { ComarkElement, ComarkNode } from 'comark'
 import { indent } from '../../../utils/index.ts'
 import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 
-// Block elements that need explicit indentation in list items.
-// Note: ol/ul are handled by their own handlers which manage indentation via listIndent context.
+// ol/ul indent themselves via the listIndent context.
 const blockElements = new Set(['pre', 'blockquote', 'table'])
 
 export async function li(node: ComarkElement, state: State) {
@@ -26,25 +25,36 @@ export async function li(node: ComarkElement, state: State) {
   }
 
   const prefixWidth = prefix.length
+
+  // Direct text children render sibling components inline.
+  const hasInlineContent = children.some((child) => typeof child === 'string')
+
   let result = ''
 
   for (const child of children) {
-    const rendered = await state.one(child, state, node)
-    if (result && Array.isArray(child)) {
-      if (blockElements.has(child[0] as string)) {
-        // Block-level child: put on its own line and indent to align with list prefix
-        const indented = indent(rendered, { width: prefixWidth })
+    if (Array.isArray(child)) {
+      const tag = child[0] as string
+
+      if (result && blockElements.has(tag)) {
+        const indented = indent(await state.one(child, state, node), { width: prefixWidth })
         result = result.trimEnd() + '\n' + indented.trimEnd() + '\n'
         continue
       }
 
-      if (child[0] === 'p') {
-        const indented = indent(rendered, { width: prefixWidth })
+      if (result && tag === 'p') {
+        const indented = indent(await state.one(child, state, node), { width: prefixWidth })
         result = result.trimEnd() + '\n\n' + indented.trimEnd() + '\n'
         continue
       }
+
+      // No parent → mdc skips its own nesting indentation, so li owns it here.
+      if (!hasInlineContent && !(tag in state.handlers)) {
+        const indented = indent(await state.one(child, state), { width: prefixWidth, ignoreFirstLine: !result })
+        result = result ? result.trimEnd() + '\n' + indented.trimEnd() + '\n' : indented.trimEnd() + '\n'
+        continue
+      }
     }
-    result += rendered
+    result += await state.one(child, state, node)
   }
   result = result.trim()
 
@@ -67,7 +77,7 @@ function escapeLeadingNumberDot(str: string): string {
 
   const len = str.length
   const firstChar = str.charCodeAt(0)
-  if (firstChar < 48 || firstChar > 57) return str // Not a digit
+  if (firstChar < 48 || firstChar > 57) return str
 
   let i = 1
   for (; i < len; i++) {


### PR DESCRIPTION
## Problem

A block component inside a list item (e.g. `::image-split`) was rendered to Markdown glued onto the preceding paragraph line instead of being placed on its own indented line:

````md
- *item one*  ::image-split
  #body
  ### Heading
  ::
````

instead of the expected:

````md
- *item one*
  ::image-split
  #body
  ### Heading
  ::
````

AST and HTML output were already correct — only the Markdown round-trip was broken.

## Root cause

`li.ts` only special-cased a fixed set of block children (`pre`/`blockquote`/`table`/`p`). Component children (rendered via `mdc`) fell through to plain inline concatenation, and the leading spaces came from `mdc` self-applying a fixed level-1 (2-space) indent whenever it has any parent — which only coincidentally matched an unordered list's prefix width.

## Fix

In `li.ts`, recognize component children (tags without a native handler) as block-level when the item has no inline text, render them **without a parent** so `mdc` skips its nesting indentation, and let `li` own the indentation via `prefixWidth`. This is also correct for ordered lists (e.g. `10. ` → 4-space continuation), which the old fixed 2-space assumption got wrong.