### PR TITLE
fix(ansi): align table columns by visible width when cells have ANSI styles

### DIFF
--- a/packages/comark-ansi/src/handlers/table.ts
+++ b/packages/comark-ansi/src/handlers/table.ts
@@ -1,6 +1,6 @@
 import type { NodeHandler, State } from 'comark/render'
 import type { ElementNode, Node } from 'comark'
-import { DIM, BOLD, RESET } from '../utils/escape.ts'
+import { DIM, BOLD, RESET, padEndVisible, visibleLength } from '../utils/escape.ts'
 
 async function getCellText(cell: Node, state: State): Promise<string> {
   if (typeof cell === 'string') return cell
@@ -52,14 +52,15 @@ export const table: NodeHandler = async (node, state) => {
   for (const c of headerCells) {
     headers.push(await getCellText(c, state))
   }
-  const colWidths = headers.map((h) => Math.max(3, h.length))
+  // Widths are visible terminal columns (ANSI escapes do not count).
+  const colWidths = headers.map((h) => Math.max(3, visibleLength(h)))
 
   for (const row of bodyRows) {
     const cells = getCells(row)
     for (let i = 0; i < cells.length; i++) {
       if (i < colWidths.length) {
         const text = await getCellText(cells[i], state)
-        colWidths[i] = Math.max(colWidths[i], text.length)
+        colWidths[i] = Math.max(colWidths[i], visibleLength(text))
       }
     }
   }
@@ -73,7 +74,7 @@ export const table: NodeHandler = async (node, state) => {
   const botBorder = sep('└', '┴', '┘', '─')
 
   const fmtRow = (cells: string[], bold = false) => {
-    const cols = cells.map((c, i) => ' ' + c.padEnd(colWidths[i]) + ' ')
+    const cols = cells.map((c, i) => ' ' + padEndVisible(c, colWidths[i]) + ' ')
     if (colors && bold) return '│' + cols.map((c) => BOLD + c + RESET).join('│') + '│'
     if (colors) return DIM + '│' + RESET + cols.join(DIM + '│' + RESET) + DIM + '│' + RESET
     return '│' + cols.join('│') + '│'

--- a/packages/comark-ansi/src/utils/escape.ts
+++ b/packages/comark-ansi/src/utils/escape.ts
@@ -15,3 +15,23 @@ export function wrap(open: string, text: string, colors: boolean): string {
   if (!colors || !text) return text
   return open + text + RESET
 }
+
+/** CSI / OSC / other ANSI escape sequences (non-printing). */
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\u001B(?:\[[\d;?]*[ -/]*[@-~]|\][^\u0007\u001B]*(?:\u0007|\u001B\\)?|[@-Z\\-_])/g
+
+/** Remove ANSI escape sequences so length reflects visible terminal columns. */
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, '')
+}
+
+/** Visible character length of a string, ignoring ANSI escape codes. */
+export function visibleLength(text: string): number {
+  return stripAnsi(text).length
+}
+
+/** Pad `text` with spaces on the right to a target *visible* width. */
+export function padEndVisible(text: string, targetVisibleWidth: number): string {
+  const pad = targetVisibleWidth - visibleLength(text)
+  return pad > 0 ? text + ' '.repeat(pad) : text
+}

--- a/packages/comark-ansi/test/index.test.ts
+++ b/packages/comark-ansi/test/index.test.ts
@@ -154,6 +154,60 @@ describe('renderAnsiFromDocument', () => {
     })
   })
 
+  describe('tables', () => {
+    const tableMd = [
+      '| Argument | Type | Description |',
+      '| -------- | ---- | ----------- |',
+      '| `guard` | guard | Specifies the guard. |',
+    ].join('\n')
+
+    it('renders a plain table with aligned columns', async () => {
+      const out = await plain(tableMd)
+      expect(out).toContain('Argument')
+      expect(out).toContain('guard')
+      expect(out).toContain('┌')
+      expect(out).toContain('│')
+    })
+
+    it('aligns columns when cells contain ANSI styling', async () => {
+      const out = await colored(tableMd)
+      // Strip ANSI so column borders line up by visible width.
+      // eslint-disable-next-line no-control-regex
+      const stripped = out.replace(/\u001B\[[\d;?]*[ -/]*[@-~]/g, '')
+      const lines = stripped
+        .split('\n')
+        .map((l) => l.trimEnd())
+        .filter((l) => l.includes('│') || l.includes('┌') || l.includes('├') || l.includes('└'))
+
+      expect(lines.length).toBeGreaterThanOrEqual(4)
+      const widths = lines.map((l) => l.length)
+      expect(new Set(widths).size).toBe(1)
+
+      // Inline code still carries color escapes in the raw output.
+      expect(out).toContain('\x1B[36m')
+      expect(out).toContain('guard')
+    })
+
+    it('aligns columns with bold/italic/link mixed in cells', async () => {
+      const md = `
+| Name | Note |
+| ---- | ---- |
+| **bold** | _italic_ and [link](https://example.com) |
+| plain | short |
+`.trim()
+      const out = await colored(md)
+      // eslint-disable-next-line no-control-regex
+      const stripped = out.replace(/\u001B\[[\d;?]*[ -/]*[@-~]/g, '')
+      const lines = stripped
+        .split('\n')
+        .map((l) => l.trimEnd())
+        .filter((l) => l.includes('│') || l.includes('┌') || l.includes('├') || l.includes('└'))
+
+      const widths = lines.map((l) => l.length)
+      expect(new Set(widths).size).toBe(1)
+    })
+  })
+
   describe('code blocks', () => {
     it('renders code block content', async () => {
       const out = await plain('```js\nconsole.log("hi")\n```')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -61,7 +61,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
     expect(report).toMatchInlineSnapshot(`
       {
         "@comark/angular": "54.5k (70 files)",
-        "@comark/ansi": "37.4k (98 files)",
+        "@comark/ansi": "38.7k (98 files)",
         "@comark/html": "18.6k (58 files)",
         "@comark/nuxt": "11.9k (58 files)",
         "@comark/react": "43.6k (74 files)",


### PR DESCRIPTION
### What

Fixes table column misalignment in `@comark/ansi` when cells contain ANSI-styled content (inline code, bold, italic, links). Column width is now measured and padded by visible terminal width via `stripAnsi` / `visibleLength` / `padEndVisible`, with regression tests covering the issue case from #354.

resolves #354 

### Why

The table handler used `String.length` and `padEnd` on already-styled cell text. Escape sequences inflated the measured width, so borders drifted whenever a cell had ANSI styling — as reported in #354 for `` `guard` `` inside a table. Visible-width math is the standard fix for terminal layout and keeps coloring intact while aligning columns correctly.