### PR TITLE
fix(angular): render nested custom components

### DIFF
--- a/packages/comark-angular/src/components/markdown-node.component.ts
+++ b/packages/comark-angular/src/components/markdown-node.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  ComponentRef,
   Input,
   ChangeDetectionStrategy,
   ViewContainerRef,
@@ -75,7 +76,7 @@ const VOID_ELEMENTS = new Set([
 ])
 
 /**
- * MarkdownNode — recursive component that renders a single Comark AST node.
+ * MarkdownNode - recursive component that renders a single Comark AST node.
  *
  * For text nodes, it inserts the text directly.
  * For element nodes, it creates a native DOM element or instantiates
@@ -150,7 +151,7 @@ export class MarkdownNode implements OnChanges {
       // Resolve attributes (:binding support)
       const resolved = resolveAttributes(nodeProps, this.renderData, { parseJson: true })
 
-      // Build childrenRenderData — only shadow parent scope when element has own attrs
+      // Build childrenRenderData - only shadow parent scope when element has own attrs
       const hasOwnAttrs = Object.keys(resolved).length > 0
       const childrenRenderData: NodeRenderData = hasOwnAttrs ? { ...this.renderData, props: resolved } : this.renderData
 
@@ -266,7 +267,7 @@ export class MarkdownNode implements OnChanges {
     // Collect all rendered child nodes for the default slot
     const defaultSlotNodes: Node[] = Array.from(tempContainer.childNodes)
 
-    // Build projectableNodes array — index 0 is the default <ng-content />
+    // Build projectableNodes array - index 0 is the default <ng-content />
     const projectableNodes: Node[][] = [defaultSlotNodes]
 
     // Create the Angular component with projected content
@@ -342,17 +343,23 @@ export class MarkdownNode implements OnChanges {
         }
 
         if (customComponent) {
-          const componentRef = this.vcr.createComponent(MarkdownNode)
-          componentRef.instance.node = child
-          componentRef.instance.components = this.components
-          componentRef.instance.renderData = renderData
-          componentRef.instance.parent = this.node
-          componentRef.changeDetectorRef.detectChanges()
+          let componentRef: ComponentRef<MarkdownNode> | undefined
+          try {
+            componentRef = this.vcr.createComponent(MarkdownNode)
+            componentRef.setInput('node', child)
+            componentRef.setInput('components', this.components)
+            componentRef.setInput('renderData', renderData)
+            componentRef.setInput('parent', this.node)
+            componentRef.changeDetectorRef.detectChanges()
 
-          // Move the component's host element into the parent
-          const nativeEl = componentRef.location.nativeElement as HTMLElement
-          nativeEl.style.display = 'contents'
-          this.renderer.appendChild(parentEl, nativeEl)
+            // Move the component's host element into the parent
+            const nativeEl = componentRef.location.nativeElement as HTMLElement
+            nativeEl.style.display = 'contents'
+            this.renderer.appendChild(parentEl, nativeEl)
+          } catch (error) {
+            componentRef?.destroy()
+            console.error(`Failed to render custom component "${childTag}"`, error)
+          }
         } else {
           const resolved = resolveAttributes(childProps, renderData, { parseJson: true })
           const hasOwnAttrs = Object.keys(resolved).length > 0

--- a/packages/comark-angular/test/nested-components.test.ts
+++ b/packages/comark-angular/test/nested-components.test.ts
@@ -1,0 +1,135 @@
+import '@angular/compiler'
+import { describe, expect, it, vi } from 'vitest'
+import { Component, provideZonelessChangeDetection, type Type } from '@angular/core'
+import { bootstrapApplication } from '@angular/platform-browser'
+import { renderApplication } from '@angular/platform-server'
+import { parseMarkdown, type MarkdownDocument as MarkdownDocumentType } from 'comark'
+import { MarkdownDocument } from '../src/components/markdown-document.component.ts'
+import { MarkdownNode } from '../src/components/markdown-node.component.ts'
+
+function createRenderer() {
+  return {
+    createText: (value: string) => ({ value }),
+    appendChild: vi.fn(),
+  }
+}
+
+function createNode(overrides: Record<string, unknown> = {}) {
+  const node = Object.create(MarkdownNode.prototype) as any
+  Object.assign(node, {
+    node: ['root', {}],
+    components: { Badge: class Badge {} },
+    renderer: createRenderer(),
+    vcr: { createComponent: vi.fn() },
+    ...overrides,
+  })
+  return node
+}
+
+describe('MarkdownNode nested component rendering', () => {
+  it('passes nested inputs through Angular input binding', () => {
+    const componentRef = {
+      setInput: vi.fn(),
+      changeDetectorRef: { detectChanges: vi.fn() },
+      location: { nativeElement: { style: {} } },
+    }
+    const node = createNode({
+      vcr: { createComponent: vi.fn(() => componentRef) },
+    })
+
+    node.renderChildren({}, [['badge', {}, 'shown']], { frontmatter: {}, meta: {}, data: {}, props: {} })
+
+    expect(componentRef.setInput).toHaveBeenCalledWith('node', ['badge', {}, 'shown'])
+    expect(componentRef.setInput).toHaveBeenCalledWith('components', node.components)
+    expect(componentRef.setInput).toHaveBeenCalledWith('parent', node.node)
+    expect(componentRef.changeDetectorRef.detectChanges).toHaveBeenCalledOnce()
+  })
+
+  it('logs a failed custom component and continues with later siblings', () => {
+    const error = new Error('constructor failed')
+    const renderer = createRenderer()
+    const node = createNode({
+      renderer,
+      vcr: {
+        createComponent: vi.fn(() => {
+          throw error
+        }),
+      },
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    node.renderChildren({}, [['badge', {}, 'gone'], 'still rendered'], {
+      frontmatter: {},
+      meta: {},
+      data: {},
+      props: {},
+    })
+
+    expect(consoleError).toHaveBeenCalledWith('Failed to render custom component "badge"', error)
+    expect(renderer.appendChild).toHaveBeenCalledWith({}, { value: 'still rendered' })
+    consoleError.mockRestore()
+  })
+})
+
+/** Badge — applied via decorator factory so Vitest/oxc need not enable experimentalDecorators. */
+class Badge {
+  name = 'badge'
+}
+Component({
+  selector: 'app-badge',
+  standalone: true,
+  template: `<span class="badge">{{ name }}</span>`,
+  inputs: ['name'],
+})(Badge)
+
+async function renderMarkdown(
+  markdown: string,
+  components: Record<string, Type<unknown>> = { badge: Badge as Type<unknown> }
+): Promise<string> {
+  const document = await parseMarkdown(markdown)
+
+  class App {
+    document: MarkdownDocumentType = document
+    components = components
+  }
+  Component({
+    selector: 'app-root',
+    standalone: true,
+    imports: [MarkdownDocument],
+    template: `
+      <comark-markdown-document
+        [value]="document"
+        [components]="components"
+      />
+    `,
+  })(App)
+
+  return renderApplication(
+    (context) =>
+      bootstrapApplication(
+        App,
+        {
+          providers: [provideZonelessChangeDetection()],
+        },
+        context
+      ),
+    {
+      document: '<!DOCTYPE html><html><head></head><body><app-root></app-root></body></html>',
+    }
+  )
+}
+
+describe('nested components', () => {
+  it('renders Badge component name for inline :badge', async () => {
+    const html = await renderMarkdown('Hello :badge')
+
+    expect(html).toContain('class="badge"')
+    expect(html).toContain('>badge</span>')
+  })
+  it('renders Badge component name for inline :badge with custom name', async () => {
+    const html = await renderMarkdown('Hello :badge{name="Ahad"}')
+
+    expect(html).toContain('class="badge"')
+    expect(html).toContain('>Ahad</span>')
+  })
+})

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -60,7 +60,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
 
     expect(report).toMatchInlineSnapshot(`
       {
-        "@comark/angular": "53.8k (66 files)",
+        "@comark/angular": "54.1k (66 files)",
         "@comark/ansi": "37.0k (94 files)",
         "@comark/html": "18.2k (54 files)",
         "@comark/nuxt": "11.4k (54 files)",


### PR DESCRIPTION
## Summary

Resolves #294.

Nested custom Angular components were initialized by assigning directly to the child component instance. That bypasses Angular input change detection, so nested components were created but rendered empty. This changes the recursive renderer to use `ComponentRef.setInput` for all child inputs.

The same path now catches component creation and initialization errors, logs the component tag, destroys a partially-created view, and continues rendering later siblings.

## Notes

This reopens the work from #330 on a new signed-commit branch so it can merge under the signed-commit requirement.

Original author: @tomatotomata

## Validation

- Added focused regression coverage for nested input binding.
- Added coverage that a failed custom component is logged without stopping later siblings.
- `git diff --check` passes.

The full package test command is left to CI because this checkout cannot materialize the repository's Windows-invalid `packages/comark/SPEC/common-mark/horizontal-rule-3*.md` fixture path.