### PR TITLE
fix(rangi): enable fence line highlights

### DIFF
--- a/docs/content/4.plugins/1.built-in/rangi.md
+++ b/docs/content/4.plugins/1.built-in/rangi.md
@@ -135,7 +135,7 @@ Rangi ships aliases built-in (`javascript`→`js`, `typescript`→`ts`, `python`
 
 ### Line highlighting
 
-Fence info `{2-3,5}` marks lines with the `.highlight` class — same as the Shiki plugin.
+Fence info `{2-3,5}` wraps the code in line spans and marks the selected lines with the `.highlight` class — same as the Shiki plugin. No `lineNumbers` option is required.
 
 ### Pre Styles
 
@@ -156,7 +156,7 @@ Returns a `ComarkPlugin` that enables rangi syntax highlighting.
 | Option | Type | Default | Description |
 |---|---|---|---|
 | [`theme`](#theme) | `ShjTheme \| { light, dark }` | rangi default pair | Inline colors |
-| [`lineNumbers`](#linenumbers) | `boolean` | `false` | Wrap each line in `<span class="line">` |
+| [`lineNumbers`](#linenumbers) | `boolean` | `false` | Always wrap each line in `<span class="line">` |
 | [`classPrefix`](#classprefix) | `string` | `'shj'` | Class prefix on the highlighted `<pre>` |
 | [`languages`](#languages) | `Record<string, grammar>` | — | Extra custom grammars, merged over the Comark ones |
 | [`preStyles`](#prestyles) | `boolean` | `false` | Add inline background/foreground styles to `<pre>` |
@@ -193,7 +193,7 @@ rangi({
 
 ### `lineNumbers`
 
-When `true`, each source line is wrapped in `<span class="line">` so `{1,3-5}` highlights can target lines and CSS gutters can number them:
+When `true`, each source line is always wrapped in `<span class="line">` so CSS gutters can number them. Highlight metadata such as `{1,3-5}` enables line wrappers automatically, even when this option is `false`:
 
 ```typescript
 rangi({ lineNumbers: true })

--- a/examples/3.plugins/vue-vite-rangi/README.md
+++ b/examples/3.plugins/vue-vite-rangi/README.md
@@ -101,7 +101,7 @@ rangi({ languages: { md, markdown: md } })
 rangi({
   // Single theme or { light, dark } pair from rangi/themes
   theme: github,
-  // Wrap lines for gutters / {n} highlights (default: false)
+  // Always wrap lines for gutters (highlights wrap lines automatically)
   lineNumbers: true,
   classPrefix: 'shj',
 })

--- a/packages/comark/src/plugins/rangi.ts
+++ b/packages/comark/src/plugins/rangi.ts
@@ -52,7 +52,8 @@ export interface RangiOptions {
 
   /**
    * Whether to wrap each source line in `<span class="line">`.
-   * Required for `{1,3-5}` line-highlight support and CSS line-number gutters.
+   * Lines are also wrapped automatically when fence highlights (`{1,3-5}`)
+   * are present.
    * @default false
    */
   lineNumbers?: boolean
@@ -298,7 +299,8 @@ export async function rangiCodeBlocks(tree: MarkdownDocument, options: RangiOpti
       try {
         const tokens = tokenizeCode(code, lang, languages)
         const lines = tokensToLines(tokens, { light, dark, dual })
-        codeChildren = buildCodeChildren(lines, attrs.highlights, lineNumbers)
+        const hasHighlights = Array.isArray(attrs.highlights) && attrs.highlights.length > 0
+        codeChildren = buildCodeChildren(lines, attrs.highlights, lineNumbers || hasHighlights)
       } catch {
         codeChildren = [code]
       }

--- a/packages/comark/test/plugins/rangi.test.ts
+++ b/packages/comark/test/plugins/rangi.test.ts
@@ -230,9 +230,9 @@ describe('rangi plugin', () => {
     expect((pre![1] as any).class).toContain('shj-lang-typescript')
   })
 
-  it('applies line highlight classes from fence info', async () => {
-    const md = '```js {2}\nconst a = 1\nconst b = 2\nconst c = 3\n```'
-    const tree = await parseMarkdown(md, { plugins: [rangi({ lineNumbers: true })] })
+  it('applies line highlight classes from fence info without lineNumbers', async () => {
+    const md = '```js {2-3}\nconst a = 1\nconst b = 2\nconst c = 3\n```'
+    const tree = await parseMarkdown(md, { plugins: [rangi()] })
     const pre = findPre(tree.nodes)!
     const code = pre[2] as ElementNode
 
@@ -240,7 +240,8 @@ describe('rangi plugin', () => {
     expect(lines.length).toBe(3)
     expect((lines[0][1] as any).class).toBe('line')
     expect((lines[1][1] as any).class).toBe('line highlight')
-    expect((lines[2][1] as any).class).toBe('line')
+    expect((lines[2][1] as any).class).toBe('line highlight')
+    expect(textOf(pre)).toBe('const a = 1\nconst b = 2\nconst c = 3')
   })
 
   it('preserves user class after the `.` separator', async () => {


### PR DESCRIPTION
### What

Make Rangi wrap code lines automatically when fence highlight metadata is present, so `{2-3}` emits `.line.highlight` without requiring `lineNumbers`. This adds regression coverage, updates the plugin and example documentation, and was verified with all 135 plugin tests, the package TypeScript build, lint, and formatting checks.

### Why

Line highlighting was coupled to the line-number gutter wrappers, so the documented highlight syntax silently did nothing with the default configuration. Wrapping only highlighted fences preserves Rangi's lightweight, unwrapped output for ordinary code blocks.
