### PR TITLE
fix(math): lazy-import katex in renderMath/validateMath

### DIFF
--- a/packages/comark/src/plugins/math.ts
+++ b/packages/comark/src/plugins/math.ts
@@ -1,5 +1,4 @@
 import type { MarkdownExit, StateInline, StateBlock } from 'markdown-exit'
-import katex from 'katex'
 import type { MarkdownItPlugin } from 'comark'
 import { defineComarkPlugin } from '../utils/helpers.ts'
 
@@ -26,12 +25,14 @@ export interface MathConfig {
  *
  * @example
  * ```ts
- * const html = renderMath('E = mc^2', false)
- * const display = renderMath('x^2', true)
+ * const html = await renderMath('E = mc^2', false)
+ * const display = await renderMath('x^2', true)
  * ```
  */
-export function renderMath(code: string, displayMode: boolean, config: MathConfig = {}): string {
+export async function renderMath(code: string, displayMode: boolean, config: MathConfig = {}): Promise<string> {
   try {
+    const katex = (await import('katex')).default
+
     const options = {
       displayMode,
       throwOnError: config.throwOnError ?? false,
@@ -56,12 +57,13 @@ export function renderMath(code: string, displayMode: boolean, config: MathConfi
  *
  * @example
  * ```ts
- * validateMath('E = mc^2') // true
- * validateMath('\\invalid') // false
+ * await validateMath('E = mc^2') // true
+ * await validateMath('\\invalid') // false
  * ```
  */
-export function validateMath(code: string): boolean {
+export async function validateMath(code: string): Promise<boolean> {
   try {
+    const katex = (await import('katex')).default
     katex.renderToString(code, { throwOnError: true })
     return true
   } catch {

--- a/packages/comark/test/plugins/math.test.ts
+++ b/packages/comark/test/plugins/math.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { parseMarkdown } from '../../src/parse'
+import math, { renderMath, validateMath } from '../../src/plugins/math'
+
+describe('math plugin', () => {
+  it('parses inline and display math without loading katex', async () => {
+    const { nodes } = await parseMarkdown('Inline $x^2$ and display $$E = mc^2$$', {
+      plugins: [math()],
+    })
+
+    expect(JSON.stringify(nodes)).toContain('math')
+  })
+
+  it('renders math lazily via katex', async () => {
+    await expect(renderMath('E = mc^2', false)).resolves.toContain('katex')
+  })
+
+  it('validates math lazily via katex', async () => {
+    await expect(validateMath('E = mc^2')).resolves.toBe(true)
+    await expect(validateMath('\\invalid')).resolves.toBe(false)
+  })
+})

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "43.1k (70 files)",
         "@comark/svelte": "43.4k (78 files)",
         "@comark/vue": "60.0k (74 files)",
-        "comark": "410k (154 files)",
+        "comark": "411k (154 files)",
       }
     `)
   })


### PR DESCRIPTION
### What

Drops the static top-level `import katex from 'katex'` in `packages/comark/src/plugins/math.ts` and loads katex through a dynamic `import('katex')` inside `renderMath` and `validateMath`, which makes both helpers async. Adds `packages/comark/test/plugins/math.test.ts` to cover parsing without katex plus the two now-async helpers.

### Why

`katex` is an optional peer dependency, but the static import made `comark/plugins/math` throw `ERR_MODULE_NOT_FOUND` at import time when katex wasn't installed (#271). The plugin itself never touches katex — only the two helpers do — so deferring the load keeps the plugin usable without katex. Making the helpers async is technically breaking for direct callers, but neither is called internally.

Supersedes #272 (rebased onto current `main`, with tests added); credit to @saschabuehrle, retained as commit co-author.

Fixes #271