### PR TITLE
feat(parse): add perf option to time the parse pipeline

### DIFF
--- a/docs/content/5.api/1.parse.md
+++ b/docs/content/5.api/1.parse.md
@@ -365,6 +365,34 @@ Both `parseMarkdown()` and `createMarkdownParser()` accept the same `ParserOptio
 | `headingIds` | `boolean` | `true` | Auto-generate `id` attributes for `h1`–`h6` headings. Set `false` to disable |
 | `registerDefaultPlugins` | `boolean` | `true` | Register the built-in default plugins (`frontmatter`, `html`, `alert`, `task-list`, `components`, `attributes`). Set `false` to disable. Also can be used to configure default plugins like `components` in conjunction with `plugins` |
 | `plugins` | `ComarkPlugin[]` | `[]` | Array of plugins to apply |
+| `perf` | `ComarkPerf` | `undefined` | Timing recorder for the parse pipeline — see [Timing the parse](#timing-the-parse) |
+
+### Timing the parse
+
+Pass a `perf` recorder to time each phase of the pipeline and every plugin hook, so you can see where parse time goes (e.g. a slow `post` highlight hook). The contract is two functions — `span(name, meta?)` returning an end callback, and `measure(name, fn, meta?)`:
+
+```ts
+const spans: { name: string, duration: number }[] = []
+const perf = {
+  span: (name) => {
+    const start = performance.now()
+    return () => spans.push({ name, duration: performance.now() - start })
+  },
+  measure: (name, fn) => {
+    const end = perf.span(name)
+    try { return fn() } finally { end() }
+  },
+}
+
+const parse = createMarkdownParser({ perf, plugins: [highlight()] })
+await parse(markdown)
+// spans → comark:autoclose, comark:pre:frontmatter, comark:tokenize,
+//         comark:nodes, comark:post:alert, comark:post:highlight, ...
+```
+
+Recorded spans: `comark:autoclose`, `comark:tokenize` (markdown parsing), `comark:nodes` (token → AST conversion and unwrapping), and `comark:pre:<name>` / `comark:post:<name>` for each plugin hook.
+
+The contract is structurally compatible with `content.perf` from [Comark Content](https://content.comark.dev), so in a content app you can pass the same recorder and comark spans show up directly in its debug timelines. There is no timing overhead when `perf` is omitted, and no Node-specific API is used — it works in the browser too.
 
 ### Inline rendering
 

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -5,6 +5,7 @@ import type {
   MarkdownExitPlugin,
   MergePluginFrontmatter,
   MergePluginMeta,
+  ComarkPerf,
   ParserOptions,
   ResolvedFrontmatter,
   ResolvedMeta,
@@ -30,6 +31,12 @@ export { parseFrontmatter } from './internal/frontmatter.ts'
 
 // Re-export plugin utilities
 export { defineComarkPlugin } from './utils/helpers.ts'
+
+/** No-op recorder used when no `perf` option is provided — zero overhead. */
+const noopPerf: ComarkPerf = {
+  span: () => () => {},
+  measure: (_name, fn) => fn(),
+}
 
 /**
  * Creates a parser function for Comark content.
@@ -62,7 +69,7 @@ export { defineComarkPlugin } from './utils/helpers.ts'
 export function createMarkdownParser<const TPlugins extends readonly ComarkPlugin<any, any>[] = []>(
   options: ParserOptions<TPlugins> = {} as ParserOptions<TPlugins>
 ): ComarkParseFn<ResolvedMeta<MergePluginMeta<TPlugins>>, ResolvedFrontmatter<MergePluginFrontmatter<TPlugins>>> {
-  const { autoUnwrap = true, autoClose = true } = options
+  const { autoUnwrap = true, autoClose = true, perf = noopPerf } = options
   // Tag set to strip from the top level of the tree (MDC `unwrap`). Resolved once.
   const unwrapTags = resolveUnwrapTags(options.unwrap)
 
@@ -131,18 +138,21 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
     }
 
     if (autoClose) {
-      state.markdown = autoCloseMarkdown(state.markdown, {
-        frontmatter: hasPlugin('frontmatter') && opts.streaming,
-        syntax: hasPlugin('components'),
-      })
+      state.markdown = perf.measure('comark:autoclose', () =>
+        autoCloseMarkdown(state.markdown, {
+          frontmatter: hasPlugin('frontmatter') && opts.streaming,
+          syntax: hasPlugin('components'),
+        })
+      )
     }
 
     for (const plugin of plugins) {
-      await plugin.pre?.(state)
+      if (!plugin.pre) continue
+      await perf.measure(`comark:pre:${plugin.name}`, () => plugin.pre!(state))
     }
 
     try {
-      state.tokens = parser.parse(state.markdown, {})
+      state.tokens = perf.measure('comark:tokenize', () => parser.parse(state.markdown, {}))
     } catch (e) {
       // in case of streaming, return the previous output if parsing fails
       // This is to avoid resetting the tree to an empty state on failure
@@ -154,6 +164,7 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
     }
 
     // Convert tokens to Comark structure
+    const endNodes = perf.span('comark:nodes')
     let nodes = marmdownItTokensToMarkdownDocument(state.tokens, {
       startLine: state.parsedLines,
       preservePositions: opts.streaming ?? false,
@@ -167,6 +178,7 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
     if (unwrapTags.length > 0) {
       nodes = applyUnwrap(nodes, unwrapTags)
     }
+    endNodes()
 
     const frontmatterData = (state.frontmatter ?? {}) as Record<string, any>
     const frontmatterText = (state.frontmatterText ?? '') as string
@@ -192,7 +204,8 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
     }
 
     for (const plugin of plugins) {
-      await plugin.post?.(state as ComarkParsePostState)
+      if (!plugin.post) continue
+      await perf.measure(`comark:post:${plugin.name}`, () => plugin.post!(state as ComarkParsePostState))
     }
 
     return state.tree

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -299,6 +299,22 @@ export type ComarkParsePostState<TMeta = Record<string, any>, TFrontmatter = Rec
 }
 
 /**
+ * Minimal timing recorder contract used to instrument the parse pipeline.
+ *
+ * Structurally compatible with richer recorders (e.g. `content.perf` from
+ * `comark-content`), so the same instance can be shared across the whole
+ * content lifecycle: pass it via {@link ParserOptions.perf} and every parse
+ * phase and plugin hook records a span into it. Universal by design — no
+ * Node-specific APIs — so it works in the browser too.
+ */
+export interface ComarkPerf {
+  /** Start a span; call the returned function to end and record it. */
+  span(name: string, meta?: Record<string, unknown>): () => void
+  /** Time a sync or async function as a single span. */
+  measure<T>(name: string, fn: () => T, meta?: Record<string, unknown>): T
+}
+
+/**
  * A Comark plugin.
  *
  * `TMeta` / `TFrontmatter` are phantom type parameters that record what this
@@ -452,6 +468,19 @@ export interface ParserOptions<TPlugins extends readonly ComarkPlugin<any, any>[
    * @default []
    */
   plugins?: TPlugins
+
+  /**
+   * Timing recorder for the parse pipeline — see {@link ComarkPerf}. When
+   * provided, each parse phase (`comark:autoclose`, `comark:tokenize`,
+   * `comark:nodes`) and every plugin hook (`comark:pre:<name>`,
+   * `comark:post:<name>`) records a span into it, so bottlenecks (e.g. a slow
+   * `post` highlight hook) become visible. Pass `content.perf` from
+   * `comark-content` to get comark spans in its debug timelines, or any object
+   * implementing the {@link ComarkPerf} contract. No timing overhead when
+   * omitted.
+   * @default undefined
+   */
+  perf?: ComarkPerf
 }
 
 /**

--- a/packages/comark/test/perf.test.ts
+++ b/packages/comark/test/perf.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { createMarkdownParser } from '../src/parse'
+import type { ComarkPerf } from '../src/types'
+
+interface RecordedSpan {
+  name: string
+  meta?: Record<string, unknown>
+}
+
+/** Minimal recorder capturing span names in completion order. */
+function createRecorder() {
+  const spans: RecordedSpan[] = []
+  const perf: ComarkPerf = {
+    span: (name, meta) => () => {
+      spans.push({ name, meta })
+    },
+    measure: (name, fn, meta) => {
+      const result = fn()
+      if (result instanceof Promise) {
+        return result.finally(() => spans.push({ name, meta })) as typeof result
+      }
+      spans.push({ name, meta })
+      return result
+    },
+  }
+  return { perf, spans }
+}
+
+const markdown = `---
+title: Hello
+---
+
+# Hello **world**
+
+::alert
+hi
+::
+`
+
+describe('ParserOptions.perf', () => {
+  it('records phase and per-plugin spans in pipeline order', async () => {
+    const { perf, spans } = createRecorder()
+    const parse = createMarkdownParser({ perf })
+    const tree = await parse(markdown)
+
+    expect(tree.frontmatter).toEqual({ title: 'Hello' })
+
+    const names = spans.map((span) => span.name)
+    expect(names).toContain('comark:autoclose')
+    expect(names).toContain('comark:tokenize')
+    expect(names).toContain('comark:nodes')
+    // Default plugins with hooks record under their own name.
+    expect(names).toContain('comark:pre:frontmatter')
+
+    // Phases come in pipeline order: autoclose → pre hooks → tokenize → nodes → post hooks.
+    const order = ['comark:autoclose', 'comark:pre:frontmatter', 'comark:tokenize', 'comark:nodes']
+    const indexes = order.map((name) => names.indexOf(name))
+    expect(indexes).toEqual([...indexes].sort((a, b) => a - b))
+  })
+
+  it('records user plugin pre/post hooks under their plugin name', async () => {
+    const { perf, spans } = createRecorder()
+    const parse = createMarkdownParser({
+      perf,
+      plugins: [
+        {
+          name: 'my-plugin',
+          pre: () => {},
+          post: () => {},
+        },
+      ],
+    })
+    await parse(markdown)
+
+    const names = spans.map((span) => span.name)
+    expect(names).toContain('comark:pre:my-plugin')
+    expect(names).toContain('comark:post:my-plugin')
+  })
+
+  it('produces identical output with and without perf', async () => {
+    const { perf } = createRecorder()
+    const withPerf = await createMarkdownParser({ perf })(markdown)
+    const withoutPerf = await createMarkdownParser()(markdown)
+    expect(withPerf).toEqual(withoutPerf)
+  })
+
+  it('records spans on the streaming path too', async () => {
+    const { perf, spans } = createRecorder()
+    const parse = createMarkdownParser({ perf })
+    await parse('# Hello', { streaming: true })
+    await parse('# Hello\n\nmore **text', { streaming: true })
+
+    expect(spans.filter((span) => span.name === 'comark:tokenize').length).toBe(2)
+  })
+})

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "42.6k (64 files)",
         "@comark/svelte": "42.7k (72 files)",
         "@comark/vue": "59.5k (68 files)",
-        "comark": "380k (142 files)",
+        "comark": "382k (142 files)",
       }
     `)
   })


### PR DESCRIPTION
## What

Adds an injectable timing recorder to `ParserOptions` so the parse pipeline can be profiled:

```ts
const parse = createMarkdownParser({ perf, plugins: [highlight()] })
```

When `perf` is provided, these spans are recorded:

- `comark:autoclose` — `autoCloseMarkdown`
- `comark:pre:<name>` — each plugin's `pre` hook (incl. built-ins like `frontmatter`)
- `comark:tokenize` — markdown-exit parse
- `comark:nodes` — token → AST conversion + unwrapping
- `comark:post:<name>` — each plugin's `post` hook (where `highlight`/`toc`/`alert` do their work — usually the actual bottleneck)

## Design

The `ComarkPerf` contract is two functions (`span`, `measure`), **structural** and **universal**:

- No Node-specific APIs (no `diagnostics_channel`) — works in the browser, where comark's streaming rendering runs.
- Structurally compatible with `content.perf` from `comark-content`, so a content app passes one recorder and comark spans appear directly in its debug timelines (see comarkdown/comark-content#99, which consumes this via the pkg.pr.new build until this is released as 0.6.x).
- No-op with zero overhead when omitted (shared frozen no-op, no conditionals at call sites).

## Testing

- `packages/comark/test/perf.test.ts`: span names/order, per-plugin naming for user plugins, identical output with/without `perf`, streaming path.
- Full `comark` package suite passes locally (one pre-existing flaky timeout in `index.test.ts` under load, unrelated; `main` shows similar local flakes).
- Docs: new "Timing the parse" section on the parse API page.