### PR TITLE
docs: position Comark as a Markdown library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,15 @@ This document provides guidance for AI agents working on the comark monorepo.
 
 ## Project Overview
 
-This is a **monorepo** containing multiple packages related to Comark (Components in Markdown) syntax parsing. The main package is `comark`.
+This is a **monorepo** containing the Comark Markdown parser, document model, plugins, and renderers. The main package is `comark`.
 
-**comark** is a Components in Markdown (Comark) parser that extends standard Markdown with component syntax. It provides:
+**comark** is a JavaScript library for parsing CommonMark and GFM into a compact, serializable document that can be rendered to HTML, ANSI, Vue, React, Svelte, or Angular. It provides:
 
-- Fast synchronous and async parsing via markdown-it
+- Fast synchronous and async parsing via markdown-exit, a TypeScript rewrite of markdown-it
+- CommonMark and GitHub Flavored Markdown support
 - Streaming support for real-time/incremental parsing
-- Vue, React, Svelte and Angular renderers
+- HTML, ANSI, Vue, React, Svelte and Angular renderers
+- Component and attribute syntax plus an extensible plugin system
 - Syntax highlighting via Shiki
 - Auto-close utilities for incomplete markdown (useful for AI streaming)
 

--- a/docs/app/app.config.ts
+++ b/docs/app/app.config.ts
@@ -2,7 +2,7 @@ export default defineAppConfig({
   seo: {
     title: 'Comark',
     description:
-      'The Markdown engine for the modern web. One parser, every renderer: Vue, React, Svelte, Angular, HTML and ANSI, with components, plugins and streaming.',
+      'Parse and render Markdown anywhere with one JavaScript library for HTML, ANSI, Vue, React, Svelte and Angular, plus plugins and streaming.',
     url: 'https://comark.dev',
     socials: {
       github: 'comarkdown/comark',

--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Comark extends standard Markdown with component syntax, parses it to a compact serializable Markdown document at build time or runtime, and renders it with Vue, React, Svelte, Angular, HTML or ANSI.
+description: Parse and render CommonMark and GFM anywhere with Comark, a JavaScript library for HTML, ANSI, Vue, React, Svelte, Angular, plugins, and streaming.
 links:
   - label: Installation
     to: /getting-started/installation
@@ -17,227 +17,82 @@ links:
 
 ## What is Comark?
 
-**Comark** stands for [**Co**]{.text-primary}mponents in [**Mark**]{.text-primary}down. It's an extension of the Markdown syntax that lets you use components directly inside your Markdown content:
+**Comark** is a JavaScript library for parsing and rendering Markdown anywhere. Give it standard CommonMark or GitHub Flavored Markdown (GFM), then render the same source to HTML, ANSI, Vue, React, Svelte, or Angular.
 
-```mdc
-# Welcome to my blog
+Parsing and rendering are decoupled through a compact, serializable [`MarkdownDocument`](/getting-started/document-model). Parse on the server, in the browser, in a worker, during a build, or as content streams in. You can then inspect, transform, cache, serialize, or render the document without tying your content to one output target.
 
-This is regular **markdown** with a custom component:
-
-::alert{type="warning"}
-This is an important message!
-::
-```
-
-The `::alert` is a block component that supports properties and children (also known as slots).
+Comark is built on [markdown-exit](https://github.com/serkodev/markdown-exit), a TypeScript rewrite of markdown-it that preserves its plugin API. It combines that foundation with streaming support, an extensible plugin system, and optional component and attribute syntax for richer content.
 
 ::tip{to="/kb/why-comark"}
 Learn why we created Comark and the principles behind its design in [Why Comark](/kb/why-comark).
 ::
 
-Comark parses this into an [serializable Markdown document](/getting-started/document-model) that can be rendered to [HTML](/rendering/html). It also supports rendering to [Vue](/rendering/vue), [Nuxt](/rendering/nuxt), [React](/rendering/react), [Svelte](/rendering/svelte), and [Angular](/rendering/angular), turning your Markdown into fully interactive content.
+Start with the renderer that matches your output:
 
 ::code-group
 
-```vue [Nuxt]
-<template>
-  <Markdown :components="{ Alert }">{{ content }}</Markdown>
-</template>
+```ts [render-html.ts]
+import { renderHtml } from '@comark/html'
 
-<script setup lang="ts">
-import Alert from './Alert.vue'
-
-const content = `
-# Hello World
-
-::alert{type="info"}
-Welcome to Comark!
-::
-`
-</script>
+const content = '# Hello **World**'
+const html = await renderHtml(content)
 ```
 
-```vue [Vue]
+```ts [render-ansi.ts]
+import { renderAnsi } from '@comark/ansi'
+
+const content = '# Hello **World**'
+const output = await renderAnsi(content)
+```
+
+```vue [App.vue]
 <script setup lang="ts">
 import { Markdown } from '@comark/vue'
-import Alert from './Alert.vue'
 
-const content = `
-# Hello World
-
-::alert{type="info"}
-Welcome to Comark!
-::
-`
+const content = '# Hello **World**'
 </script>
 
 <template>
-  <Markdown :components="{ Alert }">{{ content }}</Markdown>
+  <Suspense>
+    <Markdown>{{ content }}</Markdown>
+  </Suspense>
 </template>
 ```
 
-```tsx [React]
+```tsx [App.tsx]
 import { Markdown } from '@comark/react'
-import Alert from './Alert.tsx'
 
-const content = `
-# Hello World
-
-::alert{type="info"}
-Welcome to Comark!
-::
-`
+const content = '# Hello **World**'
 
 export default function App() {
-  return <Markdown components={{ Alert }}>{content}</Markdown>
+  return <Markdown>{content}</Markdown>
 }
 ```
 
-```svelte [Svelte]
+```svelte [App.svelte]
 <script lang="ts">
   import { Markdown } from '@comark/svelte'
-  import Alert from './Alert.svelte'
 
-  const content = `
-# Hello World
-
-::alert{type="info"}
-Welcome to Comark!
-::
-`
+  const content = '# Hello **World**'
 </script>
 
-<Markdown value={content} components={{ alert: Alert }} />
+<Markdown value={content} />
 ```
 
-```typescript [Angular]
+```typescript [app.component.ts]
 import { Component } from '@angular/core'
 import { Markdown } from '@comark/angular'
-import { AlertComponent } from './alert.component'
 
 @Component({
   selector: 'app-root',
   standalone: true,
   imports: [Markdown],
-  template: `<comark-markdown [value]="content" [components]="components" />`,
+  template: `<comark-markdown [value]="content" />`,
 })
 export class AppComponent {
-  components = { alert: AlertComponent }
-  content = `
-# Hello World
-
-::alert{type="info"}
-Welcome to Comark!
-::
-`
+  content = '# Hello **World**'
 }
 ```
-
-```ts [HTML]
-import { parseMarkdown } from 'comark'
-import { renderHtmlFromDocument } from '@comark/html'
-
-const doc = await parseMarkdown(`
-# Hello World
-
-::alert{type="info"}
-Welcome to Comark!
-::
-`)
-
-const html = await renderHtmlFromDocument(doc, {
-  components: {
-    alert: async ([_tag, attrs, ...children], { render }) => {
-      return `<div class="alert alert-${attrs.type}" role="alert">${await render(children)}</div>`
-    }
-  }
-})
-/*
-<h1>Hello World</h1>
-<div class="alert alert-info" role="alert"><p>Welcome to Comark!</p></div>
-*/
-```
-::
-
-## When to Use Comark
-
-Comark is ideal for:
-
-- **Documentation sites** - Write docs in Markdown with interactive examples
-- **Blog platforms** - Rich content with custom components for callouts, embeds, and more
-- **AI chat interfaces** - Stream and render Markdown responses in real-time
-- **CMS integrations** - Let content editors use components without touching code
-- **Technical writing** - Combine prose with live code examples and diagrams
-
-## Comparison with Other Tools
-
-For detailed, honest comparisons, see [Comark vs MDX](/compare/comark-vs-mdx), [Comark vs react-markdown](/compare/comark-vs-react-markdown), [Comark vs Streamdown](/compare/comark-vs-streamdown), and [Comark vs Markdoc](/compare/comark-vs-markdoc).
-
-| Feature | Comark | Streamdown | MDX | Markdoc |
-|---------|--------|------------|-----|---------|
-| Streaming support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
-| Component syntax | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
-| Vue support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
-| React support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
-| Svelte support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
-| Angular support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
-| No build step | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
-| Parse to AST | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
-| Compact AST | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
-| Auto-close for streams | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
-| Decoupled parsing & rendering | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
-
-## Key Features
-
-::card-group
-#default
-  ::card{icon="i-lucide-zap" title="Fast Parsing" to="/api/parse"}
-  Built on markdown-exit, producing a compact array-based AST you can cache, serialize, and send over the wire.
-  ::
-
-  ::card{icon="i-lucide-component" title="Component Syntax" to="/syntax/components"}
-  Embed custom components in Markdown with props, slots, and nested children.
-  ::
-
-  ::card{icon="i-lucide-radio" title="Streaming Support" to="/rendering/vue#streaming"}
-  Real-time incremental parsing for AI chat interfaces and live content.
-  ::
-
-  ::card{icon="i-lucide-code" title="Framework Agnostic" to="/getting-started/installation"}
-  First-class support for Vue, React, Svelte, and Angular with dedicated renderers.
-  ::
-
-  ::card{icon="i-lucide-palette" title="Syntax Highlighting" to="/plugins/built-in/shiki"}
-  Built-in Shiki integration for beautiful code blocks with theme support.
-  ::
-
-  ::card{icon="i-lucide-file-text" title="GFM Support" to="/syntax/markdown"}
-  Full GitHub Flavored Markdown support including tables, task lists, and more.
-  ::
-::
-
-## FAQ
-
-::accordion
-  :::accordion-item{label="How is Comark different from MDX?"}
-  MDX compiles Markdown to JSX at build time, tying content to a bundler and to React. Comark parses component syntax at runtime, so content can come from a database, CMS, or AI stream and render to any framework. See [Comark vs MDX](/compare/comark-vs-mdx).
-  :::
-
-  :::accordion-item{label="Does Comark require a specific framework?"}
-  No. The core parser is framework-free. Renderers exist for [Vue](/rendering/vue), [React](/rendering/react), [Svelte](/rendering/svelte), [Angular](/rendering/angular), and [Nuxt](/rendering/nuxt), plus string output as [HTML](/rendering/html) and [ANSI](/rendering/ansi).
-  :::
-
-  :::accordion-item{label="Can I use markdown-it plugins with Comark?"}
-  Yes. Comark is built on markdown-exit, a TypeScript rewrite of markdown-it, so existing markdown-it plugins work alongside [Comark plugins](/plugins). See [using markdown-it plugins](/plugins/custom/markdown-it).
-  :::
-
-  :::accordion-item{label="How does Comark handle streaming AI output?"}
-  The [auto-close](/api/auto-close) parser completes unterminated syntax (bold, code fences, components) so every incomplete frame renders correctly. Framework renderers expose this as a `streaming` prop.
-  :::
-
-  :::accordion-item{label="Do I have to use components?"}
-  No. Comark is a superset of CommonMark and GFM, so plain Markdown parses unchanged. Components and [attributes](/syntax/attributes) are opt-in syntax.
-  :::
 ::
 
 ## How It Works
@@ -259,5 +114,102 @@ graph LR
 ::
 
 1. **Parse** - Comark parses Markdown into a compact [`MarkdownDocument`](/getting-started/document-model)
-2. **Transform** - The document can be inspected, transformed, cached, or serialized
-3. **Render** - Framework-specific renderers convert the document to Vue, React, Svelte, or Angular components, or to Markdown, HTML, or ANSI strings.
+2. **Transform** - Inspect, transform, cache, or serialize the document
+3. **Render** - Convert the document to HTML, ANSI, Markdown, Vue, React, Svelte, or Angular
+
+## Extend Markdown When Needed
+
+Plain Markdown works without any component syntax. When your content needs richer structure, Comark adds readable components and attributes without embedding verbose HTML or executable framework code:
+
+```mdc
+# Welcome to my blog
+
+This is regular **Markdown** with a custom component:
+
+::alert{type="warning"}
+This is an important message!
+::
+```
+
+The `::alert` block supports properties, children, and named slots. The renderer only uses components you explicitly register, so the source remains portable data rather than framework-specific code. Learn more in [Component Syntax](/syntax/components) and [Attributes](/syntax/attributes).
+
+## When to Use Comark
+
+Comark is ideal for:
+
+- **Content platforms** - Parse Markdown from files, databases, APIs, or a CMS at build time or runtime
+- **Multi-target publishing** - Reuse one source for applications, static HTML, RSS, email, and terminal output
+- **AI chat interfaces** - Stream and render incomplete Markdown responses in real time
+- **Documentation and blogs** - Combine standard Markdown with callouts, embeds, diagrams, and interactive UI
+- **Content pipelines** - Inspect, transform, cache, or serialize a compact document before rendering
+
+## Comparison with Other Tools
+
+For detailed, honest comparisons, see [Comark vs MDX](/compare/comark-vs-mdx), [Comark vs react-markdown](/compare/comark-vs-react-markdown), [Comark vs Streamdown](/compare/comark-vs-streamdown), and [Comark vs Markdoc](/compare/comark-vs-markdoc).
+
+| Feature | Comark | Streamdown | MDX | Markdoc |
+|---------|--------|------------|-----|---------|
+| Streaming support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
+| Component syntax | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
+| Vue support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
+| React support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
+| Svelte support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
+| Angular support | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
+| No build step | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
+| Parse to AST | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
+| Compact AST | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
+| Auto-close for streams | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
+| Decoupled parsing & rendering | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
+
+## Core Capabilities
+
+::card-group
+#default
+  ::card{icon="i-lucide-file-text" title="CommonMark and GFM" to="/syntax/markdown"}
+  Parse familiar Markdown syntax, including tables, task lists, code blocks, and more.
+  ::
+
+  ::card{icon="i-lucide-layers" title="Parse Once, Render Anywhere" to="/getting-started/document-model"}
+  Produce a compact document you can inspect, cache, serialize, and render to every supported target.
+  ::
+
+  ::card{icon="i-lucide-radio" title="Streaming Support" to="/rendering/vue#streaming"}
+  Real-time incremental parsing for AI chat interfaces and live content.
+  ::
+
+  ::card{icon="i-lucide-puzzle" title="Plugin Ecosystem" to="/plugins"}
+  Extend parsing with Comark plugins or reuse plugins written for markdown-it.
+  ::
+
+  ::card{icon="i-lucide-component" title="Component Syntax" to="/syntax/components"}
+  Add props, slots, and nested UI while keeping content as readable plain text.
+  ::
+
+  ::card{icon="i-lucide-code" title="Dedicated Renderers" to="/getting-started/installation"}
+  Render to HTML, ANSI, Vue, React, Svelte, and Angular without changing the source.
+  ::
+::
+
+## FAQ
+
+::accordion
+  :::accordion-item{label="How is Comark different from MDX?"}
+  MDX compiles Markdown to JSX at build time, tying content to a bundler and to React. Comark parses Markdown into serializable data at build time or runtime, then renders it to multiple targets. See [Comark vs MDX](/compare/comark-vs-mdx).
+  :::
+
+  :::accordion-item{label="Does Comark require a specific framework?"}
+  No. The core parser is framework-free. Renderers exist for [Vue](/rendering/vue), [React](/rendering/react), [Svelte](/rendering/svelte), and [Angular](/rendering/angular), plus string output as [HTML](/rendering/html) and [ANSI](/rendering/ansi).
+  :::
+
+  :::accordion-item{label="Can I use markdown-it plugins with Comark?"}
+  Yes. Comark is built on markdown-exit, a TypeScript rewrite of markdown-it that preserves its plugin API. Existing markdown-it plugins work alongside [Comark plugins](/plugins). See [using markdown-it plugins](/plugins/custom/markdown-it).
+  :::
+
+  :::accordion-item{label="How does Comark handle streaming AI output?"}
+  The [auto-close](/api/auto-close) parser completes unterminated syntax (bold, code fences, components) so every incomplete frame renders correctly. Framework renderers expose this as a `streaming` prop.
+  :::
+
+  :::accordion-item{label="Do I have to use components?"}
+  No. Comark is a superset of CommonMark and GFM, so plain Markdown parses unchanged. Components and [attributes](/syntax/attributes) are opt-in syntax.
+  :::
+::

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install Comark and render your first Markdown with components in Vue, React, Svelte, Angular, or plain HTML in under 5 minutes.
+description: Install Comark and choose a parser or renderer for HTML, ANSI, Vue, React, Svelte, or Angular to start working with Markdown in minutes.
 links:
   - label: Comark Syntax
     icon: i-lucide-file-text
@@ -17,7 +17,7 @@ links:
 
 ## Quick Start
 
-Pick your rendering strategy and start dealing with Markdown in seconds.
+Choose the output you need and render your first Markdown document in minutes.
 
 ::card-group{cols="2"}
   ::card{icon="i-logos-vue" title="Vue" to="/rendering/vue"}
@@ -63,7 +63,7 @@ Install the [Comark extension](https://marketplace.visualstudio.com/items?itemNa
 
 :u-button[Comark Extension]{icon="i-logos-visual-studio-code" color="neutral" variant="subtle" to="https://marketplace.visualstudio.com/items?itemName=Nuxt.mdc" target="_blank"}
 
-Or within your ediror, open Quick Open (`Ctrl+P` / `Cmd+P`) and run:
+Or within your editor, open Quick Open (`Ctrl+P` / `Cmd+P`) and run:
 
 ```bash
 ext install Nuxt.mdc
@@ -71,7 +71,7 @@ ext install Nuxt.mdc
 
 ## Packages
 
-Comark has three layers. Pick the one that matches what you're building:
+Comark packages share one pipeline. The core parser produces a serializable `MarkdownDocument`, while string and UI renderers consume that document. Install the package that matches your output:
 
 ### UI Frameworks
 
@@ -192,7 +192,7 @@ Use these when you need a string output with no UI framework involved like serve
 
 ### Core
 
-`comark` is the foundation all other packages build on. Use it when you need to work with the AST itself and serialize back to Markdown. 
+`comark` is the parser and document foundation used by every renderer. Use it directly to parse Markdown, inspect or transform the AST, cache or serialize documents, and render them back to Markdown.
 
 ::note
 All framework packages re-export its types, so you only need to install `comark` separately if you're not using a framework renderer.

--- a/docs/content/4.plugins/2.custom/3.markdown-it.md
+++ b/docs/content/4.plugins/2.custom/3.markdown-it.md
@@ -14,7 +14,7 @@ links:
     variant: soft
 ---
 
-Comark's default parser is built on top of [markdown-it](https://github.com/markdown-it/markdown-it) via [markdown-exit](https://github.com/serkodev/markdown-exit), a maintained fork. Most markdown-it plugins work with Comark with minimal effort.
+Comark's default parser uses [markdown-exit](https://github.com/serkodev/markdown-exit), a TypeScript rewrite of [markdown-it](https://github.com/markdown-it/markdown-it) that preserves its plugin API. Most markdown-it plugins work with Comark with minimal effort.
 
 ## Usage
 
@@ -172,7 +172,7 @@ const components = {
 
 ### markdown-exit vs markdown-it
 
-Comark uses [`markdown-exit`](https://github.com/serkodev/markdown-exit) as its base parser. The fork maintains full API compatibility with markdown-it, so plugins written for markdown-it work without modification. The [`MarkdownItPlugin`](https://markdown-it.github.io/markdown-it/#MarkdownIt) type accepted by Comark is the standard plugin signature:
+Comark uses [`markdown-exit`](https://github.com/serkodev/markdown-exit) as its base parser. This TypeScript rewrite preserves the markdown-it plugin API, so plugins written for markdown-it work without modification. The [`MarkdownItPlugin`](https://markdown-it.github.io/markdown-it/#MarkdownIt) type accepted by Comark is the standard plugin signature:
 
 ```typescript
 type MarkdownItPlugin = (md: MarkdownIt) => void

--- a/docs/content/4.plugins/index.md
+++ b/docs/content/4.plugins/index.md
@@ -4,7 +4,9 @@ description: Extend Comark with plugins for syntax highlighting, emoji, table of
 navigation: false
 ---
 
-Comark's plugin system extends markdown functionality with specialized features. All plugins are part of the core `comark` package.
+Comark has two compatible extension layers. Comark plugins can transform source, tokens, the parsed document, or rendered output through typed lifecycle hooks. You can also reuse parser plugins written for markdown-it through Comark's markdown-exit foundation.
+
+All Comark plugins are part of the core `comark` package, while optional rendering dependencies are installed only when you use them.
 
 ## Default plugins
 

--- a/docs/content/5.api/1.parse.md
+++ b/docs/content/5.api/1.parse.md
@@ -1,6 +1,6 @@
 ---
 title: Parse API
-description: Parse Markdown with components into a compact Markdown AST using parseMarkdown() and createMarkdownParser(), on the server, in the browser, or from a stream.
+description: Parse Markdown into a compact, serializable document with parseMarkdown() or createMarkdownParser(), on the server, in the browser, or from a stream.
 links:
   - label: Document Model
     icon: i-lucide-braces
@@ -16,11 +16,11 @@ links:
 
 ## `parseMarkdown(source, options?)`{lang="ts"}
 
-Parses Comark content from a string and returns the complete parsed structure.
+Parses Markdown from a string and returns a complete `MarkdownDocument`. Default plugins add frontmatter, alerts, task lists, HTML, components, and attributes to the standard Markdown parser.
 
 **Parameters:**
 
-- `source` - The markdown/Comark content as a string
+- `source` - The Markdown content as a string
 - `options?` - Parser options including plugins
 
 **Returns:** `MarkdownDocument` object containing:

--- a/docs/content/7.kb/0.why-comark.md
+++ b/docs/content/7.kb/0.why-comark.md
@@ -1,6 +1,6 @@
 ---
-title: 'Comark: From Markdown to Interactive UI'
-description: Markdown is human-readable, token-efficient, and AI-native. Comark extends it to interactive components with runtime parsing, multi-framework rendering, and first-class streaming.
+title: 'Comark: Parse and Render Markdown Anywhere'
+description: Comark gives JavaScript applications one Markdown pipeline for standards-based parsing, serializable documents, multiple renderers, plugins, and streaming.
 navigation:
   title: Why Comark?
 links:
@@ -16,7 +16,9 @@ links:
     icon: i-lucide-download
 ---
 
-Markdown won the authoring war. But it stops at document structure: headings, lists, code blocks, emphasis. No components, no interactivity. Comark picks up where Markdown ends.
+Markdown won the authoring war. It is readable, portable, widely supported, and understood by both humans and machines. The remaining challenge is everything that happens after authoring: parsing it reliably, transforming it as data, rendering it to different targets, and displaying it while content is still arriving.
+
+Comark provides one JavaScript library for that complete Markdown pipeline.
 
 ## Why Markdown?
 
@@ -46,25 +48,57 @@ This is new. For most of computing history, human-authored content and machine-r
 
 ## Why Comark?
 
-Standard Markdown has no way to express a warning callout, a tabbed code group, a video embed, or a pricing card. The current workarounds each come with a cost.
+The JavaScript ecosystem has excellent Markdown parsers and renderers, but most tools solve only one part of the pipeline. A renderer may be tied to one UI framework. A build-time compiler may not accept content from a database or live API. A conventional parser may assume the document is complete, which causes broken formatting during an AI stream.
 
-**Raw HTML works**, but it immediately breaks the plain-text readability that makes Markdown valuable and reintroduces the token overhead that Markdown removes for AI.
+Comark separates these concerns. It parses Markdown into a shared document model, lets you transform or store that document, and renders it through the output package you choose. The same API works at build time or runtime, on the server or in the browser, and with complete or streaming input.
 
-**MDX** made Markdown programmable, but at a cost: `.mdx` files are compiled to JSX at build time. Shipping new content means triggering a rebuild and a redeploy. Your content becomes code, locked to a build pipeline ([full comparison](/compare/comark-vs-mdx)).
+### Built on markdown-it Foundations
 
-Comark takes a different position. Component syntax should stay in plain text, parsing can happen at build time or runtime, your choice, and work across any renderer. That is the design constraint every other decision follows from.
+Comark supports CommonMark and GitHub Flavored Markdown (GFM) through [markdown-exit](https://github.com/serkodev/markdown-exit), a TypeScript rewrite of markdown-it that preserves its plugin API. Existing Markdown stays familiar, and existing markdown-it plugins can work alongside [Comark plugins](/plugins).
 
-### Built on Five Years of MDC
-
-Comark is the next generation of [MDC](https://github.com/nuxt-content/mdc), the parser that has powered [Nuxt Content](https://content.nuxt.com)'s component syntax for over five years. MDC proved the concept. Comark extends it in three directions.
-
-**AI models stream token by token.** Comark's [auto-close](/api/auto-close) parser renders correctly at every incomplete frame, no buffering, no broken UI. Use `<Markdown streaming>` to pipe AI-generated Markdown directly into your component tree as chunks arrive, including interactive components rendered in real time.
-
-**Parse once, render anywhere.** Comark produces compact nodes `['tag', props, ...children]` that are easy to traverse, cache, and reuse across renderers. Parse on the server, send the document to the client as JSON, and render without repeating the parse step. The same `.md` source renders to Vue, React, Svelte, Angular, Nuxt, plain HTML, and ANSI terminal output. No rewrite when you switch stacks.
+This foundation gives Comark a mature parsing model without limiting how or where the parsed document is rendered.
 
 ### Markdown as Data, Not Code
 
-Comark's component syntax is a superset of standard Markdown, inspired by the [Markdown directives proposal](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444), a CommonMark effort to standardize a generic extension point without breaking parsers.
+`parseMarkdown(markdown)` returns a compact, serializable [`MarkdownDocument`](/getting-started/document-model). Text stays as strings, elements use tuples such as `['tag', props, ...children]`, and plugins can attach structured metadata.
+
+That shared document boundary enables a complete content pipeline:
+
+1. A file, database, CMS, or API provides the raw Markdown
+2. On request, the server runs `parseMarkdown(markdown)` and gets the [`MarkdownDocument`](/getting-started/document-model) object
+3. Your application inspects, transforms, caches, or sends the document as JSON
+4. An HTML, ANSI, Vue, React, Svelte, or Angular renderer produces the final output
+
+You can parse once and render many times without coupling stored content to a framework or build pipeline.
+
+::tip
+You can store the `MarkdownDocument` directly in the database to skip re-parsing on every request.
+::
+
+### One Source, Every Renderer
+
+Most Markdown rendering libraries are designed around one output target. Comark decouples parsing from rendering so the same source can produce:
+
+- [`renderHtml()` in @comark/html](/rendering/html): server-side HTML strings, RSS, emails, and static builds
+- [`renderAnsi()` in @comark/ansi](/rendering/ansi): styled terminal output for CLIs
+- [`<Markdown>` in Vue](/rendering/vue): async components, streaming, and slot-based composition
+- [`<Markdown>` in React](/rendering/react): Server Components and client-side rendering
+- [`<Markdown>` in Svelte](/rendering/svelte): snippets and streaming
+- [`<Markdown>` in Angular](/rendering/angular): standalone components with signals and streaming
+
+Your content outlasts your output target and framework choice.
+
+### Streaming Is Part of the Parser
+
+AI models emit Markdown token by token, but conventional parsers expect complete documents. Comark's [auto-close](/api/auto-close) support completes unterminated emphasis, links, code fences, and component blocks so each intermediate frame renders correctly.
+
+Framework renderers expose streaming directly, while the core parser lets any integration opt into the same behavior. You can display content as soon as it arrives without maintaining a separate streaming syntax or renderer.
+
+### Extend Markdown Without Embedding Code
+
+Standard Markdown does not express a warning callout, tabbed code group, video embed, or pricing card. Raw HTML can represent them, but it adds verbosity and couples content to markup. MDX allows executable JSX, but it also makes content part of a framework-specific build pipeline ([full comparison](/compare/comark-vs-mdx)).
+
+Comark keeps extensions in readable plain text. Its component syntax is inspired by the [Markdown directives proposal](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444) and builds on more than five years of production use in [MDC](https://github.com/nuxt-content/mdc):
 
 ```mdc
 ::alert{type="warning"}
@@ -72,24 +106,13 @@ This action cannot be undone.
 ::
 ```
 
-Still plain text. No bundler, no compiler step. A human reads it and understands it. An AI agent parses it as structured data: a component named `alert` with a `type` attribute and text content.
+A human can read the source, while the parser sees a component named `alert` with a `type` attribute and text content. The renderer only instantiates components registered by the application, so content remains data rather than executable code.
 
-**That shift makes Markdown data, not code.** Because `parseMarkdown(markdown)` returns a serializable [`MarkdownDocument`](/getting-started/document-model), the full CMS pattern becomes possible:
-
-1. A database, CMS, or headless service stores the raw Markdown, components included
-2. On request, the server runs `parseMarkdown(markdown)` and gets the [`MarkdownDocument`](/getting-started/document-model) object
-3. The document is sent to the client as JSON
-4. `<MarkdownDocument :value="document" :components="{...}" />` renders it by looking up each tag name in a components map at runtime
-
-No build step between authoring and rendering. Content is live the moment it is saved.
-
-::tip
-You can store the `MarkdownDocument` directly in the database to skip re-parsing on every request.
-::
+Attributes provide the same plain-text approach for adding classes, IDs, styles, and metadata to standard Markdown elements. Both extensions are available when you need them; plain CommonMark and GFM continue to work unchanged.
 
 ### First-Class Slots
 
-Where HTML breaks down is **slots**: placing rich Markdown content into named regions of a component. In Comark, slots are first-class citizens. `#slotname` markers let you compose full Markdown into any named region:
+Components can accept rich Markdown in named regions. `#slotname` markers let you compose full Markdown into each slot without falling back to HTML or framework templates:
 
 ```mdc
 ::hero
@@ -98,7 +121,7 @@ Build UIs from **Markdown**
 
 #description
 Comark parses component syntax at runtime: no compiler, no rebuild.
-Supports Vue, React, Nuxt, Svelte, and Angular out of the box.
+Renders to HTML, ANSI, Vue, React, Svelte, and Angular.
 
 #cta
 [Get started](/getting-started)
@@ -107,22 +130,6 @@ Supports Vue, React, Nuxt, Svelte, and Angular out of the box.
 
 This is still Markdown. Readable in a text editor, parseable by a machine, renderable by any framework.
 
-### One Source, Every Renderer
-
-MDX is tied to React. The original MDC was tied to Nuxt. Most Markdown renderers are locked to a single output target. Comark decouples parsing from rendering entirely.
-
-The same `.md` source file renders to:
-
-- [`<Markdown>` in Vue](/rendering/vue): async components, streaming, slot-based composition
-- [`<Markdown>` in React](/rendering/react): Server Components and client-side rendering
-- [`<Markdown>` in Nuxt](/rendering/nuxt): zero-config module with auto-imports and Nuxt UI integration
-- [`<Markdown>` in Svelte](/rendering/svelte): snippets and streaming
-- [`<Markdown>` in Angular](/rendering/angular): standalone components with signals and streaming
-- [`renderHtml()` in @comark/html](/rendering/html): server-side HTML strings, RSS, emails, static builds
-- [`renderAnsi()` in @comark/ansi](/rendering/ansi): styled terminal output for CLIs
-
-Your content outlasts your framework choice.
-
 ---
 
-Markdown gave humans and machines a shared language. Comark makes it interactive. Write once, render anywhere, stream in real time.
+Markdown gives humans and machines a shared language. Comark gives that language one pipeline: parse once, render anywhere, and stream in real time.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,18 +1,18 @@
 ---
 navigation: false
 title: Comark
-description: 'The Markdown engine for the modern web. One parser, every renderer: Vue, React, Svelte, Angular, HTML and ANSI, with components, plugins and streaming.'
+description: 'Parse and render Markdown anywhere with one JavaScript library for HTML, ANSI, Vue, React, Svelte and Angular, plus plugins and streaming.'
 seo:
-  title: The Markdown Engine for the Modern Web
-  description: 'The Markdown engine for the modern web. One parser, every renderer: Vue, React, Svelte, Angular, HTML and ANSI, with components, plugins and streaming.'
+  title: Parse and Render Markdown Anywhere with Comark
+  description: 'Parse and render Markdown anywhere with one JavaScript library for HTML, ANSI, Vue, React, Svelte and Angular, plus plugins and streaming.'
   ogImage: /social-card.jpg
 
 ---
 
 ::landing-hero
 ---
-title: The Markdown engine for the modern web
-description: One parser, every renderer. Component syntax, attributes, plugins, and streaming, with decoupled parsing you can run on the server, the client, or mid-stream.
+title: Parse and render Markdown anywhere
+description: A JavaScript library to parse and stream Markdown, with renderers for HTML, terminals, Vue, React, Svelte and Angular, plus components, attributes, and plugins.
 install: npm install comark
 primaryLabel: Get Started
 primaryTo: /getting-started/introduction
@@ -21,19 +21,19 @@ secondaryTo: https://github.com/comarkdown/comark
 demoMarkdown: |-
     # Hello World
   
-    A **high-performance** markdown parser with _streaming_ support.
+    A JavaScript library to **parse and render Markdown** anywhere.
   
     ## Features
   
-    - Parse markdown in real-time
-    - Vue, React, Svelte, and Angular components
-    - Auto-close incomplete syntax
+    - CommonMark and GFM support
+    - HTML, ANSI, and framework renderers
+    - Streaming, components, and plugins
   
     ::callout{color="info" icon="i-lucide-info"}
-    Comark handles **components in markdown** natively.
+    One Markdown source, **every renderer**.
     ::
   
-    > Built for modern web applications.
+    > Built on markdown-exit, a TypeScript rewrite of markdown-it.
   
     ```ts [example.ts]
     import { parseMarkdown } from 'comark'
@@ -49,20 +49,20 @@ demoMarkdown: |-
 ::landing-pillars
 ---
 headline: Why Comark
-title: Markdown as data, not code
-description: Component syntax stays in plain text. Parsing happens at build time or runtime, your choice, and works across any renderer. Built on five years of MDC, the parser behind Nuxt Content.
+title: One Markdown pipeline, every output
+description: Parse standard Markdown into serializable data, then render it anywhere. Add streaming, component syntax, attributes, and plugins when you need them.
 pillars:
   - icon: i-lucide-zap
     title: Runtime parsing
-    description: No build step. Parse Markdown with components on the server, in the browser, or in a worker. Content is live the moment it is saved.
+    description: No build step required. Parse Markdown on the server, in the browser, in a worker, or during a build.
     to: /api/parse
   - icon: i-lucide-radio
     title: Streaming built in
-    description: Auto-close renders incomplete Markdown correctly at every frame. Pipe AI output straight into your component tree.
+    description: Auto-close renders incomplete Markdown correctly at every frame. Display AI output as soon as it arrives.
     to: /api/auto-close
   - icon: i-lucide-layers
     title: One parser, every renderer
-    description: The same source renders to Vue, React, Svelte, Angular, Nuxt, HTML and ANSI. Your content outlasts your framework.
+    description: The same source renders to HTML, ANSI, Vue, React, Svelte and Angular. Your content outlasts your framework.
     to: /getting-started/installation
   - icon: i-lucide-file-text
     title: Still just Markdown
@@ -84,8 +84,8 @@ pillars:
 
 ::landing-features
 ---
-frameworksDescription: Embed custom components in your Markdown and render them
-  natively in Vue, React, Svelte and Angular.
+frameworksDescription: Render the same Markdown document natively in Vue,
+  React, Svelte and Angular.
 frameworksHeadline: Frameworks
 frameworksReactLinkLabel: React docs
 frameworksReactLinkTo: /rendering/react
@@ -182,7 +182,7 @@ title: Extensible plugins
 
 ::landing-cta
 ---
-description: Install Comark, pick a renderer, and render your first component in minutes.
+description: Install Comark, pick a renderer, and render your first Markdown document in minutes.
 install: npm install comark
 primaryLabel: Get Started
 primaryTo: /getting-started/introduction

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comark",
-  "description": "The Markdown engine for the modern web. One parser, every renderer: Vue, React, Svelte, Angular, HTML and ANSI, with components, plugins and streaming.",
+  "description": "Parse and render Markdown anywhere with one JavaScript library for HTML, ANSI, Vue, React, Svelte and Angular, plus plugins and streaming.",
   "type": "module",
   "scripts": {
     "dev": "nuxt dev --extends docus",

--- a/packages/comark/README.md
+++ b/packages/comark/README.md
@@ -8,9 +8,9 @@
 [![Documentation](https://img.shields.io/badge/Documentation-black?logo=readme&logoColor=white)](https://comark.dev)
 [![license](https://img.shields.io/github/license/comarkdown/comark?color=black)](https://github.com/comarkdown/comark/blob/main/LICENSE)
 
-The Markdown engine for the modern web. One parser, every renderer: Vue, React, Svelte, Angular, HTML and ANSI, with components, plugins and streaming.
+Parse and render Markdown anywhere with one JavaScript library for HTML, ANSI, Vue, React, Svelte and Angular, plus plugins and streaming.
 
-Comark (**Co**mponents in **Mark**down) extends standard Markdown with component syntax that stays plain text. No build step: parse at runtime or build time, on the server or in the browser, and render the same content anywhere.
+Comark supports CommonMark and GFM, then parses them into a compact, serializable document at build time, runtime, or during a stream. Use the same document across renderers, or extend the syntax with readable components and attributes when you need richer content.
 
 ```mdc
 # Regular Markdown
@@ -24,15 +24,15 @@ This is **Markdown** inside your own component.
 
 ## Why Comark
 
-- **Runtime parsing**: `parseMarkdown(markdown)` is a pure function returning a compact serializable Markdown document . Content from a database, CMS, or LLM is live the moment it is saved. No rebuild, no redeploy. ([Comark vs MDX](https://comark.dev/compare/comark-vs-mdx))
+- **Runtime parsing**: `parseMarkdown(markdown)` is a pure function returning a compact, serializable Markdown document. Content from a database, CMS, or LLM is live the moment it is saved. No rebuild, no redeploy. ([Comark vs MDX](https://comark.dev/compare/comark-vs-mdx))
 - **Streaming built in**: auto-close completes unterminated syntax (`**bold`, open code fences, half-open components) so AI output renders correctly at every frame.
-- **One parser, every renderer**: the same source renders to Vue, React, Svelte, Angular, Nuxt, HTML strings, and ANSI terminal output. Your content outlasts your framework.
+- **One parser, every renderer**: the same source renders to HTML, ANSI, Vue, React, Svelte, and Angular. Your content outlasts your framework.
 - **Still just Markdown**: full CommonMark + GFM, frontmatter, and `{.class}` attributes on native elements. Components are opt-in syntax, not a new language.
 - **Plugin ecosystem**: Shiki highlighting, KaTeX math, Mermaid diagrams, TOC, alerts, footnotes and more, plus compatibility with existing markdown-it plugins.
 - **Decoupled parse & render**: parse once on the server, send the serializable document (`['tag', props, ...children]`) to the client, render without re-parsing.
 - **Fast**: built on [markdown-exit](https://github.com/serkodev/markdown-exit), a TypeScript rewrite of markdown-it, with full TypeScript support.
 
-Built on five years of [MDC](https://github.com/nuxt-content/mdc), the parser behind [Nuxt Content](https://content.nuxt.com). Read [Why Comark](https://comark.dev/kb/why-comark) for the full story.
+The component and attribute syntax builds on five years of production use in [MDC](https://github.com/nuxt-content/mdc). Read [Why Comark](https://comark.dev/kb/why-comark) for the full story.
 
 ## Quick Start
 

--- a/packages/comark/package.json
+++ b/packages/comark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "comark",
   "version": "0.6.2",
-  "description": "The Markdown engine for the modern web. Parse Markdown with components, attributes and plugins to a compact AST, at build time or runtime, and render with Vue, React, Svelte, Angular, HTML or ANSI. Streaming-ready for AI output.",
+  "description": "Parse CommonMark and GFM into a compact, serializable document at build time, runtime, or during a stream, then render to HTML, ANSI, Vue, React, Svelte or Angular.",
   "keywords": [
     "ai",
     "angular",


### PR DESCRIPTION
### What

Repositions Comark as a JavaScript library for parsing and rendering Markdown anywhere. Aligns the landing page, introduction, supporting documentation, README, package metadata, and contributor guidance while keeping components and attributes as key capabilities.

### Why

The previous messaging defined Comark primarily through Components in Markdown. This follows maintainer feedback to lead with the complete Markdown pipeline and renderer ecosystem, then present standards support, streaming, plugins, components, and attributes as supporting strengths.
