### PR TITLE
fix(comark): only complete unclosed frontmatter while streaming

### DIFF
--- a/packages/comark/SPEC/COMARK/frontmatter-unclosed-is-thematic-break.md
+++ b/packages/comark/SPEC/COMARK/frontmatter-unclosed-is-thematic-break.md
@@ -1,0 +1,43 @@
+## Input
+
+```md
+---
+# Heading
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "hr",
+      {}
+    ],
+    [
+      "h1",
+      {
+        "id": "heading"
+      },
+      "Heading"
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<hr />
+<h1 id="heading">Heading</h1>
+```
+
+## Markdown
+
+```md
+---
+
+# Heading
+```

--- a/packages/comark/SPEC/common-mark/horizontal-rule-bare.md
+++ b/packages/comark/SPEC/common-mark/horizontal-rule-bare.md
@@ -1,0 +1,32 @@
+## Input
+
+```md
+---
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "hr",
+      {}
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<hr />
+```
+
+## Markdown
+
+```md
+---
+```

--- a/packages/comark/src/internal/parse/auto-close/index.ts
+++ b/packages/comark/src/internal/parse/auto-close/index.ts
@@ -62,7 +62,7 @@ export function autoCloseMarkdown(markdown: string, options: { frontmatter?: boo
     }
 
     // Frontmatter: only starts at document line 0
-    if (idx === 0 && trimmed === '---') {
+    if (idx === 0 && options.frontmatter && trimmed === '---') {
       inFrontmatter = true
       continue
     }
@@ -159,7 +159,7 @@ export function autoCloseMarkdown(markdown: string, options: { frontmatter?: boo
   }
 
   // Complete an unclosed frontmatter block only when `frontmatter` is enabled,
-  if (options.frontmatter && inFrontmatter && frontmatterHasContent) {
+  if (inFrontmatter && frontmatterHasContent) {
     const lastTrimmed = lines[lastIdx].trim()
     if (lastTrimmed === '-' || lastTrimmed === '--') {
       result += '-'.repeat(3 - lastTrimmed.length)

--- a/packages/comark/src/internal/parse/auto-close/index.ts
+++ b/packages/comark/src/internal/parse/auto-close/index.ts
@@ -10,16 +10,23 @@ import { closeTables } from './table.ts'
  * Processes markdown in O(n) time by scanning character-by-character
  *
  * @param markdown - The markdown content to auto-close
+ * @param options - `streaming` completes an unclosed leading frontmatter block.
  * @returns The markdown with unclosed syntax closed
  */
-export function autoCloseMarkdown(markdown: string): string {
+export function autoCloseMarkdown(markdown: string, options: { streaming?: boolean } = {}): string {
   if (!markdown || markdown === '') return markdown
+
+  const { streaming = false } = options
 
   const lines = markdown.split('\n')
   const n = lines.length
 
   // Single linear pass to collect document state
   let inFrontmatter = false
+  // Whether the open frontmatter block has received any content. Empty
+  // frontmatter is not valid (`parseFrontmatter` ignores it), so a lone `---`
+  // is a thematic break, not an unclosed frontmatter block to complete.
+  let frontmatterHasContent = false
   let inBlockMath = false
   let tableStart = -1
   // Tag name when inside a raw-text HTML element (`<style>`, `<script>`,
@@ -63,6 +70,7 @@ export function autoCloseMarkdown(markdown: string): string {
     }
     if (inFrontmatter) {
       if (trimmed === '---') inFrontmatter = false
+      else if (trimmed !== '') frontmatterHasContent = true
       continue
     }
 
@@ -152,8 +160,12 @@ export function autoCloseMarkdown(markdown: string): string {
     result = closeTables(result)
   }
 
-  // Close unclosed frontmatter
-  if (inFrontmatter) {
+  // Complete an unclosed frontmatter block only while streaming, and only when
+  // it has content. A complete document with a leading `---` and no closing
+  // delimiter is a thematic break (see `parseFrontmatter`), not frontmatter, so
+  // completing it would swallow the body; and completing an empty block would
+  // turn a lone `---` into two thematic breaks.
+  if (streaming && inFrontmatter && frontmatterHasContent) {
     const lastTrimmed = lines[lastIdx].trim()
     if (lastTrimmed === '-' || lastTrimmed === '--') {
       result += '-'.repeat(3 - lastTrimmed.length)

--- a/packages/comark/src/internal/parse/auto-close/index.ts
+++ b/packages/comark/src/internal/parse/auto-close/index.ts
@@ -10,13 +10,11 @@ import { closeTables } from './table.ts'
  * Processes markdown in O(n) time by scanning character-by-character
  *
  * @param markdown - The markdown content to auto-close
- * @param options - `streaming` completes an unclosed leading frontmatter block.
+ * @param options - `frontmatter` completes an unclosed leading frontmatter block.
  * @returns The markdown with unclosed syntax closed
  */
-export function autoCloseMarkdown(markdown: string, options: { streaming?: boolean } = {}): string {
+export function autoCloseMarkdown(markdown: string, options: { frontmatter?: boolean } = {}): string {
   if (!markdown || markdown === '') return markdown
-
-  const { streaming = false } = options
 
   const lines = markdown.split('\n')
   const n = lines.length
@@ -160,12 +158,8 @@ export function autoCloseMarkdown(markdown: string, options: { streaming?: boole
     result = closeTables(result)
   }
 
-  // Complete an unclosed frontmatter block only while streaming, and only when
-  // it has content. A complete document with a leading `---` and no closing
-  // delimiter is a thematic break (see `parseFrontmatter`), not frontmatter, so
-  // completing it would swallow the body; and completing an empty block would
-  // turn a lone `---` into two thematic breaks.
-  if (streaming && inFrontmatter && frontmatterHasContent) {
+  // Complete an unclosed frontmatter block only when `frontmatter` is enabled,
+  if (options.frontmatter && inFrontmatter && frontmatterHasContent) {
     const lastTrimmed = lines[lastIdx].trim()
     if (lastTrimmed === '-' || lastTrimmed === '--') {
       result += '-'.repeat(3 - lastTrimmed.length)

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -116,7 +116,7 @@ export function createParse<const TPlugins extends readonly ComarkPlugin<any, an
     }
 
     if (autoClose) {
-      state.markdown = autoCloseMarkdown(state.markdown)
+      state.markdown = autoCloseMarkdown(state.markdown, { streaming: opts.streaming })
     }
 
     for (const plugin of options.plugins || []) {

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -116,7 +116,7 @@ export function createParse<const TPlugins extends readonly ComarkPlugin<any, an
     }
 
     if (autoClose) {
-      state.markdown = autoCloseMarkdown(state.markdown, { streaming: opts.streaming })
+      state.markdown = autoCloseMarkdown(state.markdown, { frontmatter: opts.streaming })
     }
 
     for (const plugin of options.plugins || []) {

--- a/packages/comark/test/auto-close.test.ts
+++ b/packages/comark/test/auto-close.test.ts
@@ -497,38 +497,38 @@ describe('frontmatter', () => {
     const expected = '---\ntitle: Test\n---'
     expect(autoCloseMarkdown(input)).toBe(expected)
   })
-  // Partial frontmatter is only completed while streaming — for a complete
-  // document a leading `---` with no closing delimiter is a thematic break, so
-  // completing it would swallow the body (see the non-streaming cases below).
-  it('should complete partial frontmatter while streaming', () => {
+  // Partial frontmatter is only completed when `frontmatter: true` — for a
+  // complete document a leading `---` with no closing delimiter is a thematic
+  // break, so completing it would swallow the body (see the default cases below).
+  it('should complete partial frontmatter when frontmatter option is enabled', () => {
     const input = '---\ntitle: Test'
     const expected = '---\ntitle: Test\n---'
-    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
+    expect(autoCloseMarkdown(input, { frontmatter: true })).toBe(expected)
   })
-  it('should complete a partial closing delimiter (-) while streaming', () => {
+  it('should complete a partial closing delimiter (-) when frontmatter option is enabled', () => {
     const input = '---\ntitle: Test\n-'
     const expected = '---\ntitle: Test\n---'
-    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
+    expect(autoCloseMarkdown(input, { frontmatter: true })).toBe(expected)
   })
-  it('should complete a partial closing delimiter (--) while streaming', () => {
+  it('should complete a partial closing delimiter (--) when frontmatter option is enabled', () => {
     const input = '---\ntitle: Test\n--'
     const expected = '---\ntitle: Test\n---'
-    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
+    expect(autoCloseMarkdown(input, { frontmatter: true })).toBe(expected)
   })
-  it('should complete partial frontmatter with an empty value while streaming', () => {
+  it('should complete partial frontmatter with an empty value when frontmatter option is enabled', () => {
     const input = '---\ntitle: '
     const expected = '---\ntitle: \n---'
-    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
+    expect(autoCloseMarkdown(input, { frontmatter: true })).toBe(expected)
   })
-  it('should complete partial frontmatter with a trailing newline while streaming', () => {
+  it('should complete partial frontmatter with a trailing newline when frontmatter option is enabled', () => {
     const input = '---\ntitle: Test\n'
     const expected = '---\ntitle: Test\n---'
-    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
+    expect(autoCloseMarkdown(input, { frontmatter: true })).toBe(expected)
   })
 
-  it('should not complete unclosed frontmatter in a complete document', () => {
-    // Not streaming: a leading `---` with content but no close is a thematic
-    // break followed by body — completing it would swallow the body.
+  it('should not complete unclosed frontmatter by default', () => {
+    // Default (`frontmatter: false`): a leading `---` with content but no close
+    // is a thematic break followed by body — completing it would swallow the body.
     const input = '---\ntitle: Test'
     expect(autoCloseMarkdown(input)).toBe(input)
     expect(autoCloseMarkdown('---\n# Heading')).toBe('---\n# Heading')

--- a/packages/comark/test/auto-close.test.ts
+++ b/packages/comark/test/auto-close.test.ts
@@ -497,30 +497,41 @@ describe('frontmatter', () => {
     const expected = '---\ntitle: Test\n---'
     expect(autoCloseMarkdown(input)).toBe(expected)
   })
-  it('should handle frontmatter partial', () => {
+  // Partial frontmatter is only completed while streaming — for a complete
+  // document a leading `---` with no closing delimiter is a thematic break, so
+  // completing it would swallow the body (see the non-streaming cases below).
+  it('should complete partial frontmatter while streaming', () => {
     const input = '---\ntitle: Test'
     const expected = '---\ntitle: Test\n---'
-    expect(autoCloseMarkdown(input)).toBe(expected)
+    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
   })
-  it('should handle frontmatter partial', () => {
+  it('should complete a partial closing delimiter (-) while streaming', () => {
     const input = '---\ntitle: Test\n-'
     const expected = '---\ntitle: Test\n---'
-    expect(autoCloseMarkdown(input)).toBe(expected)
+    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
   })
-  it('should handle frontmatter partial', () => {
+  it('should complete a partial closing delimiter (--) while streaming', () => {
     const input = '---\ntitle: Test\n--'
     const expected = '---\ntitle: Test\n---'
-    expect(autoCloseMarkdown(input)).toBe(expected)
+    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
   })
-  it('should handle frontmatter partial 2', () => {
+  it('should complete partial frontmatter with an empty value while streaming', () => {
     const input = '---\ntitle: '
     const expected = '---\ntitle: \n---'
-    expect(autoCloseMarkdown(input)).toBe(expected)
+    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
   })
-  it('should handle frontmatter partial 3', () => {
+  it('should complete partial frontmatter with a trailing newline while streaming', () => {
     const input = '---\ntitle: Test\n'
     const expected = '---\ntitle: Test\n---'
-    expect(autoCloseMarkdown(input)).toBe(expected)
+    expect(autoCloseMarkdown(input, { streaming: true })).toBe(expected)
+  })
+
+  it('should not complete unclosed frontmatter in a complete document', () => {
+    // Not streaming: a leading `---` with content but no close is a thematic
+    // break followed by body — completing it would swallow the body.
+    const input = '---\ntitle: Test'
+    expect(autoCloseMarkdown(input)).toBe(input)
+    expect(autoCloseMarkdown('---\n# Heading')).toBe('---\n# Heading')
   })
 
   it('should handle frontmatter with content after', () => {
@@ -541,9 +552,17 @@ describe('frontmatter', () => {
     expect(autoCloseMarkdown(input)).toBe(expected)
   })
 
-  it('should handle just opening ---', () => {
+  it('should not complete a lone --- (thematic break, not frontmatter)', () => {
+    // A lone `---` has no frontmatter content; completing it to `---\n---`
+    // would parse as two thematic breaks (#268).
     const input = '---'
-    const expected = '---\n---'
+    const expected = '---'
+    expect(autoCloseMarkdown(input)).toBe(expected)
+  })
+
+  it('should not complete an empty --- opener', () => {
+    const input = '---\n'
+    const expected = '---\n'
     expect(autoCloseMarkdown(input)).toBe(expected)
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #268

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`autoCloseMarkdown` treated any leading `---` as an unclosed frontmatter opener and appended a closing `---`. That completion only makes sense while streaming; applied to a complete document it caused two bugs:

- **Doubling**: `---` → `---\n---` → parsed as **two** thematic breaks (and no `hr` round-tripped, since `renderMarkdown` emits `---`).
- **Content loss**: `---\n<body>` → `---\n<body>\n---` → looked like valid frontmatter, so `parseFrontmatter` consumed the body as YAML and **dropped it** — contradicting its own contract that an unclosed `---` stays content.

**Fix**: gate frontmatter completion on `streaming`. `autoCloseMarkdown` gains an optional `{ streaming }` argument (default `false`, backward-compatible — it has no other callers), threaded from `parse` via `opts.streaming`. A complete document now leaves a leading unclosed `---` alone, so the tokenizer reads it as a thematic break and keeps any following body; while streaming, partial frontmatter is still auto-completed exactly as before. A secondary non-empty guard means a lone `---` is never doubled, even mid-stream.

**Behavior**

| input (non-streaming) | before | after |
|-|-|-|
| `---` | `[hr, hr]` | `[hr]` |
| `---\n# Heading` | `[]` (heading lost) | `[hr, h1]` |
| `---\ntitle: x\n---\n\n# Body` | frontmatter + body | frontmatter + body (unchanged) |
| streaming `---\ntitle: x` | completes to frontmatter | completes to frontmatter (unchanged) |

**Tests**

- **SPEC horizontal-rule-bare**: a bare `---` parses to a single `hr`.
- **SPEC frontmatter-unclosed-is-thematic-break**: a leading `---` + body stays a thematic break + body (swallow).
- **test/auto-close.test.ts**: the `frontmatter partial` cases now assert streaming completion, plus new non-streaming cases asserting the body is preserved.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have run `pnpm verify` and it passes. (pre-existing issues)
- [ ] I have updated the documentation accordingly.
