### PR TITLE
fix(stringify): render children of inline components in inline form

### DIFF
--- a/packages/comark/src/internal/stringify/handlers/mdc.ts
+++ b/packages/comark/src/internal/stringify/handlers/mdc.ts
@@ -18,16 +18,19 @@ export async function mdc(node: ComarkElement, state: State, parent?: ComarkElem
   const attributeEntries = Object.entries(attributes)
   const hasObjectAttributes = attributeEntries.some(([, value]) => typeof value === 'object')
 
-  // Component is inline if it has text siblings in parent
-  // or is inside an inline HTML element
+  // Component is inline if it has text siblings in parent,
+  // is inside an inline HTML element or an inline-rendering ancestor
   const hasTextSiblings = parent?.some((child, index) => index > 1 && typeof child === 'string') ?? false
   const insideInlineElement = parent !== undefined && INLINE_HTML_ELEMENTS.has(String(parent[0]))
-  let inline = hasTextSiblings || insideInlineElement
+  let inline = hasTextSiblings || insideInlineElement || state.context.inline === true
 
   // if component has object attributes, it cannot be inline
   if (hasObjectAttributes) {
     inline = false
   }
+
+  // Block fences inside `:name[…]` content cannot be parsed back — keep children inline
+  const revert = inline ? state.applyContext({ inline: true }) : undefined
 
   let content = ''
   const childState = { ...state, nodeDepthInTree: (state.nodeDepthInTree || 0) + 1 }
@@ -35,6 +38,10 @@ export async function mdc(node: ComarkElement, state: State, parent?: ComarkElem
     content += await state.one(child, childState, node)
   }
   content = content.trimEnd()
+
+  if (revert) {
+    state.applyContext(revert)
+  }
 
   let attrs = attributeEntries.length > 0 ? comarkAttributes(attributes) : ''
 

--- a/packages/comark/test/inline-component-roundtrip.test.ts
+++ b/packages/comark/test/inline-component-roundtrip.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { parse } from '../src/parse'
+import { renderMarkdown } from '../src/render'
+import type { ComarkTree } from '../src'
+
+/**
+ * An inline-positioned component must render its element children in inline
+ * form too: a block `:::fence` inside `:name[…]` cannot be parsed back.
+ * Children here are kept bracket-free so these cases do not depend on the
+ * parser's nested-bracket handling.
+ */
+const tree = (...children: unknown[]): ComarkTree =>
+  ({ frontmatter: {}, meta: {}, nodes: [['p', {}, ...children]] }) as ComarkTree
+
+describe('inline component round-trip (renderMarkdown → parse)', () => {
+  it('renders element children of an inline component in inline form', async () => {
+    const t = tree('a ', ['alert', {}, ['item', { x: '1' }]], ' b')
+    const rendered = await renderMarkdown(t)
+
+    expect(rendered).toBe('a :alert[:item{x="1"}] b')
+    expect((await parse(rendered)).nodes).toEqual(t.nodes)
+  })
+
+  it('keeps text-only children inline', async () => {
+    const t = tree('a ', ['alert', {}, 'hello'], ' b')
+    const rendered = await renderMarkdown(t)
+
+    expect(rendered).toBe('a :alert[hello] b')
+    expect((await parse(rendered)).nodes).toEqual(t.nodes)
+  })
+
+  it('renders element children of a span in inline form', async () => {
+    const t = tree('a ', ['span', {}, ['item', { x: '1' }]], ' b')
+    const rendered = await renderMarkdown(t)
+
+    expect(rendered).toBe('a [:item{x="1"}] b')
+    expect((await parse(rendered)).nodes).toEqual(t.nodes)
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #302

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `mdc` handler now propagates its inline decision to children via `context.inline`, so an inline `:name[…]` never ends up containing block `:::fences`. Same mechanism the `span` branch was already relying on, just generalized.

P.S.: used Fable to help with branching the changes in their own PR and a final validation of my claims

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have run `pnpm verify` and it passes.
- [ ] I have updated the documentation accordingly.
