### PR TITLE
fix(docs): keep landing streaming demo paragraphs on one line

### DIFF
--- a/docs/app/components/landing/LandingFeatureStreaming.vue
+++ b/docs/app/components/landing/LandingFeatureStreaming.vue
@@ -84,7 +84,7 @@ onBeforeUnmount(() => {
       {{ description }}
     </p>
 
-    <UTheme :ui="{ prose: { p: { base: 'text-nowrap' } } }">
+    <UTheme :ui="{ prose: { p: { base: 'text-wrap' } } }">
       <div class="mt-6 h-[280px] overflow-auto border border-muted bg-muted/50 p-4">
         <ComarkDocs
           v-if="streamedText"

--- a/docs/app/components/landing/LandingFeatureStreaming.vue
+++ b/docs/app/components/landing/LandingFeatureStreaming.vue
@@ -84,7 +84,7 @@ onBeforeUnmount(() => {
       {{ description }}
     </p>
 
-    <UTheme :ui="{ prose: { p: 'text-nowrap' } }">
+    <UTheme :ui="{ prose: { p: { base: 'text-nowrap' } } }">
       <div class="mt-6 h-[280px] overflow-auto border border-muted bg-muted/50 p-4">
         <ComarkDocs
           v-if="streamedText"

--- a/docs/app/components/landing/LandingFeatureStreaming.vue
+++ b/docs/app/components/landing/LandingFeatureStreaming.vue
@@ -84,15 +84,17 @@ onBeforeUnmount(() => {
       {{ description }}
     </p>
 
-    <div class="mt-6 h-[280px] overflow-auto border border-muted bg-muted/50 p-4">
-      <ComarkDocs
-        v-if="streamedText"
-        class="text-sm"
-        :value="streamedText"
-        :streaming="isStreaming"
-        :caret="{ class: 'caret' }"
-      />
-    </div>
+    <UTheme :ui="{ prose: { p: 'text-nowrap' } }">
+      <div class="mt-6 h-[280px] overflow-auto border border-muted bg-muted/50 p-4">
+        <ComarkDocs
+          v-if="streamedText"
+          class="text-sm"
+          :value="streamedText"
+          :streaming="isStreaming"
+          :caret="{ class: 'caret' }"
+        />
+      </div>
+    </UTheme>
 
     <UButton
       :label="linkLabel"


### PR DESCRIPTION
### What

Wrap the landing page streaming demo in `UTheme` so prose paragraphs use `text-wrap`.

### Why

The streamed Rubaiyat sample wraps awkwardly mid-line in the fixed-height demo panel; keeping paragraphs on one line preserves the intended streaming presentation.