### PR TITLE
docs: configure nuxt-llms for /llms.txt and /llms-full.txt

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -12,6 +12,21 @@ export default defineNuxtConfig({
     name: 'Comark',
   },
 
+  // nuxt-llms is provided by the comark-docs layer. `domain` is required — without it the
+  // module skips registering /llms.txt and /llms-full.txt. Content sections and page bodies
+  // are filled in by the layer's llms server plugin from navigation + appConfig.docs.llms.
+  llms: {
+    domain: 'https://comark.dev',
+    title: 'Comark',
+    description:
+      'Parse and render Markdown anywhere with one JavaScript library for HTML, ANSI, Vue, React, Svelte and Angular, plus plugins and streaming.',
+    full: {
+      title: 'Comark Documentation',
+      description:
+        'Complete Comark documentation as plain markdown — getting started, syntax, rendering, plugins, API reference, comparisons, and examples.',
+    },
+  },
+
   app: {
     head: {
       link: [

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -12,9 +12,6 @@ export default defineNuxtConfig({
     name: 'Comark',
   },
 
-  // nuxt-llms is provided by the comark-docs layer. `domain` is required — without it the
-  // module skips registering /llms.txt and /llms-full.txt. Content sections and page bodies
-  // are filled in by the layer's llms server plugin from navigation + appConfig.docs.llms.
   llms: {
     domain: 'https://comark.dev',
     title: 'Comark',


### PR DESCRIPTION
## Summary

- Adds the required `llms` block to `docs/nuxt.config.ts` so [nuxt-llms](https://github.com/nuxt-content/nuxt-llms) actually registers `/llms.txt` and `/llms-full.txt`
- Without `llms.domain`, the module logs a warning and skips route registration — which is why https://comark.dev/llms.txt currently 404s
- `full` enables `/llms-full.txt`; title/description match existing `site` / `appConfig.docs.llms` copy
- Content sections and page bodies still come from the comark-docs layer's `llms` server plugin (navigation + markdown mirrors)

## Test plan

- [x] `nuxi prepare` registers `/llms.txt` and `/llms-full.txt` nitro routes
- [ ] After deploy, `curl https://comark.dev/llms.txt` returns a structured index
- [ ] `curl https://comark.dev/llms-full.txt` returns concatenated page markdown
