### PR TITLE
fix(angular): use inject() instead of constructor DI (fixes NG0202 under AOT)

### DIFF
--- a/packages/comark-angular/src/components/binding.component.ts
+++ b/packages/comark-angular/src/components/binding.component.ts
@@ -6,6 +6,7 @@ import {
   Renderer2,
   OnChanges,
   SimpleChanges,
+  inject,
 } from '@angular/core'
 
 /**
@@ -31,10 +32,8 @@ export class Binding implements OnChanges {
    */
   @Input() defaultValue?: string
 
-  constructor(
-    private elementRef: ElementRef,
-    private renderer: Renderer2
-  ) {}
+  private elementRef = inject(ElementRef)
+  private renderer = inject(Renderer2)
 
   ngOnChanges(_changes: SimpleChanges): void {
     const hostEl = this.elementRef.nativeElement as HTMLElement

--- a/packages/comark-angular/src/components/markdown-node.component.ts
+++ b/packages/comark-angular/src/components/markdown-node.component.ts
@@ -12,6 +12,7 @@ import {
   EnvironmentInjector,
   createComponent,
   reflectComponentType,
+  inject,
 } from '@angular/core'
 import type { ElementNode, Node as MarkdownAstNode, NodeRenderData } from 'comark'
 import { pascalCase, resolveAttributes } from 'comark/utils'
@@ -99,12 +100,10 @@ export class MarkdownNode implements OnChanges {
   /** Parent node (for context like `pre` tag detection) */
   @Input() parent?: MarkdownAstNode
 
-  constructor(
-    private vcr: ViewContainerRef,
-    private renderer: Renderer2,
-    private elementRef: ElementRef,
-    private injector: Injector
-  ) {}
+  private vcr = inject(ViewContainerRef)
+  private renderer = inject(Renderer2)
+  private elementRef = inject(ElementRef)
+  private injector = inject(Injector)
 
   ngOnChanges(_changes: SimpleChanges): void {
     this.render()

--- a/packages/comark-angular/src/components/markdown.component.ts
+++ b/packages/comark-angular/src/components/markdown.component.ts
@@ -6,6 +6,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Type,
+  inject,
 } from '@angular/core'
 import { createSerializedMarkdownParser } from 'comark'
 import type { ParserOptions, MarkdownDocument as MarkdownDocumentType } from 'comark'
@@ -74,7 +75,7 @@ export class Markdown implements OnChanges {
 
   private serializedParse = createSerializedMarkdownParser({})
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  private cdr = inject(ChangeDetectorRef)
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['options'] || changes['plugins'] || changes['unwrap']) {

--- a/packages/comark-angular/src/components/math.component.ts
+++ b/packages/comark-angular/src/components/math.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges, ChangeDetectionStrategy, ElementRef } from '@angular/core'
+import { Component, Input, OnChanges, SimpleChanges, ChangeDetectionStrategy, ElementRef, inject } from '@angular/core'
 import katex from 'katex'
 
 /**
@@ -24,7 +24,7 @@ export class Math implements OnChanges {
   @Input() class: string = ''
   @Input() __node: any = {}
 
-  constructor(private elementRef: ElementRef) {}
+  private elementRef = inject(ElementRef)
 
   ngOnChanges(_changes: SimpleChanges): void {
     this.renderMath()

--- a/packages/comark-angular/src/components/mermaid.component.ts
+++ b/packages/comark-angular/src/components/mermaid.component.ts
@@ -8,6 +8,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   ElementRef,
+  inject,
 } from '@angular/core'
 import { renderMermaidSVG, THEMES, type DiagramColors } from 'beautiful-mermaid'
 import type { ThemeNames } from 'comark/plugins/mermaid'
@@ -38,10 +39,8 @@ export class Mermaid implements OnInit, OnChanges, OnDestroy {
   private isDark = false
   private observer?: MutationObserver
 
-  constructor(
-    private elementRef: ElementRef,
-    private cdr: ChangeDetectorRef
-  ) {}
+  private elementRef = inject(ElementRef)
+  private cdr = inject(ChangeDetectorRef)
 
   ngOnInit(): void {
     if (typeof document === 'undefined') return

--- a/packages/comark-angular/test/markdown-document-value.test.ts
+++ b/packages/comark-angular/test/markdown-document-value.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { ChangeDetectorRef, Injector, runInInjectionContext } from '@angular/core'
 import { parseMarkdown } from 'comark'
 import { isMarkdownDocument } from 'comark/utils'
 import type { MarkdownDocument } from 'comark'
@@ -8,10 +9,16 @@ import { Markdown } from '../src/components/markdown.component.ts'
  * Angular's high-level Markdown component accepts a string or a pre-parsed
  * MarkdownDocument on `value`. When a document is passed, parsing is skipped and
  * the document is assigned for MarkdownDocument to render.
+ *
+ * The component resolves its dependencies with field-level `inject()`, so it has
+ * to be instantiated inside an injection context providing a stub ChangeDetectorRef.
  */
 function createMarkdown(): Markdown {
   const cdr = { markForCheck: vi.fn() }
-  return new Markdown(cdr as any)
+  const injector = Injector.create({
+    providers: [{ provide: ChangeDetectorRef, useValue: cdr }],
+  })
+  return runInInjectionContext(injector, () => new Markdown())
 }
 
 describe('Markdown value as MarkdownDocument', () => {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -60,7 +60,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
 
     expect(report).toMatchInlineSnapshot(`
       {
-        "@comark/angular": "54.3k (66 files)",
+        "@comark/angular": "53.8k (66 files)",
         "@comark/ansi": "37.0k (94 files)",
         "@comark/html": "18.2k (54 files)",
         "@comark/nuxt": "11.4k (54 files)",


### PR DESCRIPTION
### What

Migrate the five `@comark/angular` components that still used constructor-parameter DI — `Markdown`, `MarkdownNode`, `Binding`, `Math`, `Mermaid` — to field-level `inject()`, matching `MarkdownDocument` which already did so.

Fixes #345.

### Why

`@comark/angular` is published as plain compiled output — no `ng-packagr` Ivy factories (`ɵfac`) and no emitted decorator metadata. A consumer's AOT compiler (and any metadata-less JIT runtime such as `TestBed`) therefore can't resolve constructor-parameter types, and instantiating those components throws `NG0202` ("dependency at index 0 of the parameter list is invalid"). Since `MarkdownNode` is the leaf renderer of the whole tree, every non-trivial document fails — `MarkdownDocument` is the only component that worked, precisely because it already uses `inject()`.

`inject()` resolves from the injection context and needs no reflected metadata, so this is the minimal, behavior-preserving fix and keeps the package consistent with `MarkdownDocument`.

### Compatibility

No change to the supported Angular range. `inject()` has existed since **Angular 14**, well within the package's `>=17.0.0 <22.0.0` peer range, and is already used by `MarkdownDocument` in this same package. Every touched call is a field initializer (a valid injection context), so nothing calls `inject()` outside a supported context.

### Verification

Reproduced NG0202 in a real Angular 20.3 AOT app and in a Jest `TestBed`. Applying this exact change (constructor DI → `inject()`) makes the render tree instantiate correctly: the failing render started working and a consumer test suite went from 36/56 to 55/56 passing (the remaining failure is unrelated — the async parser just needs a microtask flush in that one test). No public API or template changes.
