### PR TITLE
chore: simplify pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,32 +1,17 @@
-<!---
-☝️ PR title should follow conventional commits (https://conventionalcommits.org)
+### What
+
+<!-- What this pull request accomplishes -->
+
+### Why
+
+<!-- Why these changes are necessary -->
+
+<!--
+
+AGENTS:
+- The What and Why should each be 1-3 sentences.
+- Write your answers based off of your conversation with the user, not purely based on the changed code
+  - It's helpful to understand the reasoning behind an approach, what alternatives were considered, and why this approach was ultimately selected, rather than a summary of the lines changed
+- For complex changes (>1k lines, not counting lockfiles):
+  - Add a `### Walkthrough` section to the end which breaks down the primary changes into easy-to-follow `#### Sub-Sections`
 -->
-
-### 🔗 Linked issue
-
-<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
-
-### ❓ Type of change
-
-<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
-
-- [ ] 📖 Documentation (updates to the documentation or readme)
-- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
-- [ ] 👌 Enhancement (improving an existing functionality like performance)
-- [ ] ✨ New feature (a non-breaking change that adds functionality)
-- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
-
-### 📚 Description
-
-<!-- Describe your changes in detail -->
-<!-- Why is this change required? What problem does it solve? -->
-
-### 📝 Checklist
-
-<!-- Put an `x` in all the boxes that apply. -->
-<!-- If your change requires a documentation PR, please link it appropriately -->
-<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-
-- [ ] I have linked an issue or discussion.
-- [ ] I have run `pnpm verify` and it passes.
-- [ ] I have updated the documentation accordingly.


### PR DESCRIPTION
### What

Simplifies the GitHub pull request template to a short What/Why structure, and adds guidance for agent-authored PR descriptions.

### Why

The previous template leaned on checklists and change-type boxes that were easy to skip or fill mechanically. A lighter What/Why format should produce clearer PR intent, with explicit notes for agents on tone, depth, and walkthroughs for large changes.