### PR TITLE
chore(astro): import Shiki themes explicitly

### DIFF
--- a/docs/content/4.plugins/1.built-in/shiki.md
+++ b/docs/content/4.plugins/1.built-in/shiki.md
@@ -26,10 +26,10 @@ The `comark/plugins/shiki` plugin provides syntax highlighting for code blocks u
 
 For a lighter alternative (no TextMate grammars), see [`comark/plugins/rangi`](/plugins/built-in/rangi).
 
-`shiki` is a peer dependency, install it alongside Comark:
+`shiki` is a peer dependency. Install it alongside the theme package used below:
 
 ```vash [terminal]
-npm install shiki
+npm install shiki @shikijs/themes
 ```
 
 ## Usage

--- a/examples/1.frameworks/astro/package.json
+++ b/examples/1.frameworks/astro/package.json
@@ -11,11 +11,13 @@
   "dependencies": {
     "@astrojs/react": "catalog:",
     "@comark/react": "workspace:*",
+    "@shikijs/themes": "catalog:",
     "@tailwindcss/vite": "catalog:",
     "astro": "catalog:",
     "comark": "workspace:*",
     "react": "catalog:",
-    "react-dom": "catalog:"
+    "react-dom": "catalog:",
+    "shiki": "catalog:"
   },
   "devDependencies": {
     "@types/react": "catalog:",

--- a/examples/1.frameworks/astro/src/pages/posts/[...id].astro
+++ b/examples/1.frameworks/astro/src/pages/posts/[...id].astro
@@ -3,6 +3,8 @@ import { getCollection } from 'astro:content'
 import { parseMarkdown } from 'comark'
 import Layout from '../../layouts/Layout.astro'
 import { MarkdownDocument } from '@comark/react'
+import githubDark from '@shikijs/themes/github-dark'
+import githubLight from '@shikijs/themes/github-light'
 import shiki from 'comark/plugins/shiki'
 import Alert from '../../components/Alert'
 
@@ -19,9 +21,9 @@ const document = await parseMarkdown(post.body!, {
   plugins: [
     shiki({
       themes: {
-        light: 'github-light',
-        dark: 'github-dark',
-      }
+        light: githubLight,
+        dark: githubDark,
+      },
     }),
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,6 +510,9 @@ importers:
       '@comark/react':
         specifier: workspace:*
         version: link:../../../packages/comark-react
+      '@shikijs/themes':
+        specifier: 'catalog:'
+        version: 4.3.1
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.2(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -525,6 +528,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.7(react@19.2.7)
+      shiki:
+        specifier: 'catalog:'
+        version: 4.3.1
     devDependencies:
       '@types/react':
         specifier: 'catalog:'


### PR DESCRIPTION
### What

Written by an AI agent on behalf of @atinux; not yet human-reviewed.

Update the Astro example to declare Shiki and `@shikijs/themes`, pass explicit GitHub theme registrations, and document the matching installation command. The Astro production build completes and its generated HTML contains highlighted token spans with light and dark theme colors.

### Why

Bundled string theme support from #308 was intentionally reverted by #327, but the Astro example retained the removed string configuration and silently rendered unhighlighted code. Explicit imports align the example with the current API and close #339.
