### PR TITLE
fix: unable to import some types

### DIFF
--- a/packages/comark/src/index.ts
+++ b/packages/comark/src/index.ts
@@ -12,4 +12,4 @@ export { createComarkContext } from './context.ts'
 export type { ComarkContext, ComarkDocument, ComarkPatch } from './context.ts'
 
 // Re-export types
-export type * from './types'
+export type * from './types.ts'


### PR DESCRIPTION
### What

<!-- What this pull request accomplishes -->

Fixes some types not exporting correctly. Everything in `/types.ts` isn't currently accessible without the file extension added.

### Why

Currently it's not possible to import some types, e.g.

```
import type { MarkdownDocument } from 'comark'
```