### PR TITLE
fix(parse): store YAML block scalars as :bindings

### DIFF
--- a/packages/comark/SPEC/COMARK/component-block-props-types.md
+++ b/packages/comark/SPEC/COMARK/component-block-props-types.md
@@ -29,14 +29,14 @@ Component content
       "component",
       {
         "title": "Hello World",
-        "count": "42",
-        "enabled": "true",
-        "hidden": "false",
-        "tags": [
+        ":count": "42",
+        ":enabled": "true",
+        ":hidden": "false",
+        ":tags": [
           "markdown",
           "docs"
         ],
-        "config": {
+        ":config": {
           "theme": "dark",
           "debug": false
         }
@@ -61,7 +61,7 @@ Component content
 ::component
 ```yaml [props]
 title: Hello World
-count: '42'
+count: 42
 enabled: true
 hidden: false
 tags:

--- a/packages/comark/SPEC/COMARK/component-nested-multiline-separated.md
+++ b/packages/comark/SPEC/COMARK/component-nested-multiline-separated.md
@@ -67,12 +67,12 @@ full-width: true
     [
       "page-section",
       {
-        "full-width": "true"
+        ":full-width": "true"
       },
       [
         "multi-column",
         {
-          "columns": "3"
+          ":columns": "3"
         },
         [
           "container",
@@ -187,8 +187,8 @@ full-width: true
 ## Markdown
 
 ```md
-::page-section{full-width="true"}
-  :::multi-column{columns="3"}
+::page-section{full-width}
+  :::multi-column{:columns="3"}
     ::::container{display="flex"}
     <svg width="10"></svg>
     ::::

--- a/packages/comark/SPEC/COMARK/component-nested4.md
+++ b/packages/comark/SPEC/COMARK/component-nested4.md
@@ -97,7 +97,7 @@ timeout:
             "button",
             {
               ":data-testid": "$doc.snippet.description",
-              "external": "true",
+              ":external": "true",
               ":to": "$doc.snippet.link",
               "appearance": "primary"
             },

--- a/packages/comark/SPEC/COMARK/component-yaml-props.md
+++ b/packages/comark/SPEC/COMARK/component-yaml-props.md
@@ -28,11 +28,11 @@ Second Paragraph
       "component",
       {
         "attr": "value",
-        "object-attr": {
+        ":object-attr": {
           "key1": "value1",
           "key2": "value2"
         },
-        "array": [
+        ":array": [
           "item 1",
           "item 2"
         ]

--- a/packages/comark/src/internal/stringify/attributes.ts
+++ b/packages/comark/src/internal/stringify/attributes.ts
@@ -221,9 +221,8 @@ export function htmlAttributes(attributes: Record<string, unknown>) {
   return parts.join(' ')
 }
 
-// Coerce string `'true'`/`'false'` (how the parser stores boolean attrs) to
-// native booleans so js-yaml v5 emits them unquoted, matching the markdown
-// source. Numbers stay strings — the parser keeps numeric attrs as strings.
+// Coerce string `'true'`/`'false'` (how inline `{attr}` parsing stores
+// boolean-like attrs) to native booleans so js-yaml v5 emits them unquoted.
 function normalizeValue(value: unknown): unknown {
   if (value === 'true') return true
   if (value === 'false') return false
@@ -241,14 +240,25 @@ export function comarkYamlAttributes(
   style: 'frontmatter' | 'codeblock' = 'codeblock'
 ) {
   // Normalize attribute values for YAML serialization:
-  //  - Strip the `:` binding prefix from boolean-like values (`:block="true"`
-  //    becomes `block: true`), since the YAML props block is the canonical form
-  //    for `::tag{...}` shorthand.
-  //  - Coerce string literals `'true'`/`'false'`
+  //  - `:`-prefixed JSON literals (`:count="42"`, `:config={…}`) restore to
+  //    native values and drop the prefix — matching @nuxtjs/mdc stringify.
+  //  - `:`-prefixed path bindings (`:to="$doc.link"`) stay prefixed so they
+  //    round-trip as bindings, not plain strings.
+  //  - Bare string literals `'true'`/`'false'` from inline attrs coerce to bools.
   const normalized = Object.fromEntries(
     Object.entries(attributes).map(([key, value]) => {
-      if (key.startsWith(':') && (value === 'true' || value === 'false')) {
-        return [key.slice(1), normalizeValue(value)]
+      if (key.startsWith(':')) {
+        if (typeof value === 'string') {
+          try {
+            // JSON number/boolean/null/object/array → typed YAML key without `:`
+            return [key.slice(1), JSON.parse(value)]
+          } catch {
+            // Path binding / non-JSON string — keep the `:` key
+            return [key, value]
+          }
+        }
+        // Already-decoded object/array (processAttributes) or native value
+        return [key.slice(1), value]
       }
       return [key, normalizeValue(value)]
     })

--- a/packages/comark/src/plugins/components.ts
+++ b/packages/comark/src/plugins/components.ts
@@ -289,8 +289,19 @@ const markdownItComarkBlock: PluginSimple = (md) => {
       const data = parseYaml(yaml)
       const token = state.env.comarkBlockTokens[0]
       Object.entries(data || {}).forEach(([key, value]) => {
-        if (key === 'class') token.attrJoin(key, value as string)
-        else token.attrSet(key, typeof value === 'string' ? value : JSON.stringify(value))
+        if (key === 'class') {
+          token.attrJoin(key, value as string)
+          return
+        }
+        // Match @nuxtjs/mdc: non-string YAML values are stored as `:`-prefixed
+        // bindings with a JSON-string payload. Framework renderers (and
+        // resolveAttributes with parseJson) restore native types; quoted YAML
+        // strings stay unprefixed and remain strings (#364).
+        if (typeof value === 'string') {
+          token.attrSet(key, value)
+        } else {
+          token.attrSet(`:${key}`, JSON.stringify(value))
+        }
       })
     }
 

--- a/packages/comark/test/empty-props.test.ts
+++ b/packages/comark/test/empty-props.test.ts
@@ -61,9 +61,39 @@ describe('empty component props block (#319)', () => {
     const hero = result.nodes[0] as Node
 
     expect(isElement(hero, 'hero')).toBe(true)
-    // Non-string attribute values are JSON-stringified onto the element (see components.ts)
-    expect(getAttrs(hero).count).toBe('3')
+    // Non-string YAML scalars are stored as `:` bindings (MDC-compatible, #364)
+    expect(getAttrs(hero)[':count']).toBe('3')
     expect(getAttrs(hero).label).toBe('hello')
+  })
+
+  it('stores non-string YAML block props as :bindings (#364)', async () => {
+    const result = await parseMarkdown(`::comp
+---
+label: "hello"
+count: 3
+enabled: false
+nested:
+  x: 1
+  y: true
+nothing: null
+---
+::`)
+    const attrs = getAttrs(result.nodes[0] as Node)
+
+    // Match @nuxtjs/mdc: `:` prefix + JSON payload for non-strings
+    expect(attrs).toEqual({
+      label: 'hello',
+      ':count': '3',
+      ':enabled': 'false',
+      ':nested': { x: 1, y: true },
+      ':nothing': 'null',
+    })
+    // Quoted YAML strings must stay unprefixed strings
+    const quoted = await parseMarkdown('::comp\n---\ncount: "3"\nenabled: "false"\n---\n::')
+    expect(getAttrs(quoted.nodes[0] as Node)).toEqual({
+      count: '3',
+      enabled: 'false',
+    })
   })
 
   it('parses document-level comment-only frontmatter without throwing', async () => {

--- a/packages/comark/test/nested-component-blank-lines.test.ts
+++ b/packages/comark/test/nested-component-blank-lines.test.ts
@@ -24,7 +24,7 @@ describe('nested component with a run of blank lines between siblings', () => {
       [
         'outer',
         {},
-        ['mid', { columns: '3' }, ['a', { display: 'flex' }], ['b', { display: 'flex' }], ['c', { display: 'flex' }]],
+        ['mid', { ':columns': '3' }, ['a', { display: 'flex' }], ['b', { display: 'flex' }], ['c', { display: 'flex' }]],
       ],
     ]
 
@@ -37,7 +37,7 @@ describe('nested component with a run of blank lines between siblings', () => {
       // `mid` must still close at its own `::`, not swallow `after` too.
       const src = '::outer\n  ::mid\n  ---\n  columns: 3\n  ---\n    ::A\n    ::\n\n\n  ::\nafter\n::'
       const tree = await parseMarkdown(src)
-      expect(tree.nodes).toEqual([['outer', {}, ['mid', { columns: '3' }, ['a', {}]], ['p', {}, 'after']]])
+      expect(tree.nodes).toEqual([['outer', {}, ['mid', { ':columns': '3' }, ['a', {}]], ['p', {}, 'after']]])
     })
   })
 

--- a/packages/comark/test/nested-component-blank-lines.test.ts
+++ b/packages/comark/test/nested-component-blank-lines.test.ts
@@ -24,7 +24,13 @@ describe('nested component with a run of blank lines between siblings', () => {
       [
         'outer',
         {},
-        ['mid', { ':columns': '3' }, ['a', { display: 'flex' }], ['b', { display: 'flex' }], ['c', { display: 'flex' }]],
+        [
+          'mid',
+          { ':columns': '3' },
+          ['a', { display: 'flex' }],
+          ['b', { display: 'flex' }],
+          ['c', { display: 'flex' }],
+        ],
       ],
     ]
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "43.6k (74 files)",
         "@comark/svelte": "43.9k (82 files)",
         "@comark/vue": "60.5k (78 files)",
-        "comark": "403k (154 files)",
+        "comark": "404k (154 files)",
       }
     `)
   })


### PR DESCRIPTION
### What

Store non-string YAML block props as `:`-prefixed bindings (MDC-compatible) so framework renderers restore numbers, booleans, and null via `resolveAttributes({ parseJson: true })`. Quoted YAML strings stay plain strings. Markdown stringify strips JSON bindings and keeps path bindings prefixed.

### Why

Top-level YAML scalars like `count: 3` / `enabled: false` were stringified without a `:` prefix, so components received `"3"` / `"false"` instead of typed values (while nested objects already survived). This broke parity with `@nuxtjs/mdc` and caused prop-validation issues. Fixes #364.