### PR TITLE
fix(syntax): stop 2+ blank lines from closing nested components early

### DIFF
--- a/packages/comark/SPEC/COMARK/component-nested-multiline-separated.md
+++ b/packages/comark/SPEC/COMARK/component-nested-multiline-separated.md
@@ -1,0 +1,213 @@
+## Input
+
+```md
+::page-section
+---
+full-width: true
+---
+  ::multi-column
+  ---
+  columns: 3
+  ---
+
+    ::container
+    ---
+    display: "flex"
+    ---
+    <svg width="10"></svg>
+    ::
+
+
+
+
+    ::container
+    ---
+    display: "flex"
+    ---
+    <svg width="10"></svg>
+    ::
+
+
+
+
+    ::container
+    ---
+    display: "flex"
+    ---
+    <svg width="10"></svg>
+    ::
+
+    ::container
+    ---
+    display: "flex"
+    ---
+    <svg width="10"></svg>
+    ::
+
+
+
+
+    ::container
+    ---
+    display: "flex"
+    ---
+    <svg width="10"></svg>
+    ::
+  ::
+::
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "page-section",
+      {
+        "full-width": "true"
+      },
+      [
+        "multi-column",
+        {
+          "columns": "3"
+        },
+        [
+          "container",
+          {
+            "display": "flex"
+          },
+          [
+            "svg",
+            {
+              "$": {
+                "block": 0,
+                "html": 1
+              },
+              "width": "10"
+            }
+          ]
+        ],
+        [
+          "container",
+          {
+            "display": "flex"
+          },
+          [
+            "svg",
+            {
+              "$": {
+                "block": 0,
+                "html": 1
+              },
+              "width": "10"
+            }
+          ]
+        ],
+        [
+          "container",
+          {
+            "display": "flex"
+          },
+          [
+            "svg",
+            {
+              "$": {
+                "block": 0,
+                "html": 1
+              },
+              "width": "10"
+            }
+          ]
+        ],
+        [
+          "container",
+          {
+            "display": "flex"
+          },
+          [
+            "svg",
+            {
+              "$": {
+                "block": 0,
+                "html": 1
+              },
+              "width": "10"
+            }
+          ]
+        ],
+        [
+          "container",
+          {
+            "display": "flex"
+          },
+          [
+            "svg",
+            {
+              "$": {
+                "block": 0,
+                "html": 1
+              },
+              "width": "10"
+            }
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<page-section full-width>
+  <multi-column columns="3">
+    <container display="flex">
+      <svg width="10"></svg>
+    </container>
+    <container display="flex">
+      <svg width="10"></svg>
+    </container>
+    <container display="flex">
+      <svg width="10"></svg>
+    </container>
+    <container display="flex">
+      <svg width="10"></svg>
+    </container>
+    <container display="flex">
+      <svg width="10"></svg>
+    </container>
+  </multi-column>
+</page-section>
+```
+
+## Markdown
+
+```md
+::page-section{full-width="true"}
+  :::multi-column{columns="3"}
+    ::::container{display="flex"}
+    <svg width="10"></svg>
+    ::::
+
+    ::::container{display="flex"}
+    <svg width="10"></svg>
+    ::::
+
+    ::::container{display="flex"}
+    <svg width="10"></svg>
+    ::::
+
+    ::::container{display="flex"}
+    <svg width="10"></svg>
+    ::::
+
+    ::::container{display="flex"}
+    <svg width="10"></svg>
+    ::::
+  :::
+::
+```

--- a/packages/comark/src/plugins/syntax.ts
+++ b/packages/comark/src/plugins/syntax.ts
@@ -99,8 +99,6 @@ const markdownItComarkBlock: PluginSimple = (md) => {
       // If there's unparsed remaining content, treat it as inline component in a paragraph
       if (remaining) return false
 
-      state.lineMax = startLine + 1
-
       if (!silent) {
         if (content !== undefined) {
           const tokenOpen = state.push('mdc_block_shorthand', name, 1)
@@ -337,7 +335,6 @@ const markdownItComarkBlock: PluginSimple = (md) => {
     }
 
     state.line = lineEnd + 1
-    state.lineMax = lineEnd + 1
     return true
   })
 
@@ -392,11 +389,12 @@ const markdownItComarkBlock: PluginSimple = (md) => {
 
     if (silent) {
       state.line = lineEnd
-      state.lineMax = lineEnd
       return true
     }
 
-    state.lineMax = startLine + 1
+    // Restore lineMax after tokenizing so it doesn't leak a narrower bound to
+    // whatever comes after this slot (see `comark_block`'s save/restore above).
+    const oldLineMax = state.lineMax
     const slot = state.push('mdc_block_slot', 'template', 1)
     slot.attrSet(`#${name}`, '')
     props?.forEach(([key, value]) => {
@@ -412,7 +410,7 @@ const markdownItComarkBlock: PluginSimple = (md) => {
     state.push('mdc_block_slot', 'template', -1)
 
     state.line = lineEnd
-    state.lineMax = lineEnd
+    state.lineMax = oldLineMax
 
     return true
   })

--- a/packages/comark/test/nested-component-blank-lines.test.ts
+++ b/packages/comark/test/nested-component-blank-lines.test.ts
@@ -24,13 +24,7 @@ describe('nested component with a run of blank lines between siblings', () => {
       [
         'outer',
         {},
-        [
-          'mid',
-          { columns: '3' },
-          ['a', { display: 'flex' }],
-          ['b', { display: 'flex' }],
-          ['c', { display: 'flex' }],
-        ],
+        ['mid', { columns: '3' }, ['a', { display: 'flex' }], ['b', { display: 'flex' }], ['c', { display: 'flex' }]],
       ],
     ]
 
@@ -92,7 +86,10 @@ describe('nested component with a run of blank lines between siblings', () => {
     it('still terminates at the parent close after a blank run (no over-absorption)', async () => {
       const src = '::outer\n  #title\n  Hello\n\n\n  ::\nafter\n::'
       const tree = await parse(src)
-      expect(tree.nodes).toEqual([['outer', {}, ['template', { name: 'title' }, 'Hello']], ['p', {}, 'after']])
+      expect(tree.nodes).toEqual([
+        ['outer', {}, ['template', { name: 'title' }, 'Hello']],
+        ['p', {}, 'after'],
+      ])
     })
   })
 })

--- a/packages/comark/test/nested-component-blank-lines.test.ts
+++ b/packages/comark/test/nested-component-blank-lines.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { parse } from '../src/parse'
+
+// Regression tests for https://github.com/comarkdown/comark/issues/322
+//
+// `comark_block_yaml`, `comark_block_shorthand`, and `comark_block_slots` each
+// narrowed `state.lineMax` after matching and never restored it, unlike
+// `comark_block`. Since `skipEmptyLines` is bounded by `state.lineMax`, a
+// *second* consecutive blank line inside a nested component fell through it
+// unskipped, then failed the tokenizer's indent check: `comark_block_yaml`/
+// `comark_block_shorthand` broke out of the loop and dropped every later
+// sibling; `comark_block_slots` emitted a spurious empty paragraph instead.
+//
+// The fixes restore (or stop touching) `state.lineMax` so a blank-line run of
+// any length is treated as a single separator, as in CommonMark.
+describe('nested component with a run of blank lines between siblings', () => {
+  describe('YAML props fence (`---`/`---`)', () => {
+    const build = (blanks: number) =>
+      `::outer\n  ::mid\n  ---\n  columns: 3\n  ---\n${['A', 'B', 'C']
+        .map((name) => `    ::${name}\n    ---\n    display: "flex"\n    ---\n    ::`)
+        .join('\n' + '\n'.repeat(blanks))}\n  ::\n::`
+
+    const expected = [
+      [
+        'outer',
+        {},
+        [
+          'mid',
+          { columns: '3' },
+          ['a', { display: 'flex' }],
+          ['b', { display: 'flex' }],
+          ['c', { display: 'flex' }],
+        ],
+      ],
+    ]
+
+    it.each([1, 2, 3, 7])('keeps every sibling with %i consecutive blank line(s) between them', async (blanks) => {
+      const tree = await parse(build(blanks))
+      expect(tree.nodes).toEqual(expected)
+    })
+
+    it('still closes the enclosing component at its own marker after a blank run (no over-absorption)', async () => {
+      // `mid` must still close at its own `::`, not swallow `after` too.
+      const src = '::outer\n  ::mid\n  ---\n  columns: 3\n  ---\n    ::A\n    ::\n\n\n  ::\nafter\n::'
+      const tree = await parse(src)
+      expect(tree.nodes).toEqual([['outer', {}, ['mid', { columns: '3' }, ['a', {}]], ['p', {}, 'after']]])
+    })
+  })
+
+  describe('shorthand block (`:name[content]`)', () => {
+    const build = (blanks: number) =>
+      `::outer\n  :leaf1[hi]\n${'\n'.repeat(blanks)}  ::leaf2\n  ::\n${'\n'.repeat(blanks)}  ::leaf3\n  ::\n::`
+
+    const expected = [['outer', {}, ['leaf1', {}, 'hi'], ['leaf2', {}], ['leaf3', {}]]]
+
+    it.each([1, 2, 3, 7])('keeps every sibling with %i consecutive blank line(s) after it', async (blanks) => {
+      const tree = await parse(build(blanks))
+      expect(tree.nodes).toEqual(expected)
+    })
+
+    it('still closes the enclosing component at its own marker after a blank run (no over-absorption)', async () => {
+      const src = '::outer\n  :leaf1[hi]\n\n\nafter\n::'
+      const tree = await parse(src)
+      expect(tree.nodes).toEqual([['outer', {}, ['leaf1', {}, 'hi'], ['p', {}, 'after']]])
+    })
+  })
+
+  describe('template slot (`#slotname`)', () => {
+    const build = (blanks: number) =>
+      `::outer\n  #title\n  Hello\n  ::childA\n  ::\n${'\n'.repeat(blanks)}  ::childB\n  ::\n::`
+
+    const expected = [
+      ['outer', {}, ['template', { name: 'title' }, ['p', {}, 'Hello'], ['child-a', {}], ['child-b', {}]]],
+    ]
+
+    it.each([1, 2, 3, 7])(
+      'keeps every sibling with %i consecutive blank line(s) between them, with no spurious paragraph token',
+      async (blanks) => {
+        const tree = await parse(build(blanks))
+        expect(tree.nodes).toEqual(expected)
+      }
+    )
+
+    it('still terminates at the next `#slot` marker regardless of a preceding blank run', async () => {
+      const src = '::outer\n  #title\n  Hello\n\n\n  #footer\n  Bye\n  ::\n::'
+      const tree = await parse(src)
+      expect(tree.nodes).toEqual([
+        ['outer', {}, ['template', { name: 'title' }, 'Hello'], ['template', { name: 'footer' }, 'Bye']],
+      ])
+    })
+
+    it('still terminates at the parent close after a blank run (no over-absorption)', async () => {
+      const src = '::outer\n  #title\n  Hello\n\n\n  ::\nafter\n::'
+      const tree = await parse(src)
+      expect(tree.nodes).toEqual([['outer', {}, ['template', { name: 'title' }, 'Hello']], ['p', {}, 'after']])
+    })
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#322 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A run of 2+ consecutive blank lines inside a nested `::component` body silently dropped every sibling after the blank run (or, for `#slotname` slots, emitted a spurious empty paragraph).

Root cause: `comark_block_yaml`, `comark_block_shorthand`, and `comark_block_slots` narrowed `state.lineMax` after matching but never restored it, unlike `comark_block`. Since `skipEmptyLines` is bounded by `state.lineMax`, the second blank line in a run fell through unskipped and broke the tokenizer's indent check.

- `comark_block_yaml` / `comark_block_shorthand`: removed the stray `lineMax` narrowing (neither rule recurses, so it served no purpose).
- `comark_block_slots`: save/restore `lineMax` around its recursive tokenize call, matching the existing pattern in `comark_block`.
- Verified auto-close/streaming interaction still works with the fix

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have run `pnpm verify` and it passes.
- [ ] I have updated the documentation accordingly.

---

> [!NOTE]
> 2 pre-existing, unrelated failures in `test/inline-component-roundtrip.test.ts` (single-char attribute names, e.g. `x`, get dropped from inline components).