### PR TITLE
refactor: migrate remaining Comark 0.6 rename leftovers in examples/docs

### DIFF
--- a/docs/app/components/landing/HeroDemo.vue
+++ b/docs/app/components/landing/HeroDemo.vue
@@ -35,7 +35,7 @@ const sourceAsCode = computed(() => ['```md', props.demoMarkdown, '```'].join('\
         <div class="shiki-source h-[280px] overflow-y-auto overflow-x-hidden p-4 md:h-[400px]">
           <ComarkDocs
             class="font-mono text-sm/6"
-            :markdown="sourceAsCode"
+            :value="sourceAsCode"
             :components="{ ProsePre: 'pre' }"
           />
         </div>

--- a/examples/1.frameworks/astro/package.json
+++ b/examples/1.frameworks/astro/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@astrojs/react": "catalog:",
+    "@comark/react": "workspace:*",
     "@tailwindcss/vite": "catalog:",
     "astro": "catalog:",
     "comark": "workspace:*",

--- a/examples/1.frameworks/astro/src/pages/posts/[...id].astro
+++ b/examples/1.frameworks/astro/src/pages/posts/[...id].astro
@@ -1,8 +1,8 @@
 ---
 import { getCollection } from 'astro:content'
-import { parse } from 'comark'
+import { parseMarkdown } from 'comark'
 import Layout from '../../layouts/Layout.astro'
-import { MarkdownParsed } from '@comark/react'
+import { MarkdownDocument } from '@comark/react'
 import highlight from 'comark/plugins/highlight'
 import Alert from '../../components/Alert'
 
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props
-const tree = await parse(post.body!, {
+const document = await parseMarkdown(post.body!, {
   plugins: [
     highlight({
       themes: {
@@ -43,6 +43,6 @@ const tree = await parse(post.body!, {
         </div>
       </div>
     </header>
-    <MarkdownParsed value={tree} className="prose" components={{ Alert }} />
+    <MarkdownDocument value={document} className="prose" components={{ Alert }} />
   </article>
 </Layout>

--- a/examples/1.frameworks/nuxt/README.md
+++ b/examples/1.frameworks/nuxt/README.md
@@ -19,7 +19,7 @@ defaultValue: content/posts/comark-syntax.md
 ::Browser{src="https://comark-nuxt.vercel.app/blog/comark-syntax"}
 ::
 
-This example demonstrates how to use Comark Syntax with Nuxt UI. Comark Syntax automatically detects when Nuxt UI is installed and uses its components for rendering. Simply add both `comark/nuxt` and `@nuxt/ui` modules to your Nuxt config, and the `Comark` component will use Nuxt UI components automatically.
+This example demonstrates how to use Comark Syntax with Nuxt UI. Comark Syntax automatically detects when Nuxt UI is installed and uses its components for rendering. Simply add both `comark/nuxt` and `@nuxt/ui` modules to your Nuxt config, and the `Markdown` component will use Nuxt UI components automatically.
 
 ## What does `comark/nuxt` module do
 

--- a/examples/2.vite/angular/content/posts/angular-integration.md
+++ b/examples/2.vite/angular/content/posts/angular-integration.md
@@ -30,8 +30,8 @@ export async function getPost(slug: string) {
   const content = Object.entries(rawFiles)
     .find(([path]) => path.endsWith(`${slug}.md`))?.[1]
 
-  const tree = await parseMarkdown(content!, { plugins: [highlight()] })
-  return { slug, tree, ...tree.frontmatter }
+  const document = await parseMarkdown(content!, { plugins: [highlight()] })
+  return { slug, tree: document, ...document.frontmatter }
 }
 ```
 
@@ -41,7 +41,7 @@ export async function getPost(slug: string) {
   imports: [MarkdownDocument],
   template: `
     @if (post) {
-      <comark-markdown-parsed [value]="post.tree" [components]="components" />
+      <comark-markdown-document [value]="post.tree" [components]="components" />
     }
   `,
 })
@@ -54,7 +54,7 @@ Since this is a client-side SPA, `parseMarkdown()` runs in the browser. Markdown
 
 ## Custom components
 
-Pass custom components via the `components` input on `<comark-markdown-parsed>`. Each component receives props as `@Input()` values and children via `<ng-content />`:
+Pass custom components via the `components` input on `<comark-markdown-document>`. Each component receives props as `@Input()` values and children via `<ng-content />`:
 
 ```ts
 @Component({

--- a/examples/2.vite/angular/content/posts/hello-world.md
+++ b/examples/2.vite/angular/content/posts/hello-world.md
@@ -24,8 +24,8 @@ This alert is rendered using a custom Comark component mapped via the `component
 import { parseMarkdown } from 'comark'
 import { MarkdownDocument } from '@comark/angular'
 
-const tree = await parseMarkdown(markdown)
-// <comark-markdown-parsed [value]="tree" [components]="components" />
+const document = await parseMarkdown(markdown)
+// <comark-markdown-document [value]="document" [components]="components" />
 ```
 
 ::alert{type="success"}

--- a/examples/2.vite/react/README.md
+++ b/examples/2.vite/react/README.md
@@ -16,4 +16,4 @@ defaultValue: src/App.tsx
 ---
 ::
 
-This example demonstrates the simplest way to use Comark with React - use the `Comark` component and pass it markdown content. The component handles parsing and rendering automatically.
+This example demonstrates the simplest way to use Comark with React - use the `Markdown` component and pass it markdown content. The component handles parsing and rendering automatically.

--- a/examples/2.vite/svelte/README.md
+++ b/examples/2.vite/svelte/README.md
@@ -19,4 +19,4 @@ defaultValue: src/App.svelte
 ::Browser{src="https://comark-svelte.vercel.app"}
 ::
 
-This example demonstrates the simplest way to use Comark with Svelte - use the `Comark` component and pass it markdown content. The component handles parsing and rendering automatically using Svelte 5's `$state` and `$effect` runes.
+This example demonstrates the simplest way to use Comark with Svelte - use the `Markdown` component and pass it markdown content. The component handles parsing and rendering automatically using Svelte 5's `$state` and `$effect` runes.

--- a/examples/2.vite/vue/README.md
+++ b/examples/2.vite/vue/README.md
@@ -19,4 +19,4 @@ defaultValue: content/posts/comark-syntax.md
 ::Browser{src="https://comark-vue.vercel.app/#/blog/comark-syntax"}
 ::
 
-This example demonstrates the simplest way to use Comark with Vue - use the `h()` render function with the `Comark` component and pass it markdown content. The component handles parsing and rendering automatically.
+This example demonstrates the simplest way to use Comark with Vue - use the `h()` render function with the `Markdown` component and pass it markdown content. The component handles parsing and rendering automatically.

--- a/examples/3.plugins/react-vite-math/README.md
+++ b/examples/3.plugins/react-vite-math/README.md
@@ -34,12 +34,12 @@ This example demonstrates how to use Comark with LaTeX math formulas in React:
 
 2. Import the math plugin, component, and KaTeX CSS:
    ```tsx
-   import { Comark } from '@comark/react'
+   import { Markdown } from '@comark/react'
    import math, { Math } from '@comark/react/plugins/math'
    import 'katex/dist/katex.min.css'
    ```
 
-3. Pass the plugin and component to `Comark`:
+3. Pass the plugin and component to `Markdown`:
    ```tsx
    <Markdown
      value={content}

--- a/examples/3.plugins/react-vite-mermaid/README.md
+++ b/examples/3.plugins/react-vite-mermaid/README.md
@@ -34,11 +34,11 @@ This example demonstrates how to use Comark with Mermaid diagrams in React:
 
 2. Import the mermaid plugin and component:
    ```tsx
-   import { Comark } from '@comark/react'
+   import { Markdown } from '@comark/react'
    import mermaid, { Mermaid } from '@comark/react/plugins/mermaid'
    ```
 
-3. Pass the plugin and component to `Comark`:
+3. Pass the plugin and component to `Markdown`:
    ```tsx
    <Markdown
      value={content}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,6 +504,9 @@ importers:
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.1(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)
+      '@comark/react':
+        specifier: workspace:*
+        version: link:../../../packages/comark-react
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.2(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -1364,7 +1367,7 @@ importers:
         version: link:../comark
       nuxt:
         specifier: ^4.0.0
-        version: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.73.0)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(sass@1.99.0)(srvx@0.11.16)(terser@5.49.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.73.0)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(sass@1.99.0)(srvx@0.11.22)(terser@5.49.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
     devDependencies:
       '@vue/server-renderer':
         specifier: 'catalog:'
@@ -15135,7 +15138,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.6(9ce4c0fb49f772d60f206fda87dd499b)':
+  '@nuxt/nitro-server@4.4.6(9fc86c8e20f41eb057448a4a69239466)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -15152,8 +15155,8 @@ snapshots:
       impound: 1.1.5(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.131.0)(rolldown@1.1.5)(srvx@0.11.16)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.73.0)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(sass@1.99.0)(srvx@0.11.16)(terser@5.49.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
+      nitropack: 2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.131.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.73.0)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(sass@1.99.0)(srvx@0.11.22)(terser@5.49.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.8
       ohash: 2.0.11
       pathe: 2.0.3
@@ -15444,7 +15447,7 @@ snapshots:
       - vue
       - webpack
 
-  '@nuxt/vite-builder@4.4.6(4fffb992422c14e65d38c968cc714ab0)':
+  '@nuxt/vite-builder@4.4.6(8c4bbaa15bba8c2f72cb6f8d79afcba2)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.2)
@@ -15462,7 +15465,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.73.0)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(sass@1.99.0)(srvx@0.11.16)(terser@5.49.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.73.0)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(sass@1.99.0)(srvx@0.11.22)(terser@5.49.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.8
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -21464,7 +21467,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.131.0)(rolldown@1.1.5)(srvx@0.11.16)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)):
+  nitropack@2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.131.0)(rolldown@1.1.5)(srvx@0.11.22)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
@@ -21502,7 +21505,7 @@ snapshots:
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
-      listhen: 1.10.0(srvx@0.11.16)
+      listhen: 1.10.0(srvx@0.11.22)
       magic-string: 0.30.21
       magicast: 0.5.3
       mime: 4.1.0
@@ -22019,16 +22022,16 @@ snapshots:
       - uploadthing
       - vue
 
-  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.73.0)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(sass@1.99.0)(srvx@0.11.16)(terser@5.49.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.73.0)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(sass@1.99.0)(srvx@0.11.22)(terser@5.49.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@5.9.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.6(9ce4c0fb49f772d60f206fda87dd499b)
+      '@nuxt/nitro-server': 4.4.6(9fc86c8e20f41eb057448a4a69239466)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.6(4fffb992422c14e65d38c968cc714ab0)
+      '@nuxt/vite-builder': 4.4.6(8c4bbaa15bba8c2f72cb6f8d79afcba2)
       '@unhead/vue': 2.1.15(vue@3.5.39(typescript@5.9.3))
       '@vue/shared': 3.5.35
       chokidar: 5.0.0


### PR DESCRIPTION
## Summary
- Migrate the Astro framework example off removed 0.6 APIs (`parse` → `parseMarkdown`, `MarkdownParsed` → `MarkdownDocument`) and add the missing `@comark/react` dependency.
- Fix docs HeroDemo still passing the removed `:markdown` prop; use `:value`.
- Update example READMEs and Angular sample markdown that still referenced `Comark` / `comark-markdown-parsed`.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Grep confirms no remaining removed symbols (`MarkdownParsed`, `import { parse }`, `:markdown=`, `comark-markdown-parsed`, `import { Comark`) in examples/docs app code
- [ ] Smoke Astro blog post page renders with `MarkdownDocument`