### PR TITLE
docs: add KB guide for custom Pre without a code prop

### DIFF
--- a/docs/content/4.plugins/1.built-in/shiki.md
+++ b/docs/content/4.plugins/1.built-in/shiki.md
@@ -16,6 +16,11 @@ links:
     to: /kb/twoslash
     color: neutral
     variant: soft
+  - label: Custom Pre
+    icon: i-lucide-clipboard-copy
+    to: /kb/custom-pre
+    color: neutral
+    variant: soft
 ---
 
 The `comark/plugins/shiki` plugin provides syntax highlighting for code blocks using [Shiki](https://shiki.style/). It supports multiple themes, line highlighting, and on-demand language loading.
@@ -362,6 +367,10 @@ shiki({
 ```
 
 See the [Twoslash guide](/kb/twoslash) for TypeScript-powered type tooltips and error annotations in code blocks.
+
+::tip{to="/kb/custom-pre"}
+Need a copy button or collapse threshold on a custom `ProsePre`? After highlighting there is no `code` prop — reconstruct the source with `__node` and `textContent()`. See [Custom Pre](/kb/custom-pre).
+::
 
 ### Live Examples
 

--- a/docs/content/7.kb/2.migration-from-mdc.md
+++ b/docs/content/7.kb/2.migration-from-mdc.md
@@ -582,6 +582,10 @@ The resolution naming changed:
 
 The names are the same. The internal resolution mechanism changed: MDC resolved `prose-p` (kebab-case) in the renderer, then looked up the registered `ProseP` component. Comark resolves directly by `ProseP` (PascalCase). If your prose components are in `components/prose/` and follow the `Prose*.vue` naming convention, they work without changes.
 
+::note
+Custom `ProsePre` components that relied on a `code` prop (or `meta.lines`) for copy buttons or collapse thresholds need a small update: after highlighting, Comark does not expose the raw source as a prop. Declare `__node` and reconstruct the text with `textContent()` from `comark/utils`. See [Custom Pre](/kb/custom-pre).
+::
+
 ### Nuxt UI
 
 If your project uses [Nuxt UI](https://ui.nuxt.com), `@comark/nuxt` registers [Nuxt UI prose components](https://ui.nuxt.com/docs/typography) automatically.

--- a/docs/content/7.kb/5.custom-pre.md
+++ b/docs/content/7.kb/5.custom-pre.md
@@ -1,0 +1,89 @@
+---
+title: Custom Pre
+description: How to build copy buttons, collapse thresholds, and other code-block UI when Comark does not pass a raw `code` prop.
+seo:
+  title: 'Custom Pre: Copy & Line Count without a code Prop'
+  description: Reconstruct source and line counts from the highlighted AST with __node and textContent — no DOM measuring required.
+links:
+  - label: Syntax Highlighting
+    icon: i-lucide-code
+    to: /plugins/built-in/shiki
+    color: neutral
+    variant: soft
+  - label: Migration from MDC
+    icon: i-lucide-arrow-right-left
+    to: /kb/migration-from-mdc
+    color: neutral
+    variant: soft
+---
+
+After the [Shiki plugin](/plugins/built-in/shiki) runs, a `<pre>` node no longer carries the raw source as a `code` prop. The string is replaced by highlighted `<span class="line">` children. That is intentional: duplicating the source on the attrs would double the AST payload.
+
+If you are migrating from MDC / Nuxt Content, a custom `ProsePre` that did `(props.code || '').split('\n')` for copy or collapse will break. Reconstruct the source from the AST instead.
+
+## What `pre` receives
+
+Fence metadata is still on the node attrs and becomes component props:
+
+| Prop | Origin |
+|------|--------|
+| `language` | fence info string |
+| `filename` | `[name]` in the fence |
+| `highlights` | `{1,3-5}` line highlights |
+| `meta` | leftover fence meta |
+| `class` / `style` | Shiki output (and `preStyles`) |
+
+There is **no** `code` or `lines` prop. The highlighted tree lives in the default slot (and on the full AST node when you ask for it).
+
+## Pattern: `__node` + `textContent`
+
+Comark injects the full element node when your component declares a `__node` prop. Flatten it with [`textContent`](/getting-started/document-model#extract-text) from `comark/utils`:
+
+```vue
+<script setup lang="ts">
+import { textContent } from 'comark/utils'
+import type { ElementNode } from 'comark'
+
+const props = defineProps<{
+  __node?: ElementNode
+  language?: string
+  filename?: string
+}>()
+
+const COLLAPSE_THRESHOLD = 15
+
+const code = computed(() => (props.__node ? textContent(props.__node) : ''))
+const lines = computed(() => code.value.split('\n').length)
+const isLong = computed(() => lines.value > COLLAPSE_THRESHOLD)
+
+async function copy() {
+  await navigator.clipboard.writeText(code.value)
+}
+</script>
+
+<template>
+  <div class="relative group">
+    <button type="button" @click="copy">Copy</button>
+    <div :class="isLong && 'max-h-[360px] overflow-hidden'">
+      <pre><slot /></pre>
+    </div>
+  </div>
+</template>
+```
+
+This works during SSR (no `onMounted` wait), stays in sync when `__node` changes, and does not depend on the rendered DOM.
+
+::tip
+The same idea applies in React: declare `__node` on `propTypes` (or accept it as a prop) so `@comark/react` injects the node, then call `textContent(__node)`.
+::
+
+## See also
+
+::card-group{cols="2"}
+  ::card{icon="i-lucide-code" title="Shiki plugin" to="/plugins/built-in/shiki"}
+  Themes, line highlights, and fence meta that become `pre` props.
+  ::
+  ::card{icon="i-lucide-arrow-right-left" title="Migration from MDC" to="/kb/migration-from-mdc"}
+  Package and prose-component changes when moving off `@nuxtjs/mdc`.
+  ::
+::


### PR DESCRIPTION
Document reconstructing copy text and line counts via `__node `+ `textContent`, and cross-link from MDC migration and Shiki docs.

### What

<!-- What this pull request accomplishes -->

### Why

<!-- Why these changes are necessary -->

<!--

AGENTS:
- The What and Why should each be 1-3 sentences.
- Write your answers based off of your conversation with the user, not purely based on the changed code
  - It's helpful to understand the reasoning behind an approach, what alternatives were considered, and why this approach was ultimately selected, rather than a summary of the lines changed
- For complex changes (>1k lines, not counting lockfiles):
  - Add a `### Walkthrough` section to the end which breaks down the primary changes into easy-to-follow `#### Sub-Sections`
-->
