### PR TITLE
fix(react): pass class name to Math and Mermaid components

### DIFF
--- a/examples/3.plugins/react-vite-math/README.md
+++ b/examples/3.plugins/react-vite-math/README.md
@@ -1,0 +1,94 @@
+---
+title: Math formulas
+description: Example showing how to use Comark with LaTeX math formulas in React and Vite.
+navigation:
+  icon:  i-lucide-calculator
+category: Plugins
+path: /examples/plugins/react-vite-math
+---
+
+::code-explorer
+---
+org: comarkdown
+repo: comark@8d0c4a8023b71e8588ee6328820a2f26f2285232
+path: examples/3.plugins/react-vite-math
+defaultValue: src/App.tsx
+---
+::
+
+## Features
+
+This example demonstrates how to use Comark with LaTeX math formulas in React:
+
+- **Math Plugin**: Import and configure the `math` plugin to parse `$...$` and `$$...$$` expressions
+- **Math Component**: Register the `Math` component to render formulas using KaTeX
+- **Inline & Display Math**: Supports both inline formulas and display equations
+- **Full LaTeX Syntax**: All KaTeX-supported LaTeX commands work
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   npm install @comark/react katex
+   ```
+
+2. Import the math plugin, component, and KaTeX CSS:
+   ```tsx
+   import { Comark } from '@comark/react'
+   import math, { Math } from '@comark/react/plugins/math'
+   import 'katex/dist/katex.min.css'
+   ```
+
+3. Pass the plugin and component to `Comark`:
+   ```tsx
+   <Comark
+     markdown={content}
+     components={{ Math }}
+     plugins={[math()]}
+   />
+   ```
+
+4. Use math expressions in your markdown:
+   ```markdown
+   Inline: $E = mc^2$
+
+   Display:
+   $$
+   x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+   $$
+   ```
+
+## Syntax Examples
+
+**Inline Math**: Use single `$` delimiters
+```markdown
+The formula $x^2 + y^2 = z^2$ is inline.
+```
+
+**Display Math**: Use double `$$` delimiters
+```markdown
+$$
+\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}
+$$
+```
+
+**Fractions**: `\frac{numerator}{denominator}`
+```markdown
+$\frac{a}{b}$
+```
+
+**Greek Letters**: `\alpha`, `\beta`, `\gamma`, etc.
+```markdown
+$\alpha + \beta = \gamma$
+```
+
+**Subscripts & Superscripts**: `_` and `^`
+```markdown
+$x_1^2 + x_2^2$
+```
+
+## Learn More
+
+- [Math Plugin Documentation](/plugins/built-in/math)
+- [KaTeX Documentation](https://katex.org)
+- [Comark Documentation](https://comark.dev)

--- a/examples/3.plugins/react-vite-math/index.html
+++ b/examples/3.plugins/react-vite-math/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Comark + Math - React Example</title>
+    <link
+      href="/src/index.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script
+      type="module"
+      src="/src/main.tsx"
+    ></script>
+  </body>
+</html>

--- a/examples/3.plugins/react-vite-math/package.json
+++ b/examples/3.plugins/react-vite-math/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "comark-react-vite-math",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@comark/react": "workspace:*",
+    "@tailwindcss/vite": "catalog:",
+    "katex": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tailwindcss": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/examples/3.plugins/react-vite-math/src/App.tsx
+++ b/examples/3.plugins/react-vite-math/src/App.tsx
@@ -1,0 +1,56 @@
+import { ComarkClient } from '@comark/react'
+import math, { Math } from '@comark/react/plugins/math'
+import 'katex/dist/katex.min.css'
+
+const markdown = `
+# Math Formula Examples
+
+## Inline Math
+
+The famous equation $E = mc^2$ relates energy and mass.
+
+The Pythagorean theorem states that $a^2 + b^2 = c^2$.
+
+## Display Math
+
+The quadratic formula:
+
+$$
+x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}
+$$
+
+## Complex Formulas
+
+The integral:
+
+$$
+\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}
+$$
+
+Summation:
+
+$$
+\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}
+$$
+
+Matrix:
+
+$$
+\\begin{pmatrix}
+a & b \\\\
+c & d
+\\end{pmatrix}
+$$
+`
+
+export default function App() {
+  return (
+    <main className="max-w-2xl mx-auto prose">
+      <ComarkClient
+        markdown={markdown}
+        components={{ Math }}
+        plugins={[math()]}
+      />
+    </main>
+  )
+}

--- a/examples/3.plugins/react-vite-math/src/index.css
+++ b/examples/3.plugins/react-vite-math/src/index.css
@@ -1,0 +1,27 @@
+@import 'tailwindcss';
+
+body {
+  @apply bg-neutral-50 dark:bg-neutral-950 p-4 text-neutral-900 dark:text-neutral-50;
+}
+
+.prose :where(h1):not(:where(.not-prose, .not-prose *)) {
+  @apply text-3xl font-bold mb-4 mt-0;
+}
+
+.prose :where(h2):not(:where(.not-prose, .not-prose *)) {
+  @apply text-2xl font-semibold mt-8 mb-3;
+}
+
+.prose :where(p):not(:where(.not-prose, .not-prose *)) {
+  @apply mb-4 leading-relaxed;
+}
+
+.prose :where(code):not(:where(.not-prose, .not-prose *)) {
+  @apply bg-neutral-200 dark:bg-neutral-800 px-1.5 py-0.5 rounded text-sm font-mono;
+}
+
+/* KaTeX block math */
+
+.prose :where(.math.block):not(:where(.not-prose, .not-prose *)) {
+  @apply my-6 overflow-x-auto;
+}

--- a/examples/3.plugins/react-vite-math/src/main.tsx
+++ b/examples/3.plugins/react-vite-math/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(<App />)

--- a/examples/3.plugins/react-vite-math/src/vite-env.d.ts
+++ b/examples/3.plugins/react-vite-math/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/3.plugins/react-vite-math/tsconfig.json
+++ b/examples/3.plugins/react-vite-math/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/examples/3.plugins/react-vite-math/vite.config.ts
+++ b/examples/3.plugins/react-vite-math/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+})

--- a/examples/3.plugins/react-vite-mermaid/README.md
+++ b/examples/3.plugins/react-vite-mermaid/README.md
@@ -1,0 +1,75 @@
+---
+title: Mermaid diagrams
+description: Example showing how to use Comark with Mermaid diagrams in React and Vite.
+navigation:
+  icon:  i-simple-icons-mermaid
+category: Plugins
+path: /examples/plugins/react-vite-mermaid
+---
+
+::code-explorer
+---
+org: comarkdown
+repo: comark@8d0c4a8023b71e8588ee6328820a2f26f2285232
+path: examples/3.plugins/react-vite-mermaid
+defaultValue: src/App.tsx
+---
+::
+
+## Features
+
+This example demonstrates how to use Comark with Mermaid diagrams in React:
+
+- **Mermaid Plugin**: Import and configure the `mermaid` plugin to parse mermaid code blocks
+- **Mermaid Component**: Register the `Mermaid` component to render diagrams as SVG
+- **Multiple Diagram Types**: Supports flowcharts, sequence diagrams, class diagrams, and all other Mermaid diagram types
+- **Configurable**: Customize theme, width, and height via component props
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   npm install @comark/react beautiful-mermaid
+   ```
+
+2. Import the mermaid plugin and component:
+   ```tsx
+   import { Comark } from '@comark/react'
+   import mermaid, { Mermaid } from '@comark/react/plugins/mermaid'
+   ```
+
+3. Pass the plugin and component to `Comark`:
+   ```tsx
+   <Comark
+     markdown={content}
+     components={{ Mermaid }}
+     plugins={[mermaid()]}
+   />
+   ```
+
+4. Use mermaid code blocks in your markdown:
+   ````markdown
+   ```mermaid
+   graph TD
+       A[Start] --> B[End]
+   ```
+   ````
+
+## Theme Support
+
+Pass a theme via the code block info string:
+
+````markdown
+```mermaid {theme='zinc-dark'}
+sequenceDiagram
+    participant A
+    participant B
+    A->>B: Hello
+```
+````
+
+## Learn More
+
+- [Mermaid Plugin Documentation](/plugins/built-in/mermaid)
+- [Mermaid Documentation](https://mermaid.js.org)
+- [Comark Documentation](https://comark.dev)

--- a/examples/3.plugins/react-vite-mermaid/index.html
+++ b/examples/3.plugins/react-vite-mermaid/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Comark + Mermaid - React Example</title>
+    <link
+      href="/src/index.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script
+      type="module"
+      src="/src/main.tsx"
+    ></script>
+  </body>
+</html>

--- a/examples/3.plugins/react-vite-mermaid/package.json
+++ b/examples/3.plugins/react-vite-mermaid/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "comark-react-vite-mermaid",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@comark/react": "catalog:",
+    "@tailwindcss/vite": "catalog:",
+    "beautiful-mermaid": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tailwindcss": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/examples/3.plugins/react-vite-mermaid/src/App.tsx
+++ b/examples/3.plugins/react-vite-mermaid/src/App.tsx
@@ -1,0 +1,60 @@
+import { ComarkClient } from '@comark/react'
+import mermaid, { Mermaid } from '@comark/react/plugins/mermaid'
+
+const markdown = `
+# Mermaid Diagram Example
+
+## Flowchart
+
+\`\`\`mermaid
+graph TD
+    A[Start] --> B{Is it working?}
+    B -->|Yes| C[Great!]
+    B -->|No| D[Debug]
+    D --> A
+\`\`\`
+
+## Sequence Diagram
+
+\`\`\`mermaid {theme='zinc-dark'}
+sequenceDiagram
+    participant User
+    participant App
+    participant API
+    User->>App: Request data
+    App->>API: Fetch data
+    API-->>App: Return data
+    App-->>User: Display data
+\`\`\`
+
+## Class Diagram
+
+\`\`\`mermaid
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        +makeSound() void
+    }
+    class Dog {
+        +fetch() void
+    }
+    class Cat {
+        +purr() void
+    }
+    Animal <|-- Dog
+    Animal <|-- Cat
+\`\`\`
+`
+
+export default function App() {
+  return (
+    <main className="max-w-2xl mx-auto prose">
+      <ComarkClient
+        markdown={markdown}
+        components={{ Mermaid }}
+        plugins={[mermaid()]}
+      />
+    </main>
+  )
+}

--- a/examples/3.plugins/react-vite-mermaid/src/index.css
+++ b/examples/3.plugins/react-vite-mermaid/src/index.css
@@ -1,0 +1,29 @@
+@import 'tailwindcss';
+
+body {
+  @apply bg-neutral-50 dark:bg-neutral-950 p-4 text-neutral-900 dark:text-neutral-50;
+}
+
+.prose :where(h1):not(:where(.not-prose, .not-prose *)) {
+  @apply text-3xl font-bold mb-4 mt-0;
+}
+
+.prose :where(h2):not(:where(.not-prose, .not-prose *)) {
+  @apply text-2xl font-semibold mt-8 mb-3;
+}
+
+.prose :where(p):not(:where(.not-prose, .not-prose *)) {
+  @apply mb-4 leading-relaxed;
+}
+
+.prose :where(pre):not(:where(.not-prose, .not-prose *)) {
+  @apply bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-100 text-neutral-800 rounded-lg p-4 overflow-x-auto mb-4;
+}
+
+.prose :where(.mermaid):not(:where(.not-prose, .not-prose *)) {
+  @apply my-6;
+}
+
+.prose :where(.mermaid svg):not(:where(.not-prose, .not-prose *)) {
+  @apply max-w-full h-auto;
+}

--- a/examples/3.plugins/react-vite-mermaid/src/main.tsx
+++ b/examples/3.plugins/react-vite-mermaid/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(<App />)

--- a/examples/3.plugins/react-vite-mermaid/src/vite-env.d.ts
+++ b/examples/3.plugins/react-vite-mermaid/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/3.plugins/react-vite-mermaid/tsconfig.json
+++ b/examples/3.plugins/react-vite-mermaid/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/examples/3.plugins/react-vite-mermaid/vite.config.ts
+++ b/examples/3.plugins/react-vite-mermaid/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+})

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "dev:vue": "pnpm --filter comark-vue run dev",
     "dev:vue:mermaid": "pnpm --filter comark-vue-vite-mermaid run dev",
     "dev:vue:math": "pnpm --filter comark-vue-vite-math run dev",
+    "dev:react:mermaid": "pnpm --filter comark-react-vite-mermaid run dev",
+    "dev:react:math": "pnpm --filter comark-react-vite-math run dev",
     "dev:astro": "pnpm --filter comark-astro run dev",
     "dev:vitepress": "pnpm --filter comark-vitepress run dev",
     "dev:nuxt": "pnpm --filter comark-nuxt run dev",

--- a/packages/comark-react/src/components/Math.tsx
+++ b/packages/comark-react/src/components/Math.tsx
@@ -3,10 +3,10 @@ import katex from 'katex'
 
 export interface MathProps {
   content: string
-  class?: string
+  className?: string
 }
 
-export function Math({ content, class: className = '' }: MathProps) {
+export function Math({ content, className = '' }: MathProps) {
   const isInline = className.includes('inline')
   const [mathml, setMathml] = useState<string>('...')
 

--- a/packages/comark-react/src/components/Mermaid.tsx
+++ b/packages/comark-react/src/components/Mermaid.tsx
@@ -4,7 +4,7 @@ import type { ThemeNames } from 'comark/plugins/mermaid'
 
 export interface MermaidProps {
   content: string
-  class?: string
+  className?: string
   height?: string
   width?: string
   theme?: ThemeNames | DiagramColors
@@ -13,7 +13,7 @@ export interface MermaidProps {
 
 export function Mermaid({
   content,
-  class: className = '',
+  className = '',
   height = 'auto',
   width = '100%',
   theme,

--- a/packages/comark-react/src/components/Mermaid.tsx
+++ b/packages/comark-react/src/components/Mermaid.tsx
@@ -11,14 +11,7 @@ export interface MermaidProps {
   themeDark?: ThemeNames | DiagramColors
 }
 
-export function Mermaid({
-  content,
-  className = '',
-  height = 'auto',
-  width = '100%',
-  theme,
-  themeDark,
-}: MermaidProps) {
+export function Mermaid({ content, className = '', height = 'auto', width = '100%', theme, themeDark }: MermaidProps) {
   const [svgContent, setSvgContent] = useState<string>('')
   const [error, setError] = useState<string | null>(null)
   const [isDark, setIsDark] = useState(false)

--- a/packages/comark-react/test/plugin-math.test.tsx
+++ b/packages/comark-react/test/plugin-math.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { parse } from 'comark'
+import { ComarkRenderer } from '../src/components/ComarkRenderer'
+import math, { Math } from '../src/plugins/math'
+
+// `Math` derives its wrapper markup from the incoming class string, so the
+// `class` -> `className` renderer remap is observable under SSR alone —
+// `useEffect` (katex) never runs here.
+
+describe('@comark/react plugins/math — Math component', () => {
+  it('renders inline math as an inline <span class="math inline">', async () => {
+    const tree = await parse('$x^2$', { plugins: [math()] })
+    const html = renderToString(
+      <ComarkRenderer
+        tree={tree}
+        components={{ math: Math }}
+      />
+    )
+    expect(html).toContain('<span class="math inline"')
+    expect(html).not.toContain('math block')
+  })
+
+  it('renders block math as a block <div class="math block">', async () => {
+    const tree = await parse('$$E = mc^2$$', { plugins: [math()] })
+    const html = renderToString(
+      <ComarkRenderer
+        tree={tree}
+        components={{ math: Math }}
+      />
+    )
+    expect(html).toContain('<div class="math block"')
+  })
+})

--- a/packages/comark-react/test/plugin-mermaid.test.tsx
+++ b/packages/comark-react/test/plugin-mermaid.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { parse } from 'comark'
+import { ComarkRenderer } from '../src/components/ComarkRenderer'
+import mermaid, { Mermaid } from '../src/plugins/mermaid'
+
+// `Mermaid` derives its wrapper class from the incoming class string, so the
+// `class` -> `className` renderer remap is observable under SSR alone —
+// `useEffect` (beautiful-mermaid / `document`) never runs here.
+
+describe('@comark/react plugins/mermaid — Mermaid component', () => {
+  it('applies custom fence classes to the wrapper', async () => {
+    const tree = await parse('```mermaid {.custom}\ngraph TD; A-->B;\n```', { plugins: [mermaid()] })
+    const html = renderToString(
+      <ComarkRenderer
+        tree={tree}
+        components={{ mermaid: Mermaid }}
+      />
+    )
+    expect(html).toContain('mermaid')
+    expect(html).toContain('custom')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,6 +878,80 @@ importers:
         specifier: 'catalog:'
         version: 4.1.0
 
+  examples/3.plugins/react-vite-math:
+    dependencies:
+      '@comark/react':
+        specifier: workspace:*
+        version: link:../../../packages/comark-react
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      katex:
+        specifier: 'catalog:'
+        version: 0.16.47
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.3.0
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  examples/3.plugins/react-vite-mermaid:
+    dependencies:
+      '@comark/react':
+        specifier: 'catalog:'
+        version: 0.5.0(beautiful-mermaid@1.1.3)(katex@0.16.47)(react@19.2.6)(shiki@4.1.0)
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      beautiful-mermaid:
+        specifier: 'catalog:'
+        version: 1.1.3
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.3.0
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
   examples/3.plugins/vue-vite-binding:
     dependencies:
       '@comark/vue':


### PR DESCRIPTION
## Summary

resolves #273 

The core parser emits math/mermaid nodes with a `class` attribute (`math inline` / `math block`, plus any `{.custom}` fence classes), and `ComarkRenderer` remaps `class` → `className` before passing props to every component — the idiomatic React behavior applied consistently across the package. But `Math` and `Mermaid` were the only components that destructured `class`, so they always fell back to `''`: inline math always rendered as a block `<div>`, and Mermaid dropped custom fence classes.

The fix renames the prop on both components (`class` → `className`), aligning them with the renderer's contract and every other component in the package. The shared renderer remap is untouched.

Added separate SSR regression tests for each — they observe the class mismatch via `renderToString` without needing a jsdom env, since the `useEffect` that touches katex/mermaid/`document` never runs during SSR.