### PR TITLE
fix(svelte): sync core plugins on build

### DIFF
--- a/packages/comark-svelte/package.json
+++ b/packages/comark-svelte/package.json
@@ -54,7 +54,7 @@
   },
   "scripts": {
     "stub": "node ../../scripts/stub.mjs",
-    "build": "svelte-package --input src",
+    "build": "svelte-package --input src && node ../../scripts/sync-plugins.mjs",
     "build:watch": "svelte-package --input src --watch",
     "test": "vitest run",
     "check": "svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
This PR replaces #257.

The original PR contained unsigned commits, while this repository requires every commit to have a verified signature. The changes have been preserved by squashing them into a single maintainer-signed commit, rebased onto the current `main`. Original contributor attribution is retained via a GitHub `Co-authored-by:` trailer.

## Summary

`svelte-package` regenerates `dist` on build, so the dist-only synced plugin files were dropped from published packages — making imports like `@comark/svelte/plugins/emoji` fail. This runs `scripts/sync-plugins.mjs` after `svelte-package` so the core plugin re-exports land in `dist`.

Closes #257