### PR TITLE
docs: use shiki() instead of deprecated highlight() alias

### DIFF
--- a/docs/content/3.rendering/8.ansi.md
+++ b/docs/content/3.rendering/8.ansi.md
@@ -221,7 +221,7 @@ import math, { Math } from '@comark/ansi/plugins/math'
 import shiki from '@comark/ansi/plugins/shiki'
 
 const write = createAnsiWriter({
-  plugins: [math(), highlight()],
+  plugins: [math(), shiki()],
   components: { Math },
   width: 120,
 })

--- a/docs/content/5.api/1.parse.md
+++ b/docs/content/5.api/1.parse.md
@@ -369,15 +369,16 @@ Both `parseMarkdown()` and `createMarkdownParser()` accept the same `ParserOptio
 
 ### Timing the parse
 
-Pass a `tracer` to time each phase of the pipeline and every plugin hook, so you can see where parse time goes (e.g. a slow `post` highlight hook). The contract is a structural subset of [OpenTelemetry](https://opentelemetry.io/docs/languages/js/instrumentation/#creating-spans) `Tracer` — `startSpan` and `startActiveSpan` — so a real OTel tracer works as-is:
+Pass a `tracer` to time each phase of the pipeline and every plugin hook, so you can see where parse time goes (e.g. a slow `post` shiki hook). The contract is a structural subset of [OpenTelemetry](https://opentelemetry.io/docs/languages/js/instrumentation/#creating-spans) `Tracer` — `startSpan` and `startActiveSpan` — so a real OTel tracer works as-is:
 
 ```ts
 import { trace } from '@opentelemetry/api'
+import shiki from 'comark/plugins/shiki'
 
 const parse = createMarkdownParser({
   // Uses the OpenTelemetry provider registered by your app or hosting platform.
   tracer: trace.getTracer('comark'),
-  plugins: [highlight()],
+  plugins: [shiki()],
 })
 ```
 
@@ -406,7 +407,7 @@ const tracer = {
   },
 }
 
-const parse = createMarkdownParser({ tracer, plugins: [highlight()] })
+const parse = createMarkdownParser({ tracer, plugins: [shiki()] })
 await parse(markdown)
 // spans → comark:parse
 //           ├─ comark:autoclose
@@ -414,7 +415,7 @@ await parse(markdown)
 //           ├─ comark:tokenize
 //           ├─ comark:nodes
 //           ├─ comark:post:alert
-//           └─ comark:post:highlight
+//           └─ comark:post:shiki
 //           …
 ```
 

--- a/docs/content/5.api/3.reference.md
+++ b/docs/content/5.api/3.reference.md
@@ -214,7 +214,7 @@ Parses and renders markdown in one async step.
 ```
 
 ```html [Angular]
-<comark-markdown [value]="content" [plugins]="[highlight()]" [components]="{ alert: Alert }" />
+<comark-markdown [value]="content" [plugins]="[shiki()]" [components]="{ alert: Alert }" />
 ```
 ::
 

--- a/docs/content/7.kb/2.migration-from-mdc.md
+++ b/docs/content/7.kb/2.migration-from-mdc.md
@@ -681,7 +681,7 @@ These features may be added in a future release. If your project relies on bindi
 | Excerpt | `result.excerpt` (built-in) | `document.meta.summary` (summary plugin) |
 | Renderer | `<MDCRenderer :body :data>` | `<MarkdownDocument :value>` |
 | All-in-one | `<MDC :value>` | `<Markdown :value>` |
-| Highlight | `mdc.highlight` in nuxt.config | `highlight()` plugin in `defineMarkdownComponent` |
+| Highlight | `mdc.highlight` in nuxt.config | `shiki()` plugin in `defineMarkdownComponent` |
 | Prose components | `components/prose/Prose*.vue` | `components/prose/Prose*.vue` |
 | Render slot | `<MDCSlot />` | `<slot />` |
 | Unwrap slot | `<MDCSlot unwrap="p" />` or `<slot mdc-unwrap="p" />` | `<slot unwrap="p" />` |

--- a/docs/skills/migrate-mdc-to-comark/SKILL.md
+++ b/docs/skills/migrate-mdc-to-comark/SKILL.md
@@ -72,7 +72,7 @@ The `unified`/`remark`/`rehype` pipeline is replaced by Comark's own lighter plu
 
 | Feature | Before | After |
 |---|---|---|
-| Syntax highlighting | `rehypeHighlight` via `createMarkdownParser` | `highlight()` from `comark/plugins/shiki` |
+| Syntax highlighting | `rehypeHighlight` via `createMarkdownParser` | `shiki()` from `comark/plugins/shiki` |
 | Table of Contents | `parseMarkdown(md, { toc: { depth: 3 } })` | `toc({ depth: 3 })` plugin |
 | Excerpt / Summary | `result.excerpt` (built-in) | `summary()` plugin → `document.meta.summary` |
 | Emoji | `remark-emoji` (enabled by default) | `emoji()` plugin (opt-in) |

--- a/examples/1.frameworks/astro/src/pages/posts/[...id].astro
+++ b/examples/1.frameworks/astro/src/pages/posts/[...id].astro
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content'
 import { parseMarkdown } from 'comark'
 import Layout from '../../layouts/Layout.astro'
 import { MarkdownDocument } from '@comark/react'
-import highlight from 'comark/plugins/highlight'
+import shiki from 'comark/plugins/shiki'
 import Alert from '../../components/Alert'
 
 export async function getStaticPaths() {
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
 const { post } = Astro.props
 const document = await parseMarkdown(post.body!, {
   plugins: [
-    highlight({
+    shiki({
       themes: {
         light: 'github-light',
         dark: 'github-dark',

--- a/examples/2.vite/svelte/src/pages/Syntax.svelte
+++ b/examples/2.vite/svelte/src/pages/Syntax.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Markdown } from '@comark/svelte'
-  import highlight from '@comark/svelte/plugins/highlight'
+  import shiki from '@comark/svelte/plugins/shiki'
   import Alert from '../components/Alert.svelte'
   import python from '@shikijs/langs/python'
 
@@ -174,7 +174,7 @@ Text before the comment and text after the comment both render normally.
 
 <Markdown
   {markdown}
-  plugins={[highlight({ languages: [python] })]}
+  plugins={[shiki({ languages: [python] })]}
   components={{ Alert }}
   {componentsManifest}
 />


### PR DESCRIPTION
## What

Replace leftover `highlight()` usages with `shiki()` across docs and examples after importing from `plugins/shiki`.

## Why

`highlight` is a deprecated alias of the shiki plugin. Docs and examples should show the canonical `shiki()` API.