### PR TITLE
fix: preserve image attributes when a title is present

### DIFF
--- a/packages/comark/src/internal/stringify/handlers/img.ts
+++ b/packages/comark/src/internal/stringify/handlers/img.ts
@@ -8,5 +8,6 @@ export function img(node: ComarkElement, _state: State) {
 
   const attrsString = Object.keys(rest).length > 0 ? comarkAttributes(rest) : ''
 
-  return title ? `![${alt}](${src} "${title}")` : `![${alt}](${src})${attrsString}`
+  const link = title ? `![${alt}](${src} "${title}")` : `![${alt}](${src})`
+  return `${link}${attrsString}`
 }

--- a/packages/comark/test/img-attributes.test.ts
+++ b/packages/comark/test/img-attributes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { parse } from 'comark'
+import { renderMarkdown } from 'comark/render'
+
+async function roundTrip(src: string): Promise<string> {
+  const tree = await parse(`${src}\n`)
+  return (await renderMarkdown(tree, {})).trim()
+}
+
+describe('image: attributes are preserved alongside a title', () => {
+  it('keeps attributes when the image has no title', async () => {
+    expect(await roundTrip('![alt](img.png){width="200"}')).toBe(
+      '![alt](img.png){width="200"}',
+    )
+  })
+
+  it('keeps the title when the image has no attributes', async () => {
+    expect(await roundTrip('![alt](img.png "A title")')).toBe(
+      '![alt](img.png "A title")',
+    )
+  })
+
+  it('keeps width when the image also has a title', async () => {
+    expect(await roundTrip('![alt](img.png "A title"){width="200"}')).toBe(
+      '![alt](img.png "A title"){width="200"}',
+    )
+  })
+
+  it('keeps class and width when the image also has a title', async () => {
+    expect(
+      await roundTrip('![alt](img.png "A title"){.rounded-asymmetric width="200"}'),
+    ).toBe('![alt](img.png "A title"){.rounded-asymmetric width="200"}')
+  })
+})

--- a/packages/comark/test/img-attributes.test.ts
+++ b/packages/comark/test/img-attributes.test.ts
@@ -9,26 +9,20 @@ async function roundTrip(src: string): Promise<string> {
 
 describe('image: attributes are preserved alongside a title', () => {
   it('keeps attributes when the image has no title', async () => {
-    expect(await roundTrip('![alt](img.png){width="200"}')).toBe(
-      '![alt](img.png){width="200"}',
-    )
+    expect(await roundTrip('![alt](img.png){width="200"}')).toBe('![alt](img.png){width="200"}')
   })
 
   it('keeps the title when the image has no attributes', async () => {
-    expect(await roundTrip('![alt](img.png "A title")')).toBe(
-      '![alt](img.png "A title")',
-    )
+    expect(await roundTrip('![alt](img.png "A title")')).toBe('![alt](img.png "A title")')
   })
 
   it('keeps width when the image also has a title', async () => {
-    expect(await roundTrip('![alt](img.png "A title"){width="200"}')).toBe(
-      '![alt](img.png "A title"){width="200"}',
-    )
+    expect(await roundTrip('![alt](img.png "A title"){width="200"}')).toBe('![alt](img.png "A title"){width="200"}')
   })
 
   it('keeps class and width when the image also has a title', async () => {
-    expect(
-      await roundTrip('![alt](img.png "A title"){.rounded-asymmetric width="200"}'),
-    ).toBe('![alt](img.png "A title"){.rounded-asymmetric width="200"}')
+    expect(await roundTrip('![alt](img.png "A title"){.rounded-asymmetric width="200"}')).toBe(
+      '![alt](img.png "A title"){.rounded-asymmetric width="200"}'
+    )
   })
 })


### PR DESCRIPTION
## Summary

- Fixes image markdown stringify dropping attributes when a title is present
- `![alt](src "title"){width="200"}` now round-trips correctly instead of becoming `![alt](src "title")`
- Adds regression tests covering attributes+title and class+title cases

This supersedes #290 with the same changes, rewritten as verified (signed) commits. Author preserved as Simon Haines <sh@ines.dev>.

## Test plan

- [x] `pnpm --filter comark vitest run test/img-attributes.test.ts`
- [ ] CI green