### PR TITLE
fix: do not include standard html tag names in heading slugs

### DIFF
--- a/docs/content/3.rendering/2.html.md
+++ b/docs/content/3.rendering/2.html.md
@@ -77,9 +77,9 @@ This is a **bold** statement with a [link](https://example.com).
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| [`plugins`](#code-render-options-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
-| [`components`](#code-render-options-code-components) | `Record<string, fn>` | `{}` | Custom component renderers |
-| [`data`](#code-render-options-code-data) | `Record<string, any>` | `undefined` | Data passed to component renderers |
+| [`plugins`](#render-options-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
+| [`components`](#render-options-components) | `Record<string, fn>` | `{}` | Custom component renderers |
+| [`data`](#render-options-data) | `Record<string, any>` | `undefined` | Data passed to component renderers |
 
 #### `plugins`
 
@@ -179,7 +179,7 @@ const html2 = await render('# Document 2\n\n...')
 
 #### Options
 
-Same as [`render()`](#code-render-options).
+Same as [`render()`](#render-options).
 
 ---
 
@@ -218,8 +218,8 @@ const html = await renderHTML(tree)
 
 | Option | Type | Description |
 | --- | --- | --- |
-| [`components`](#code-render-options-code-components) | `Record<string, fn>` | Custom component renderers |
-| [`data`](#code-render-options-code-data) | `Record<string, any>` | Data passed to component renderers |
+| [`components`](#render-options-components) | `Record<string, fn>` | Custom component renderers |
+| [`data`](#render-options-data) | `Record<string, any>` | Data passed to component renderers |
 
 ---
 

--- a/docs/content/3.rendering/3.vue.md
+++ b/docs/content/3.rendering/3.vue.md
@@ -95,15 +95,15 @@ Pass markdown content via the default slot or the `markdown` prop:
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `markdown` | `string` | `undefined` | Alternative to default slot |
-| [`options`](#code-comark-props-code-options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
-| [`plugins`](#code-comark-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
+| [`options`](#comark-props-options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
+| [`plugins`](#comark-props-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
 | `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
-| [`components`](#code-comark-props-code-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
-| [`componentsManifest`](#code-comark-props-code-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver |
+| [`components`](#comark-props-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
+| [`componentsManifest`](#comark-props-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | `summary` | `boolean` | `false` | Only render content before `<!-- more -->` |
 | [`caret`](#streaming-caret) | `boolean \| { class: string }` | `false` | Append caret to last text node |
-| [`data`](#code-comark-props-code-data) | `Record<string, unknown>` | `{}` | Runtime values referenced from markdown via `:prop="data.path"` |
+| [`data`](#comark-props-data) | `Record<string, unknown>` | `{}` | Runtime values referenced from markdown via `:prop="data.path"` |
 
 #### `options`
 
@@ -330,14 +330,14 @@ import { AppComark } from './comark'
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| [`extends`](#code-comark-code-definecomarkcomponent-code-extends) | `ReturnType<typeof defineComarkComponent>` | `undefined` | Inherit plugins and components from another component |
+| [`extends`](#comark-definecomarkcomponent-extends) | `ReturnType<typeof defineComarkComponent>` | `undefined` | Inherit plugins and components from another component |
 | `name` | `string` | `undefined` | Component name for debugging |
 | `autoUnwrap` | `boolean` | `true` | Automatically unwrap single block elements |
 | `autoClose` | `boolean` | `true` | Auto-close incomplete markdown syntax |
 | `html` | `boolean` | `true` | Parse embedded HTML tags into AST nodes |
 | `linkify` | `boolean` | `true` | Auto-convert URL-like text into links |
-| [`plugins`](#code-comark-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
-| [`components`](#code-comark-props-code-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
+| [`plugins`](#comark-props-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
+| [`components`](#comark-props-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
 | `class` | `string` | `undefined` | Additional CSS classes for the wrapper div |
 
 #### `extends`
@@ -433,11 +433,11 @@ const tree = await res.json()
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `tree` | `ComarkTree` | — | **Required.** The parsed tree returned by `parse()` |
-| [`components`](#code-comark-props-code-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
-| [`componentsManifest`](#code-comark-props-code-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver for lazy-loaded components |
+| [`components`](#comark-props-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
+| [`componentsManifest`](#comark-props-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver for lazy-loaded components |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | [`caret`](#streaming-caret) | `boolean \| { class: string }` | `false` | Append a blinking caret to the last text node |
-| [`data`](#code-comark-props-code-data) | `Record<string, unknown>` | `{}` | Runtime values referenced from markdown via `:prop="data.path"` |
+| [`data`](#comark-props-data) | `Record<string, unknown>` | `{}` | Runtime values referenced from markdown via `:prop="data.path"` |
 
 ### `defineComarkRendererComponent`
 
@@ -486,9 +486,9 @@ const tree = await res.json()
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| [`extends`](#code-comarkrenderer-code-definecomarkrenderercomponent-inheritance) | `ReturnType<typeof defineComarkRendererComponent>` | `undefined` | Inherit component mappings from another renderer |
+| [`extends`](#comarkrenderer-definecomarkrenderercomponent-inheritance) | `ReturnType<typeof defineComarkRendererComponent>` | `undefined` | Inherit component mappings from another renderer |
 | `name` | `string` | `undefined` | Component name for debugging |
-| [`components`](#code-comark-props-code-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
+| [`components`](#comark-props-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
 | `class` | `string` | `undefined` | Additional CSS classes for the wrapper div |
 
 #### Inheritance

--- a/docs/content/3.rendering/4.nuxt.md
+++ b/docs/content/3.rendering/4.nuxt.md
@@ -97,11 +97,11 @@ Pass markdown via the default slot or the `markdown` prop:
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `markdown` | `string` | `undefined` | Alternative to default slot |
-| [`options`](#code-comark-props-code-options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
-| [`plugins`](#code-comark-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
+| [`options`](#comark-props-options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
+| [`plugins`](#comark-props-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
 | `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
-| [`components`](#code-comark-props-code-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
-| [`componentsManifest`](#code-comark-props-code-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver |
+| [`components`](#comark-props-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
+| [`componentsManifest`](#comark-props-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | `summary` | `boolean` | `false` | Only render content before `<!-- more -->` |
 | [`caret`](#streaming-caret) | `boolean \| { class: string }` | `false` | Append caret to last text node |

--- a/docs/content/3.rendering/5.react.md
+++ b/docs/content/3.rendering/5.react.md
@@ -84,14 +84,14 @@ Pass markdown content via `children` or the `markdown` prop:
 |------|------|---------|-------------|
 | `children` | `React.ReactNode` | - | Markdown content to parse and render |
 | `markdown` | `string` | `''` | Alternative to children |
-| [`options`](#code-comark-props-code-options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
-| [`plugins`](#code-comark-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
+| [`options`](#comark-props-options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
+| [`plugins`](#comark-props-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
 | `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
-| [`components`](#code-comark-props-code-components) | `Record<string, ComponentType>` | `{}` | Custom React component mappings |
-| [`componentsManifest`](#code-comark-props-code-componentsmanifest) | `(name: string) => Promise<Component>` | `undefined` | Dynamic component resolver |
+| [`components`](#comark-props-components) | `Record<string, ComponentType>` | `{}` | Custom React component mappings |
+| [`componentsManifest`](#comark-props-componentsmanifest) | `(name: string) => Promise<Component>` | `undefined` | Dynamic component resolver |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | [`caret`](#streaming-caret) | `boolean \| { class: string }` | `false` | Append caret to last text node |
-| [`data`](#code-comark-props-code-data) | `Record<string, unknown>` | `undefined` | Runtime values referenced from markdown via `:prop="data.path"` |
+| [`data`](#comark-props-data) | `Record<string, unknown>` | `undefined` | Runtime values referenced from markdown via `:prop="data.path"` |
 | `className` | `string` | `undefined` | CSS class for wrapper element |
 
 #### `options`
@@ -293,14 +293,14 @@ export default function App() {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| [`extends`](#code-comark-code-definecomarkcomponent-code-extends) | `ReturnType<typeof defineComarkComponent>` | `undefined` | Inherit plugins and components from another component |
+| [`extends`](#comark-definecomarkcomponent-extends) | `ReturnType<typeof defineComarkComponent>` | `undefined` | Inherit plugins and components from another component |
 | `name` | `string` | `undefined` | Component name for debugging |
 | `autoUnwrap` | `boolean` | `true` | Automatically unwrap single block elements |
 | `autoClose` | `boolean` | `true` | Auto-close incomplete markdown syntax |
 | `html` | `boolean` | `true` | Parse embedded HTML tags into AST nodes |
 | `linkify` | `boolean` | `true` | Auto-convert URL-like text into links |
-| [`plugins`](#code-comark-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
-| [`components`](#code-comark-props-code-components) | `Record<string, ComponentType>` | `{}` | Custom React component mappings |
+| [`plugins`](#comark-props-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
+| [`components`](#comark-props-components) | `Record<string, ComponentType>` | `{}` | Custom React component mappings |
 | `className` | `string` | `undefined` | Additional CSS classes for the wrapper div |
 
 #### `extends`
@@ -401,11 +401,11 @@ export default async function DocsPage({ params }: { params: { slug: string } })
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `tree` | `ComarkTree` | — | **Required.** The parsed tree returned by `parse()` |
-| [`components`](#code-comark-props-code-components) | `Record<string, ComponentType>` | `{}` | Custom React component mappings |
-| [`componentsManifest`](#code-comark-props-code-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver for lazy-loaded components |
+| [`components`](#comark-props-components) | `Record<string, ComponentType>` | `{}` | Custom React component mappings |
+| [`componentsManifest`](#comark-props-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver for lazy-loaded components |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | [`caret`](#streaming-caret) | `boolean \| { class: string }` | `false` | Append a blinking caret to the last text node |
-| [`data`](#code-comark-props-code-data) | `Record<string, unknown>` | `undefined` | Runtime values referenced from markdown via `:prop="data.path"` |
+| [`data`](#comark-props-data) | `Record<string, unknown>` | `undefined` | Runtime values referenced from markdown via `:prop="data.path"` |
 | `className` | `string` | `undefined` | CSS class for the wrapper `<div>` |
 
 ### `defineComarkRendererComponent`
@@ -452,9 +452,9 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| [`extends`](#code-comarkrenderer-code-definecomarkrenderercomponent-inheritance) | `ReturnType<typeof defineComarkRendererComponent>` | `undefined` | Inherit component mappings from another renderer |
+| [`extends`](#comarkrenderer-definecomarkrenderercomponent-inheritance) | `ReturnType<typeof defineComarkRendererComponent>` | `undefined` | Inherit component mappings from another renderer |
 | `name` | `string` | `undefined` | Component name for debugging |
-| [`components`](#code-comark-props-code-components) | `Record<string, ComponentType>` | `{}` | Custom React component mappings |
+| [`components`](#comark-props-components) | `Record<string, ComponentType>` | `{}` | Custom React component mappings |
 | `className` | `string` | `undefined` | Additional CSS classes for the wrapper div |
 
 #### Inheritance

--- a/docs/content/3.rendering/6.svelte.md
+++ b/docs/content/3.rendering/6.svelte.md
@@ -47,7 +47,7 @@ bun add @comark/svelte
 The `<Comark>` component is the simplest way to render markdown in Svelte 5. It handles parsing and rendering automatically using `$state` and `$effect`.
 
 ::warning
-`<Comark>` uses `$effect` internally and **will not render during SSR**. For SvelteKit, parse in your `load()` function and use [`<ComarkRenderer>`](#code-comarkrenderer) instead.
+`<Comark>` uses `$effect` internally and **will not render during SSR**. For SvelteKit, parse in your `load()` function and use [`<ComarkRenderer>`](#comarkrenderer) instead.
 ::
 
 ### Usage
@@ -69,14 +69,14 @@ Pass markdown content via the `markdown` prop:
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `markdown` | `string` | `''` | Markdown content to parse and render |
-| [`options`](#code-comark-props-code-options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
-| [`plugins`](#code-comark-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
+| [`options`](#comark-props-options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
+| [`plugins`](#comark-props-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
 | `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
-| [`components`](#code-comark-props-code-components) | `Record<string, Component>` | `{}` | Custom Svelte component mappings |
-| [`componentsManifest`](#code-comark-props-code-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver |
+| [`components`](#comark-props-components) | `Record<string, Component>` | `{}` | Custom Svelte component mappings |
+| [`componentsManifest`](#comark-props-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | [`caret`](#streaming-caret) | `boolean \| { class: string }` | `false` | Append caret to last text node |
-| [`data`](#code-comark-props-code-data) | `Record<string, unknown>` | `undefined` | Runtime values referenced from markdown via `:prop="data.path"` |
+| [`data`](#comark-props-data) | `Record<string, unknown>` | `undefined` | Runtime values referenced from markdown via `:prop="data.path"` |
 | `class` | `string` | `''` | CSS class for wrapper element |
 
 #### `options`
@@ -367,11 +367,11 @@ export const load: PageLoad = async ({ params, fetch }) => {
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `tree` | `ComarkTree` | — | **Required.** The parsed tree returned by `parse()` |
-| [`components`](#code-comark-props-code-components) | `Record<string, Component>` | `{}` | Custom Svelte component mappings |
-| [`componentsManifest`](#code-comarkrenderer-code-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver for lazy-loaded components |
+| [`components`](#comark-props-components) | `Record<string, Component>` | `{}` | Custom Svelte component mappings |
+| [`componentsManifest`](#comarkrenderer-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver for lazy-loaded components |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | [`caret`](#streaming-caret) | `boolean \| { class: string }` | `false` | Append a blinking caret to the last text node |
-| [`data`](#code-comark-props-code-data) | `Record<string, unknown>` | `undefined` | Runtime values referenced from markdown via `:prop="data.path"` |
+| [`data`](#comark-props-data) | `Record<string, unknown>` | `undefined` | Runtime values referenced from markdown via `:prop="data.path"` |
 | `class` | `string` | `''` | CSS class for wrapper element |
 
 ### `componentsManifest`
@@ -395,7 +395,7 @@ For lazy-loading components on demand:
 ```
 
 ::warning
-During SSR, `<ComarkRenderer>` can only render manifest entries synchronously. Use eager/static components for SSR HTML, or use [`<ComarkAsync>`](#code-comarkasync-code-experimental) when the manifest returns dynamic imports.
+During SSR, `<ComarkRenderer>` can only render manifest entries synchronously. Use eager/static components for SSR HTML, or use [`<ComarkAsync>`](#comarkasync-experimental) when the manifest returns dynamic imports.
 ::
 
 ---

--- a/docs/content/3.rendering/7.angular.md
+++ b/docs/content/3.rendering/7.angular.md
@@ -79,14 +79,14 @@ This is **markdown** with Comark components.
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `markdown` | `string` | `''` | Markdown content to parse and render |
-| [`options`](#code-options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
-| [`plugins`](#code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
+| [`options`](#options) | `ParseOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
+| [`plugins`](#plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
 | `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
-| [`components`](#code-components) | `Record<string, Type<any>>` | `{}` | Custom Angular component mappings |
+| [`components`](#components) | `Record<string, Type<any>>` | `{}` | Custom Angular component mappings |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | `summary` | `boolean` | `false` | Only render content before `<!-- more -->` |
 | [`caret`](#caret) | `boolean \| { class: string }` | `false` | Append caret to last text node |
-| [`data`](#code-data) | `Record<string, unknown>` | `{}` | Runtime values referenced from markdown via `:prop="data.path"` |
+| [`data`](#data) | `Record<string, unknown>` | `{}` | Runtime values referenced from markdown via `:prop="data.path"` |
 
 #### `options`
 
@@ -273,10 +273,10 @@ export class DocsComponent implements OnInit {
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `tree` | `ComarkTree` | — | **Required.** The parsed tree returned by `parse()` |
-| [`components`](#code-components) | `Record<string, Type<any>>` | `{}` | Custom Angular component mappings |
+| [`components`](#components) | `Record<string, Type<any>>` | `{}` | Custom Angular component mappings |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | [`caret`](#caret) | `boolean \| { class: string }` | `false` | Append a blinking caret to the last text node |
-| [`data`](#code-data) | `Record<string, unknown>` | `{}` | Runtime values referenced from markdown via `:prop="data.path"` |
+| [`data`](#data) | `Record<string, unknown>` | `{}` | Runtime values referenced from markdown via `:prop="data.path"` |
 
 ---
 

--- a/docs/content/3.rendering/8.ansi.md
+++ b/docs/content/3.rendering/8.ansi.md
@@ -79,9 +79,9 @@ This is a bold statement with a link (https://example.com).
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| [`plugins`](#code-render-options-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
-| [`components`](#code-render-options-code-components) | `Record<string, fn>` | `{}` | Custom component renderers |
-| [`data`](#code-render-options-code-data) | `Record<string, any>` | `undefined` | Data passed to component renderers |
+| [`plugins`](#render-options-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
+| [`components`](#render-options-components) | `Record<string, fn>` | `{}` | Custom component renderers |
+| [`data`](#render-options-data) | `Record<string, any>` | `undefined` | Data passed to component renderers |
 | `colors` | `boolean` | `true`* | Emit ANSI escape codes |
 | `width` | `number` | `80` | Terminal width for HR and code block headers |
 
@@ -164,7 +164,7 @@ const out2 = await render('# Document 2\n\n...')
 
 #### Options
 
-Same as [`render()`](#code-render-options).
+Same as [`render()`](#render-options).
 
 ---
 
@@ -223,7 +223,7 @@ await log('# Document 2\n\n...')
 
 #### Options
 
-Same as [`log()`](#code-log).
+Same as [`log()`](#log).
 
 ---
 
@@ -254,8 +254,8 @@ process.stdout.write(output)
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| [`components`](#code-render-options-code-components) | `Record<string, fn>` | `{}` | Custom component renderers |
-| [`data`](#code-render-options-code-data) | `Record<string, any>` | — | Data passed to component renderers |
+| [`components`](#render-options-components) | `Record<string, fn>` | `{}` | Custom component renderers |
+| [`data`](#render-options-data) | `Record<string, any>` | — | Data passed to component renderers |
 | `colors` | `boolean` | `true`* | Emit ANSI escape codes |
 | `width` | `number` | `80` | Terminal width for HR and code block headers |
 

--- a/docs/content/4.plugins/1.built-in/headings.md
+++ b/docs/content/4.plugins/1.built-in/headings.md
@@ -60,9 +60,9 @@ The description check always looks at the node **immediately after** the title: 
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| [`titleTag`](#options-code-titletag) | `string \| false` | `'h1'` | Element tag to extract as the page title, or `false` to disable |
-| [`descriptionTag`](#options-code-descriptiontag) | `string \| false` | `'p'` | Element tag to extract as the page description, or `false` to disable |
-| [`remove`](#options-code-remove) | `boolean` | `false` | Remove extracted nodes from the tree after extraction |
+| [`titleTag`](#options-titletag) | `string \| false` | `'h1'` | Element tag to extract as the page title, or `false` to disable |
+| [`descriptionTag`](#options-descriptiontag) | `string \| false` | `'p'` | Element tag to extract as the page description, or `false` to disable |
+| [`remove`](#options-remove) | `boolean` | `false` | Remove extracted nodes from the tree after extraction |
 
 ### `titleTag`
 

--- a/docs/content/4.plugins/1.built-in/punctuation.md
+++ b/docs/content/4.plugins/1.built-in/punctuation.md
@@ -131,10 +131,10 @@ Returns a `ComarkPlugin` that applies typographic transformations to text nodes.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| [`quotes`](#options-code-quotes) | `boolean` | `true` | Convert straight quotes to smart quotes |
-| [`dashes`](#options-code-dashes) | `boolean` | `true` | Convert `--` to en-dash and `---` to em-dash |
-| [`ellipsis`](#options-code-ellipsis) | `boolean` | `true` | Convert `...` to ellipsis character |
-| [`symbols`](#options-code-symbols) | `boolean` | `true` | Convert `(c)`, `(r)`, `(tm)`, `+-` |
+| [`quotes`](#options-quotes) | `boolean` | `true` | Convert straight quotes to smart quotes |
+| [`dashes`](#options-dashes) | `boolean` | `true` | Convert `--` to en-dash and `---` to em-dash |
+| [`ellipsis`](#options-ellipsis) | `boolean` | `true` | Convert `...` to ellipsis character |
+| [`symbols`](#options-symbols) | `boolean` | `true` | Convert `(c)`, `(r)`, `(tm)`, `+-` |
 
 ### `quotes`
 

--- a/docs/content/4.plugins/1.built-in/security.md
+++ b/docs/content/4.plugins/1.built-in/security.md
@@ -137,14 +137,14 @@ Returns a `ComarkPlugin` that sanitizes the parsed AST.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| [`blockedTags`](#options-code-blockedtags) | `string[]` | `[]` | Tag names to remove entirely from the AST |
-| [`allowedTags`](#options-code-allowedtags) | `string[]` | `[]` | Tag names to allow exclusively in the AST |
-| [`tagFallback`](#options-code-tagfallback) | `function` | `false`  | Defines how to handle unallowed tags in the AST |
-| [`allowedProtocols`](#options-code-allowedprotocols) | `string[]` | `['*']` | Protocols permitted in `href` and `src` |
-| [`allowedLinkPrefixes`](#options-code-allowedlinkprefixes) | `string[]` | `['*']` | URL prefixes permitted in `href` |
-| [`allowedImagePrefixes`](#options-code-allowedimageprefixes) | `string[]` | `['*']` | URL prefixes permitted in `src` |
-| [`defaultOrigin`](#options-code-defaultorigin) | `string` | `undefined` | Rewrite disallowed URLs to this origin instead of stripping |
-| [`allowDataImages`](#options-code-allowdataimages) | `boolean` | `true` | Allow `data:image/*` URIs in `src` |
+| [`blockedTags`](#options-blockedtags) | `string[]` | `[]` | Tag names to remove entirely from the AST |
+| [`allowedTags`](#options-allowedtags) | `string[]` | `[]` | Tag names to allow exclusively in the AST |
+| [`tagFallback`](#options-tagfallback) | `function` | `false`  | Defines how to handle unallowed tags in the AST |
+| [`allowedProtocols`](#options-allowedprotocols) | `string[]` | `['*']` | Protocols permitted in `href` and `src` |
+| [`allowedLinkPrefixes`](#options-allowedlinkprefixes) | `string[]` | `['*']` | URL prefixes permitted in `href` |
+| [`allowedImagePrefixes`](#options-allowedimageprefixes) | `string[]` | `['*']` | URL prefixes permitted in `src` |
+| [`defaultOrigin`](#options-defaultorigin) | `string` | `undefined` | Rewrite disallowed URLs to this origin instead of stripping |
+| [`allowDataImages`](#options-allowdataimages) | `boolean` | `true` | Allow `data:image/*` URIs in `src` |
 
 ### `blockedTags`
 

--- a/docs/content/4.plugins/1.built-in/summary.md
+++ b/docs/content/4.plugins/1.built-in/summary.md
@@ -98,7 +98,7 @@ The extracted nodes are stored at `tree.meta.summary` as `ComarkNode[]`. If no d
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| [`delimiter`](#options-code-delimiter) | `string` | `'<!-- more -->'` | HTML comment used to split summary from full content |
+| [`delimiter`](#options-delimiter) | `string` | `'<!-- more -->'` | HTML comment used to split summary from full content |
 
 ### `delimiter`
 

--- a/docs/content/4.plugins/1.built-in/syntax-highlight.md
+++ b/docs/content/4.plugins/1.built-in/syntax-highlight.md
@@ -209,12 +209,12 @@ Returns a `ComarkPlugin` that enables Shiki syntax highlighting.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| [`themes`](#options-code-themes) | `object` | Material themes | Light and dark theme registrations |
-| [`languages`](#options-code-languages) | `LanguageRegistration[]` | `undefined` | Languages to preload |
-| [`transformers`](#options-code-transformers) | `ShikiTransformer[]` | `undefined` | Shiki transformers applied to every block |
-| [`preStyles`](#options-code-prestyles) | `boolean` | `false` | Add inline background/foreground styles to `<pre>` |
-| [`registerDefaultLanguages`](#options-code-registerdefaultlanguages) | `boolean` | `true` | Register the built-in default language set |
-| [`registerDefaultThemes`](#options-code-registerdefaultthemes) | `boolean` | `true` | Register the built-in Material themes |
+| [`themes`](#options-themes) | `object` | Material themes | Light and dark theme registrations |
+| [`languages`](#options-languages) | `LanguageRegistration[]` | `undefined` | Languages to preload |
+| [`transformers`](#options-transformers) | `ShikiTransformer[]` | `undefined` | Shiki transformers applied to every block |
+| [`preStyles`](#options-prestyles) | `boolean` | `false` | Add inline background/foreground styles to `<pre>` |
+| [`registerDefaultLanguages`](#options-registerdefaultlanguages) | `boolean` | `true` | Register the built-in default language set |
+| [`registerDefaultThemes`](#options-registerdefaultthemes) | `boolean` | `true` | Register the built-in Material themes |
 
 ### `themes`
 

--- a/docs/content/4.plugins/1.built-in/toc.md
+++ b/docs/content/4.plugins/1.built-in/toc.md
@@ -71,9 +71,9 @@ interface TocLink {
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| [`depth`](#options-code-depth) | `number` | `2` | Heading levels to include: `1` = h2 only, `2` = h2–h3, `3` = h2–h4, etc. |
-| [`searchDepth`](#options-code-searchdepth) | `number` | `2` | How deep to search for headings in nested component structures |
-| [`title`](#options-code-title) | `string` | `''` | Title field on the returned `TocTree` |
+| [`depth`](#options-depth) | `number` | `2` | Heading levels to include: `1` = h2 only, `2` = h2–h3, `3` = h2–h4, etc. |
+| [`searchDepth`](#options-searchdepth) | `number` | `2` | How deep to search for headings in nested component structures |
+| [`title`](#options-title) | `string` | `''` | Title field on the returned `TocTree` |
 
 ::tip
 All three options can also be set via frontmatter: `depth`, `searchDepth`, and `title` keys are read automatically and override the plugin options.

--- a/docs/content/4.plugins/2.custom/1.plugin-api.md
+++ b/docs/content/4.plugins/2.custom/1.plugin-api.md
@@ -22,7 +22,7 @@ Wraps a plugin factory function to provide type safety for both options and the 
 
 **Parameters:**
 
-- `factory` - A function `(options?: O) => ComarkPlugin` where `O` is an optional options type. When the plugin is instantiated, `options` receives the values passed by the caller. See [`ComarkPlugin`](#code-comarkplugin) for the full shape of the returned object.
+- `factory` - A function `(options?: O) => ComarkPlugin` where `O` is an optional options type. When the plugin is instantiated, `options` receives the values passed by the caller. See [`ComarkPlugin`](#comarkplugin) for the full shape of the returned object.
 
 **Type parameters:**
 

--- a/docs/content/5.api/0.render.md
+++ b/docs/content/5.api/0.render.md
@@ -71,11 +71,11 @@ For full type definitions, see [ComarkNode](/syntax/comark-ast#comarknode) in th
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| [`maxInlineAttributes`](#options-code-maxinlineattributes) | `number` | `3` | Maximum attributes before switching to YAML block syntax. Set to `0` to always use block syntax |
+| [`maxInlineAttributes`](#options-maxinlineattributes) | `number` | `3` | Maximum attributes before switching to YAML block syntax. Set to `0` to always use block syntax |
 | `blockAttributesStyle` | `'frontmatter' \| 'codeblock'` | `'codeblock'` | Syntax style for block attributes when they exceed `maxInlineAttributes` |
-| [`frontmatterOptions`](#options-code-frontmatteroptions) | `DumpOptions` | `{ indent: 2, lineWidth: -1 }` | js-yaml [DumpOptions](https://github.com/nodeca/js-yaml#dump-object---options-) passed to the frontmatter serializer |
-| [`components`](#options-code-components) | `Record<string, NodeHandler \| ConditionalNodeHandler>` | `{}` | Custom render handlers for specific elements |
-| [`data`](#options-code-data) | `Record<string, any>` | `{}` | Additional data passed to render handlers |
+| [`frontmatterOptions`](#options-frontmatteroptions) | `DumpOptions` | `{ indent: 2, lineWidth: -1 }` | js-yaml [DumpOptions](https://github.com/nodeca/js-yaml#dump-object---options-) passed to the frontmatter serializer |
+| [`components`](#options-components) | `Record<string, NodeHandler \| ConditionalNodeHandler>` | `{}` | Custom render handlers for specific elements |
+| [`data`](#options-data) | `Record<string, any>` | `{}` | Additional data passed to render handlers |
 
 ### `maxInlineAttributes`
 

--- a/packages/comark-svelte/test/ComarkNode.svelte.test.ts
+++ b/packages/comark-svelte/test/ComarkNode.svelte.test.ts
@@ -76,7 +76,7 @@ describe('ComarkRenderer', () => {
       level: 1,
     })
     await expect.element(heading).toBeInTheDocument()
-    await expect.element(heading).toHaveAttribute('id', 'hello-strong-world')
+    await expect.element(heading).toHaveAttribute('id', 'hello-world')
   })
 
   it('renders multiple block elements', async () => {

--- a/packages/comark-svelte/test/ComarkNode.test.ts
+++ b/packages/comark-svelte/test/ComarkNode.test.ts
@@ -139,7 +139,7 @@ describe('ComarkRenderer', () => {
     const tree = await parse('# Hello **World**')
     const { body } = render(ComarkRenderer, { props: { tree } })
     const output = html(body)
-    expect(output).toContain('<h1 id="hello-strong-world">')
+    expect(output).toContain('<h1 id="hello-world">')
     expect(output).toContain('Hello <strong>World</strong>')
     expect(output).toContain('</h1>')
     expect(output).toMatch(/^<div class="comark-content ">.*<\/div>$/)

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -635,6 +635,40 @@ function mergeAdjacentTextNodes(nodes: ComarkNode[]): ComarkNode[] {
   return merged
 }
 
+const HTML_INLINE_TAGS = new Set([
+  'a',
+  'abbr',
+  'b',
+  'bdi',
+  'bdo',
+  'cite',
+  'code',
+  'data',
+  'del',
+  'dfn',
+  'em',
+  'i',
+  'img',
+  'ins',
+  'kbd',
+  'mark',
+  'q',
+  'rp',
+  'rt',
+  'ruby',
+  's',
+  'samp',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'time',
+  'u',
+  'var',
+  'wbr',
+])
+
 /**
  * Extract text content from nodes for heading ID generation
  */
@@ -654,9 +688,11 @@ function extractTextContent(nodes: ComarkNode[]): string {
         continue
       }
 
-      // Include the tag name (e.g., "inline" from :inline component)
-      text += ' ' + tag + ' '
-      // Also include any text from children
+      // Only inline components contribute their name to the slug; standard
+      // HTML tags (emphasis, code, links, ...) contribute text content only
+      if (typeof tag === 'string' && !HTML_INLINE_TAGS.has(tag)) {
+        text += ' ' + tag + ' '
+      }
       if (children.length > 0) {
         text += extractTextContent(children)
       }

--- a/packages/comark/test/heading-ids.test.ts
+++ b/packages/comark/test/heading-ids.test.ts
@@ -28,4 +28,37 @@ describe('headingIds option', () => {
       ['h2', { id: 'section' }, 'Section'],
     ])
   })
+
+  it('deduplicates hierarchical ids with a numeric suffix', async () => {
+    const tree = await parse('## Options\n\n## Options')
+
+    const ids = tree.nodes.map((n: any) => n[1].id)
+    expect(ids).toEqual(['options', 'options-1'])
+  })
+
+  describe('slug text extraction', () => {
+    it('does not leak tag names from bold text', async () => {
+      const tree = await parse('## 1. Never let an LLM **speak** for you')
+
+      expect((tree.nodes[0] as any)[1].id).toBe('_1-never-let-an-llm-speak-for-you')
+    })
+
+    it('does not leak tag names from inline code', async () => {
+      const tree = await parse('## The `parse` function')
+
+      expect((tree.nodes[0] as any)[1].id).toBe('the-parse-function')
+    })
+
+    it('does not leak tag names from links', async () => {
+      const tree = await parse('## See [Nuxt](https://nuxt.com) docs')
+
+      expect((tree.nodes[0] as any)[1].id).toBe('see-nuxt-docs')
+    })
+
+    it('includes inline component names in the slug', async () => {
+      const tree = await parse('## Star :icon-star here')
+
+      expect((tree.nodes[0] as any)[1].id).toBe('star-icon-star-here')
+    })
+  })
 })

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "40.5k (58 files)",
         "@comark/svelte": "40.6k (66 files)",
         "@comark/vue": "57.3k (62 files)",
-        "comark": "372k (136 files)",
+        "comark": "373k (136 files)",
       }
     `)
   })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

it would surprise me if we wanted to have the names of html elements in the generated heading ids, but I might be wrong...

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have run `pnpm verify` and it passes.
- [ ] I have updated the documentation accordingly.
