### PR TITLE
feat(emoji): add `extend` option for custom shortcodes

### DIFF
--- a/docs/content/4.plugins/1.built-in/emoji.md
+++ b/docs/content/4.plugins/1.built-in/emoji.md
@@ -18,7 +18,7 @@ links:
     variant: soft
 ---
 
-The `comark/plugins/emoji` plugin converts emoji shortcodes (e.g. `:smile:`) into their corresponding emoji characters. It takes no configuration options.
+The `comark/plugins/emoji` plugin converts emoji shortcodes (e.g. `:smile:`) into their corresponding emoji characters. It ships with a curated set of common emojis, and you can add the full GitHub set or your own shortcodes with the [`extend`](#extend) option.
 
 ## Usage
 
@@ -81,7 +81,7 @@ Shortcodes are case-sensitive and must use exact names. Invalid or unknown short
 
 ### Shortcodes
 
-The plugin supports 200+ popular emojis across all common categories:
+The plugin ships with 200+ popular emojis across all common categories:
 
 - **Smileys & Emotions**: `:smile:` `:heart_eyes:` `:thinking:` `:cry:` `:joy:`
 - **People & Gestures**: `:thumbsup:` `:clap:` `:wave:` `:muscle:` `:pray:`
@@ -105,13 +105,54 @@ Some emojis have multiple valid shortcodes:
 :punch: or :facepunch:      → 👊
 ```
 
+### Custom shortcodes
+
+Use the `extend` option to add your own shortcodes or override built-in ones. This is handy for team-specific emojis or GitHub custom shortcodes that aren't part of the Unicode set (e.g. `:shipit:`):
+
+```typescript
+import emoji from 'comark/plugins/emoji'
+
+parse(content, {
+  plugins: [
+    emoji({
+      extend: {
+        shipit: '🚀',
+        myteam: '🦄',
+      },
+    }),
+  ],
+})
+```
+
+Values in `extend` take precedence over the built-in set, so you can also remap an existing shortcode.
+
+### Full emoji set
+
+The built-in set is intentionally small to keep the bundle light. To support the complete GitHub set, install a dataset such as [`gemoji`](https://github.com/wooorm/gemoji) and pass its map through `extend`:
+
+```typescript
+import emoji from 'comark/plugins/emoji'
+import { nameToEmoji } from 'gemoji'
+
+parse(content, {
+  plugins: [emoji({ extend: nameToEmoji })],
+})
+```
+
 ---
 
 ## API
 
-### `emoji()`
+### `emoji(options?)`
 
-Returns a `ComarkPlugin` that converts emoji shortcodes to characters. Takes no configuration options.
+Returns a `ComarkPlugin` that converts emoji shortcodes to characters.
+
+#### `extend`
+
+- Type: `Record<string, string>`
+- Optional
+
+A map of shortcode names (without colons) to emoji characters. Added on top of the built-in set; values override built-in shortcodes of the same name.
 
 **Returns:** `ComarkPlugin`
 

--- a/packages/comark/src/plugins/emoji.ts
+++ b/packages/comark/src/plugins/emoji.ts
@@ -1,9 +1,11 @@
 import type { MarkdownItPlugin } from 'comark'
 import { defineComarkPlugin } from '../utils/helpers.ts'
 
-// Common emoji definitions (200+ emojis)
-// Organized by category for easier maintenance
-const EMOJI_MAP = new Map<string, string>([
+// Curated set of common emoji shortcodes, organized by category.
+// For the full GitHub set, install a dataset (e.g. `gemoji`) and pass it via
+// the `extend` option — see EmojiOptions below.
+const BASE_EMOJI = new Map<string, string>([
+  // Smileys & emotions
   ['grinning', '😀'],
   ['smiley', '😃'],
   ['smile', '😄'],
@@ -67,12 +69,16 @@ const EMOJI_MAP = new Map<string, string>([
   ['nose', '👃'],
   ['lips', '👄'],
   ['tongue', '👅'],
+
+  // Hearts
   ['heart', '❤️'],
   ['yellow_heart', '💛'],
   ['green_heart', '💚'],
   ['blue_heart', '💙'],
   ['purple_heart', '💜'],
   ['broken_heart', '💔'],
+
+  // People & gestures
   ['thumbsup', '👍'],
   ['+1', '👍'],
   ['thumbsdown', '👎'],
@@ -96,6 +102,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['writing_hand', '✍️'],
   ['nail_care', '💅'],
   ['selfie', '🤳'],
+
+  // Objects & symbols
   ['fire', '🔥'],
   ['sparkles', '✨'],
   ['star', '⭐'],
@@ -110,6 +118,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['gift', '🎁'],
   ['birthday', '🎂'],
   ['cake', '🍰'],
+
+  // Travel & places
   ['rocket', '🚀'],
   ['helicopter', '🚁'],
   ['airplane', '✈️'],
@@ -121,6 +131,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['car', '🚗'],
   ['bike', '🚲'],
   ['checkered_flag', '🏁'],
+
+  // Activities
   ['medal', '🏅'],
   ['trophy', '🏆'],
   ['medal_sports', '🏅'],
@@ -133,6 +145,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['bowling', '🎳'],
   ['golf', '⛳'],
   ['dart', '🎯'],
+
+  // Food & drink
   ['beer', '🍺'],
   ['beers', '🍻'],
   ['wine_glass', '🍷'],
@@ -174,6 +188,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['sake', '🍶'],
   ['champagne', '🍾'],
   ['tropical_drink', '🍹'],
+
+  // Weather & nature
   ['sunny', '☀️'],
   ['cloud', '☁️'],
   ['umbrella', '☂️'],
@@ -182,14 +198,13 @@ const EMOJI_MAP = new Map<string, string>([
   ['rainbow', '🌈'],
   ['ocean', '🌊'],
   ['droplet', '💧'],
-  ['zap', '⚡'],
-  ['fire', '🔥'],
-  ['star', '⭐'],
   ['moon', '🌙'],
   ['partly_sunny', '⛅'],
   ['thunder_cloud_and_rain', '⛈️'],
   ['wind_face', '🌬️'],
   ['fog', '🌫️'],
+
+  // Animals
   ['dog', '🐶'],
   ['cat', '🐱'],
   ['mouse', '🐭'],
@@ -225,6 +240,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['octopus', '🐙'],
   ['shell', '🐚'],
   ['crab', '🦀'],
+
+  // Plants
   ['tree', '🌲'],
   ['evergreen_tree', '🌲'],
   ['deciduous_tree', '🌳'],
@@ -249,6 +266,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['gift_heart', '💝'],
   ['ring', '💍'],
   ['gem', '💎'],
+
+  // Tech & objects
   ['bulb', '💡'],
   ['book', '📖'],
   ['pencil', '📝'],
@@ -265,7 +284,7 @@ const EMOJI_MAP = new Map<string, string>([
   ['keyboard', '⌨️'],
   ['desktop_computer', '🖥️'],
   ['printer', '🖨️'],
-  ['mouse', '🖱️'],
+  ['computer_mouse', '🖱️'],
   ['trackball', '🖲️'],
   ['joystick', '🕹️'],
   ['watch', '⌚'],
@@ -289,6 +308,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['wrench', '🔧'],
   ['hammer', '🔨'],
   ['nut_and_bolt', '🔩'],
+
+  // Symbols
   ['thinking', '🤔'],
   ['thinking_face', '🤔'],
   ['question', '❓'],
@@ -335,6 +356,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['radio_button', '🔘'],
   ['white_square_button', '🔳'],
   ['black_square_button', '🔲'],
+
+  // Office & documents
   ['scissors', '✂️'],
   ['paperclip', '📎'],
   ['pushpin', '📌'],
@@ -344,7 +367,7 @@ const EMOJI_MAP = new Map<string, string>([
   ['open_book', '📖'],
   ['green_book', '📗'],
   ['blue_book', '📘'],
-  ['orange_book', '�orange_book'],
+  ['orange_book', '📙'],
   ['notebook', '📓'],
   ['ledger', '📒'],
   ['page_with_curl', '📃'],
@@ -364,6 +387,8 @@ const EMOJI_MAP = new Map<string, string>([
   ['package', '📦'],
   ['inbox_tray', '📥'],
   ['outbox_tray', '📤'],
+
+  // Music & art
   ['musical_note', '🎵'],
   ['notes', '🎶'],
   ['microphone', '🎤'],
@@ -381,11 +406,36 @@ const EMOJI_MAP = new Map<string, string>([
 ])
 
 /**
- * Emoji parser for markdown-it
- * Only supports :emoji_name: syntax (no shortcuts/emoticons)
- * Uses Map for O(1) lookups and simple string scanning
+ * Options for the emoji plugin.
  */
-const emojiRule = (state: any, silent: boolean) => {
+export interface EmojiOptions {
+  /**
+   * Add or override shortcodes. Values take precedence over the built-in set,
+   * so this can also be used to remap an existing shortcode.
+   *
+   * Pass a full dataset here to go beyond the curated built-in set — install a
+   * package such as `gemoji` and forward its map:
+   *
+   * @example
+   * ```ts
+   * import { nameToEmoji } from 'gemoji'
+   * emoji({ extend: nameToEmoji })
+   * ```
+   *
+   * @example
+   * ```ts
+   * emoji({ extend: { shipit: '🚀', myteam: '🦄' } })
+   * ```
+   */
+  extend?: Record<string, string>
+}
+
+/**
+ * Emoji parser for markdown-it.
+ * Only supports :emoji_name: syntax (no shortcuts/emoticons).
+ * Uses a Map for O(1) lookups and simple string scanning.
+ */
+const createEmojiRule = (emojiMap: Map<string, string>) => (state: any, silent: boolean) => {
   const max = state.posMax
   const start = state.pos
 
@@ -404,7 +454,7 @@ const emojiRule = (state: any, silent: boolean) => {
       const emojiName = state.src.slice(start + 1, pos)
 
       // Check if this is a valid emoji
-      const emojiChar = EMOJI_MAP.get(emojiName)
+      const emojiChar = emojiMap.get(emojiName)
       if (emojiChar) {
         if (!silent) {
           const token = state.push('emoji', '', 0)
@@ -442,10 +492,20 @@ const emojiRule = (state: any, silent: boolean) => {
 }
 
 export const markdownItEmoji: MarkdownItPlugin = (md) => {
-  md.inline.ruler.before('emphasis', 'emoji', emojiRule)
+  md.inline.ruler.before('emphasis', 'emoji', createEmojiRule(BASE_EMOJI))
 }
 
-export default defineComarkPlugin(() => ({
-  name: 'emoji',
-  markdownItPlugins: [markdownItEmoji],
-}))
+export default defineComarkPlugin<EmojiOptions>((options) => {
+  const emojiMap = options?.extend
+    ? new Map<string, string>([...BASE_EMOJI, ...Object.entries(options.extend)])
+    : BASE_EMOJI
+
+  const markdownItPlugin: MarkdownItPlugin = (md) => {
+    md.inline.ruler.before('emphasis', 'emoji', createEmojiRule(emojiMap))
+  }
+
+  return {
+    name: 'emoji',
+    markdownItPlugins: [markdownItPlugin],
+  }
+})

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "40.0k (58 files)",
         "@comark/svelte": "40.1k (66 files)",
         "@comark/vue": "56.0k (62 files)",
-        "comark": "358k (134 files)",
+        "comark": "359k (134 files)",
       }
     `)
   })


### PR DESCRIPTION
## Summary

Adds an `extend` option to the emoji plugin so users can add or override shortcodes — including bringing the **complete GitHub set** via their own dependency, without comark bundling a large dataset.

This follows the same "bring your own dataset" pattern as Nuxt UI's [Editor emoji menu](https://ui.nuxt.com/docs/components/editor-emoji-menu), where `@tiptap/extension-emoji`'s `gitHubEmojis` is installed separately and passed in.

## What's in here

- **New `extend` option** — `Record<string, string>` merged on top of the built-in set (values override built-ins, so it also remaps):
  ```ts
  emoji({ extend: { shipit: '🚀', myteam: '🦄' } })
  ```
- **Full set = bring your own** — the built-in set stays small; for the complete GitHub set, install a dataset such as [`gemoji`](https://github.com/wooorm/gemoji) and forward its map:
  ```ts
  import { nameToEmoji } from 'gemoji'
  emoji({ extend: nameToEmoji })
  ```
  No new runtime **or** dev dependency added to comark — the dataset lives in the consumer's project.
- **Bug fixes** in the curated set:
  - `:orange_book:` was a corrupted value (mojibake) → now renders 📙.
  - `:mouse:` (🐭) was silently overridden by a duplicate key for the computer mouse; the animal is restored and the computer mouse moved to `:computer_mouse:` (🖱️). Redundant `zap`/`fire`/`star` duplicates removed.
- **Docs** updated with the `extend` option and the full-set (BYO dataset) pattern.

Backward-compatible: `emoji()` with no options works exactly as before.

## Verification

- ✅ 1,103 `comark` tests pass — emoji SPEC fixtures unchanged.
- ✅ 64 `@comark/vue` tests pass (plugin dedup/idempotency unaffected).
- ✅ Verified end-to-end: base `:rocket:`→🚀, `:orange_book:`→📙, `:mouse:`→🐭, `:computer_mouse:`→🖱️, `:shipit:` via `extend`→🚀, override `:rocket:`→🛸, unknown shortcodes left unchanged.
- ✅ Lint clean (oxlint + oxfmt).

> [!NOTE]
> `pnpm typecheck` reports 3 errors, but all are pre-existing in unrelated test files (`comark-angular/test/rendering.test.ts`, `comark-vue/test/vite.test.ts`) and untouched by this change.