### PR TITLE
fix(breaks): preserve newlines in whitespace-sensitive elements

### DIFF
--- a/packages/comark/src/plugins/breaks.ts
+++ b/packages/comark/src/plugins/breaks.ts
@@ -1,12 +1,15 @@
 import { defineComarkPlugin } from '../utils/helpers.ts'
 import { visit } from '../utils/index.ts'
 
+// Tags whose text content is whitespace-sensitive and must keep literal newlines
+const IGNORED_TAGS = new Set(['pre', 'code', 'math', 'script', 'style', 'textarea'])
+
 export default defineComarkPlugin(() => ({
   name: 'breaks',
   post(state) {
     visit(
       state.tree,
-      (node) => Array.isArray(node) && node.length > 2,
+      (node) => Array.isArray(node) && node.length > 2 && !IGNORED_TAGS.has(node[0] as string),
       (node) => {
         const parent = node as any[]
         const newParent = [parent[0], parent[1]]

--- a/packages/comark/test/breaks.test.ts
+++ b/packages/comark/test/breaks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { parse } from '../src/parse'
 import breaks from '../src/plugins/breaks'
+import math from '../src/plugins/math'
 
 describe('breaks plugin', () => {
   it('should replace all occurrences of \n with the comark :br component', async () => {
@@ -8,5 +9,22 @@ describe('breaks plugin', () => {
     const tree = await parse(md, { plugins: [breaks()] })
 
     expect(tree.nodes).toEqual([['p', {}, 'She said "hello world" to', ['br', {}], 'him.']])
+  })
+
+  it('should not replace \n inside code blocks', async () => {
+    const md = 'soft\nbreak\n\n```\nline1\nline2\n```'
+    const tree = await parse(md, { plugins: [breaks()] })
+
+    expect(tree.nodes).toEqual([
+      ['p', {}, 'soft', ['br', {}], 'break'],
+      ['pre', {}, ['code', {}, 'line1\nline2']],
+    ])
+  })
+
+  it('should not replace \n inside math blocks', async () => {
+    const md = '$$\nx = 1 \\\\\ny = 2\n$$'
+    const tree = await parse(md, { plugins: [math(), breaks()] })
+
+    expect(tree.nodes).toEqual([['math', { class: 'math block', content: 'x = 1 \\\\\ny = 2' }, 'x = 1 \\\\\ny = 2']])
   })
 })

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "40.5k (58 files)",
         "@comark/svelte": "40.6k (66 files)",
         "@comark/vue": "57.3k (62 files)",
-        "comark": "372k (136 files)",
+        "comark": "374k (136 files",
       }
     `)
   })

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "40.5k (58 files)",
         "@comark/svelte": "40.6k (66 files)",
         "@comark/vue": "57.3k (62 files)",
-        "comark": "374k (136 files",
+        "comark": "374k (136 files)",
       }
     `)
   })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #311

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In `breaks` plugin, ignored list of tags is added while walking through the child nodes.

In addition to `<pre>` and `<code>` which are related to the linked issue, `<math>`, `<script>`, `<style>`, and `<textarea>` are also in the ignorelist.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have run `pnpm verify` and it passes.
- [ ] I have updated the documentation accordingly.
