### PR TITLE
fix(stringify): render ordered-list `start` as native numbering

### DIFF
--- a/packages/comark/SPEC/COMARK/ordered-list-start-wrapper-normalizes.md
+++ b/packages/comark/SPEC/COMARK/ordered-list-start-wrapper-normalizes.md
@@ -1,0 +1,51 @@
+## Input
+
+```md
+::ol{start="3"}
+1. apple
+2. banana
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ol",
+      {
+        "start": "3"
+      },
+      [
+        "li",
+        {},
+        "apple"
+      ],
+      [
+        "li",
+        {},
+        "banana"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ol start="3">
+  <li>apple</li>
+  <li>banana</li>
+</ol>
+```
+
+## Markdown
+
+```md
+3. apple
+4. banana
+```

--- a/packages/comark/SPEC/common-mark/ordered-list-start.md
+++ b/packages/comark/SPEC/common-mark/ordered-list-start.md
@@ -1,0 +1,57 @@
+## Input
+
+```md
+5. First item
+6. Second item
+7. Third item
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ol",
+      {
+        "start": "5"
+      },
+      [
+        "li",
+        {},
+        "First item"
+      ],
+      [
+        "li",
+        {},
+        "Second item"
+      ],
+      [
+        "li",
+        {},
+        "Third item"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ol start="5">
+  <li>First item</li>
+  <li>Second item</li>
+  <li>Third item</li>
+</ol>
+```
+
+## Markdown
+
+```md
+5. First item
+6. Second item
+7. Third item
+```

--- a/packages/comark/src/internal/stringify/attributes.ts
+++ b/packages/comark/src/internal/stringify/attributes.ts
@@ -97,8 +97,6 @@ export function resolveAttribute(attrs: Record<string, unknown>, renderData: Nod
 // is implicit in `- [ ]`) so they should not echo back as user attrs.
 const IMPLICIT_ATTRS: Record<string, { drop?: string[]; classBlocklist?: string[] }> = {
   blockquote: { drop: ['as'] },
-  // `start` is conveyed by the native ordered-list numbering (`5. …`), so it
-  // must not echo back as a `::ol{start=…}` wrapper.
   ol: { drop: ['start'] },
   ul: { classBlocklist: ['contains-task-list'] },
   li: { classBlocklist: ['task-list-item'] },

--- a/packages/comark/src/internal/stringify/attributes.ts
+++ b/packages/comark/src/internal/stringify/attributes.ts
@@ -97,6 +97,9 @@ export function resolveAttribute(attrs: Record<string, unknown>, renderData: Nod
 // is implicit in `- [ ]`) so they should not echo back as user attrs.
 const IMPLICIT_ATTRS: Record<string, { drop?: string[]; classBlocklist?: string[] }> = {
   blockquote: { drop: ['as'] },
+  // `start` is conveyed by the native ordered-list numbering (`5. …`), so it
+  // must not echo back as a `::ol{start=…}` wrapper.
+  ol: { drop: ['start'] },
   ul: { classBlocklist: ['contains-task-list'] },
   li: { classBlocklist: ['task-list-item'] },
   // `language`/`filename`/`highlights`/`meta` ride on the fence info string.

--- a/packages/comark/src/internal/stringify/handlers/ol.ts
+++ b/packages/comark/src/internal/stringify/handlers/ol.ts
@@ -6,10 +6,8 @@ import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 export async function ol(node: ComarkElement, state: State) {
   const children = node.slice(2) as ComarkNode[]
 
-  // A non-1 `start` is conveyed by the native list numbering (`5. …`), so seed
-  // the item counter from it instead of forcing 1. `userBlockAttrs` drops
-  // `start` (see IMPLICIT_ATTRS), so it never also leaks into a `::ol{…}` wrapper.
-  const start = Number((node[1] as Record<string, unknown>)?.start)
+  // `start` is carried by the native numbering; IMPLICIT_ATTRS drops it from user attrs.
+  const start = Number((node[1] as Record<string, unknown>).start)
   const order = Number.isInteger(start) && start >= 1 ? start : 1
 
   const revert = state.applyContext({ list: true, order, listIndent: 3 })

--- a/packages/comark/src/internal/stringify/handlers/ol.ts
+++ b/packages/comark/src/internal/stringify/handlers/ol.ts
@@ -6,7 +6,13 @@ import { comarkAttributes, userBlockAttrs } from '../attributes.ts'
 export async function ol(node: ComarkElement, state: State) {
   const children = node.slice(2) as ComarkNode[]
 
-  const revert = state.applyContext({ list: true, order: 1, listIndent: 3 })
+  // A non-1 `start` is conveyed by the native list numbering (`5. …`), so seed
+  // the item counter from it instead of forcing 1. `userBlockAttrs` drops
+  // `start` (see IMPLICIT_ATTRS), so it never also leaks into a `::ol{…}` wrapper.
+  const start = Number((node[1] as Record<string, unknown>)?.start)
+  const order = Number.isInteger(start) && start >= 1 ? start : 1
+
+  const revert = state.applyContext({ list: true, order, listIndent: 3 })
 
   let result = ''
   for (const child of children) {


### PR DESCRIPTION
## Problem

An ordered list with a non-1 `start` round-tripped to the verbose `::ol{…}` block form instead of native markdown numbering:

````md
5. First item        ::ol{start="5"}
6. Second item   →    1. First item
7. Third item         2. Second item
                      ::
````

The same path means a legacy `::ol{start="…"}` wrapper (e.g. one written by an older renderer) never normalizes back to a plain list — it stays an MDC component block. AST and HTML were already correct; only the Markdown round-trip was affected.

## Root cause

`handlers/ol.ts` hardcoded the item counter to `order: 1`, and nothing marked `start` as implicit. So `userBlockAttrs('ol', { start })` treated `start` as a genuine user attr and forced the `::ol{…}` wrapper form, losing the native numbering.

## Fix

- `handlers/ol.ts`: seed the item counter from `start` (`order = start >= 1 ? start : 1`) so native numbering carries it.
- `stringify/attributes.ts`: add `ol: { drop: ['start'] }` to `IMPLICIT_ATTRS`, so `start` is recognized as conveyed by the native syntax and never echoes into a wrapper.

## Result (idempotent)

- `5. 6. 7.` → round-trips as native `5. 6. 7.`
- `::ol{start="3"}\n1. …\n::` → normalizes to native `3. 4. …`
- `::ol{start="undefined"}\n1. …\n::` → heals to clean `1. 2. 3.`
- `::ol{attr="value"}` (a genuine non-`start` attr) → still wraps (unchanged)

## Tests

Two new SPECs (`common-mark/ordered-list-start.md`, `COMARK/ordered-list-start-wrapper-normalizes.md`); full suite **1084 passing**. The #214 attribute specs (`attributes/ordered-list.md`, `attributes/wrapped-ol.md`) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)