### PR TITLE
fix: restore three PRs clobbered by stale-tree merge of #245

### DIFF
--- a/docs/content/3.rendering/4.nuxt.md
+++ b/docs/content/3.rendering/4.nuxt.md
@@ -123,7 +123,7 @@ See [ComarkPlugin](/plugins) for available plugins.
 
 ```vue [app.vue]
 <script setup lang="ts">
-import highlight from '@comark/vue/plugins/highlight'
+import highlight from '@comark/nuxt/plugins/highlight'
 import githubLight from '@shikijs/themes/github-light'
 import githubDark from '@shikijs/themes/github-dark'
 
@@ -143,8 +143,8 @@ For math and mermaid plugins, also pass the companion components:
 
 ```vue [app.vue]
 <script setup lang="ts">
-import math, { Math } from '@comark/vue/plugins/math'
-import mermaid, { Mermaid } from '@comark/vue/plugins/mermaid'
+import math, { Math } from '@comark/nuxt/plugins/math'
+import mermaid, { Mermaid } from '@comark/nuxt/plugins/mermaid'
 import 'katex/dist/katex.min.css'
 </script>
 

--- a/examples/1.frameworks/astro/README.md
+++ b/examples/1.frameworks/astro/README.md
@@ -10,7 +10,7 @@ path: /examples/frameworks/astro
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/1.frameworks/astro
 defaultValue: src/content/posts/comark-syntax.md
 ---

--- a/examples/1.frameworks/nextjs/README.md
+++ b/examples/1.frameworks/nextjs/README.md
@@ -11,7 +11,7 @@ demo: https://comark-nextjs.vercel.app
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/1.frameworks/nextjs
 defaultValue: content/posts/comark-syntax.md
 ---

--- a/examples/1.frameworks/vitepress/README.md
+++ b/examples/1.frameworks/vitepress/README.md
@@ -10,7 +10,7 @@ path: /examples/frameworks/vitepress
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/1.frameworks/vitepress
 defaultValue: demo.md
 ---

--- a/examples/2.vite/angular/README.md
+++ b/examples/2.vite/angular/README.md
@@ -10,7 +10,7 @@ path: /examples/vite/angular
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/2.vite/angular
 defaultValue: src/main.ts
 ---

--- a/examples/2.vite/react/README.md
+++ b/examples/2.vite/react/README.md
@@ -10,7 +10,7 @@ path: /examples/vite/react
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/2.vite/react
 defaultValue: src/App.tsx
 ---

--- a/examples/2.vite/svelte/README.md
+++ b/examples/2.vite/svelte/README.md
@@ -10,7 +10,7 @@ path: /examples/vite/svelte
 ::CodeExplorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/2.vite/svelte
 defaultValue: src/App.svelte
 ---

--- a/examples/2.vite/vue/README.md
+++ b/examples/2.vite/vue/README.md
@@ -10,7 +10,7 @@ path: /examples/vite/vue
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/2.vite/vue
 defaultValue: content/posts/comark-syntax.md
 ---

--- a/examples/3.plugins/vue-vite-highlight/README.md
+++ b/examples/3.plugins/vue-vite-highlight/README.md
@@ -10,7 +10,7 @@ path: /examples/plugins/vue-vite-highlight
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/3.plugins/vue-vite-highlight
 defaultValue: src/App.vue
 ---

--- a/examples/3.plugins/vue-vite-math/README.md
+++ b/examples/3.plugins/vue-vite-math/README.md
@@ -10,7 +10,7 @@ path: /examples/plugins/vue-vite-math
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/3.plugins/vue-vite-math
 defaultValue: src/App.vue
 ---

--- a/examples/3.plugins/vue-vite-mermaid/README.md
+++ b/examples/3.plugins/vue-vite-mermaid/README.md
@@ -10,7 +10,7 @@ path: /examples/plugins/vue-vite-mermaid
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 path: examples/3.plugins/vue-vite-mermaid
 defaultValue: src/App.vue
 ---

--- a/examples/4.ai/nuxt-ai-sdk/README.md
+++ b/examples/4.ai/nuxt-ai-sdk/README.md
@@ -10,7 +10,7 @@ path: /examples/ai/nuxt-ai-sdk
 ::code-explorer
 ---
 org: comarkdown
-repo: comark
+repo: comark@81a416b278b0f304d7e7577c7ac6bbfc78414790
 branch: feat/aisdk-nuxt-example
 path: examples/4.ai/nuxt-ai-sdk
 defaultValue: server/api/chat.post.ts

--- a/packages/comark/SPEC/COMARK/component-block-in-list-item.md
+++ b/packages/comark/SPEC/COMARK/component-block-in-list-item.md
@@ -1,0 +1,79 @@
+## Input
+
+```md
+- *item one*
+  ::block
+  #body
+  ### Heading
+  ::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ul",
+      {},
+      [
+        "li",
+        {},
+        [
+          "p",
+          {},
+          [
+            "em",
+            {},
+            "item one"
+          ]
+        ],
+        [
+          "block",
+          {},
+          [
+            "template",
+            {
+              "name": "body"
+            },
+            [
+              "h3",
+              {
+                "id": "heading"
+              },
+              "Heading"
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ul>
+  <li>
+    <p><em>item one</em></p>
+    <block>
+      <template name="body">
+        <h3 id="heading">Heading</h3>
+      </template>
+    </block>
+  </li>
+</ul>
+```
+
+## Markdown
+
+```md
+- *item one*
+  ::block
+  #body
+  ### Heading
+  ::
+```

--- a/packages/comark/src/internal/stringify/handlers/li.ts
+++ b/packages/comark/src/internal/stringify/handlers/li.ts
@@ -26,25 +26,36 @@ export async function li(node: ComarkElement, state: State) {
   }
 
   const prefixWidth = prefix.length
+
+  // Direct text children render sibling components inline.
+  const hasInlineContent = children.some((child) => typeof child === 'string')
+
   let result = ''
 
   for (const child of children) {
-    const rendered = await state.one(child, state, node)
-    if (result && Array.isArray(child)) {
-      if (blockElements.has(child[0] as string)) {
-        // Block-level child: put on its own line and indent to align with list prefix
-        const indented = indent(rendered, { width: prefixWidth })
+    if (Array.isArray(child)) {
+      const tag = child[0] as string
+
+      if (result && blockElements.has(tag)) {
+        const indented = indent(await state.one(child, state, node), { width: prefixWidth })
         result = result.trimEnd() + '\n' + indented.trimEnd() + '\n'
         continue
       }
 
-      if (child[0] === 'p') {
-        const indented = indent(rendered, { width: prefixWidth })
+      if (result && tag === 'p') {
+        const indented = indent(await state.one(child, state, node), { width: prefixWidth })
         result = result.trimEnd() + '\n\n' + indented.trimEnd() + '\n'
         continue
       }
+
+      // No parent → mdc skips its own nesting indentation, so li owns it here.
+      if (!hasInlineContent && !(tag in state.handlers)) {
+        const indented = indent(await state.one(child, state), { width: prefixWidth, ignoreFirstLine: !result })
+        result = result ? result.trimEnd() + '\n' + indented.trimEnd() + '\n' : indented.trimEnd() + '\n'
+        continue
+      }
     }
-    result += rendered
+    result += await state.one(child, state, node)
   }
   result = result.trim()
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -74,7 +74,7 @@ describe.skipIf(stubbed || process.env.SKIP_BUNDLE_SIZE === 'true')('package bun
         "@comark/react": "37.2k (56 files)",
         "@comark/svelte": "39.2k (66 files)",
         "@comark/vue": "54.8k (62 files)",
-        "comark": "347k (132 files)",
+        "comark": "348k (132 files)",
       }
     `)
   })


### PR DESCRIPTION
Restores three PRs that were reverted by the stale-tree merge of #245 (which was based on a tree older than all of them):

- **#252** — `fix(stringify): render block component children of list items on their own line`
- **#251** — `docs: fix imports in nuxt rendering`
- **#253** — `docs: use new cache url for code examples`

Each commit restores the original PR's content verbatim.