### PR TITLE
fix: preserve number, boolean, and null types in YAML block props

### DIFF
--- a/packages/comark/SPEC/COMARK/component-block-props-types.md
+++ b/packages/comark/SPEC/COMARK/component-block-props-types.md
@@ -29,9 +29,9 @@ Component content
       "component",
       {
         "title": "Hello World",
-        "count": "42",
-        "enabled": "true",
-        "hidden": "false",
+        "count": 42,
+        "enabled": true,
+        "hidden": false,
         "tags": [
           "markdown",
           "docs"
@@ -50,7 +50,7 @@ Component content
 ## HTML
 
 ```html
-<component title="Hello World" count="42" enabled hidden="false" tags="[\"markdown\",\"docs\"]" config="{\"theme\":\"dark\",\"debug\":false}">
+<component title="Hello World" count="42" enabled tags="[\"markdown\",\"docs\"]" config="{\"theme\":\"dark\",\"debug\":false}">
   Component content
 </component>
 ```
@@ -61,7 +61,7 @@ Component content
 ::component
 ```yaml [props]
 title: Hello World
-count: '42'
+count: 42
 enabled: true
 hidden: false
 tags:

--- a/packages/comark/SPEC/COMARK/component-nested-multiline-separated.md
+++ b/packages/comark/SPEC/COMARK/component-nested-multiline-separated.md
@@ -67,12 +67,12 @@ full-width: true
     [
       "page-section",
       {
-        "full-width": "true"
+        "full-width": true
       },
       [
         "multi-column",
         {
-          "columns": "3"
+          "columns": 3
         },
         [
           "container",

--- a/packages/comark/SPEC/COMARK/component-nested4.md
+++ b/packages/comark/SPEC/COMARK/component-nested4.md
@@ -97,7 +97,7 @@ timeout:
             "button",
             {
               ":data-testid": "$doc.snippet.description",
-              "external": "true",
+              "external": true,
               ":to": "$doc.snippet.link",
               "appearance": "primary"
             },

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -1,5 +1,6 @@
 import type { ElementNode, Node } from 'comark'
 import { htmlToNodes, parseInlineHtmlTag } from './html/index.ts'
+import { decodeYamlTypedValue } from '../yaml.ts'
 
 // `::tag` components that should fold into a single same-tagged child.
 const WRAPPER_TAGS = new Set(['ul', 'ol', 'table', 'blockquote', 'pre'])
@@ -121,13 +122,27 @@ function processAttributes(
       const [key] = attr
       let value = attr[1]
 
+      // Restore the real type of a value encoded by `encodeYamlTypedValue`.
+      // A restored value is already correctly typed, so it must skip the
+      // `{`/`[` heuristic below. Otherwise a YAML string that looks like JSON
+      // (e.g. `tags: "[1,2,3]"`) would get parsed a second time and lose its
+      // real type as a string.
+      let isYamlTypedValue = false
+      if (typeof value === 'string') {
+        const decoded = decodeYamlTypedValue(value)
+        if (decoded !== value) {
+          value = decoded
+          isYamlTypedValue = true
+        }
+      }
+
       // Filter empty values if requested
       if (filterEmpty && (value === '' || value === null || value === undefined)) {
         continue
       }
 
       // Handle JSON values
-      if (handleJSON && typeof value === 'string') {
+      if (handleJSON && !isYamlTypedValue && typeof value === 'string') {
         if (value.startsWith('{') && value.endsWith('}')) {
           try {
             value = JSON.parse(value)

--- a/packages/comark/src/internal/yaml.ts
+++ b/packages/comark/src/internal/yaml.ts
@@ -16,6 +16,48 @@ export function parseYaml(content: string): Record<string, unknown> | undefined 
 }
 
 /**
+ * A markdown-it token attr must be a string. This prefix marks a string as an
+ * encoded value, so it can round-trip back to its real type.
+ *
+ * The prefix starts with a NUL byte. `encodeYamlTypedValue` always applies it
+ * through `JSON.stringify`, which escapes any NUL byte in the source value as
+ * literal text (` `), not a raw byte. So the raw NUL only ever appears at
+ * position 0, placed by this function. It can't collide with real content,
+ * even a quoted YAML string that itself contains an escaped NUL byte.
+ */
+const YAML_TYPED_VALUE_PREFIX = '\x00yaml:'
+
+/**
+ * Encode a value so it can be stored as a token attr string, then later
+ * restored by `decodeYamlTypedValue`. Call this for every value read from a
+ * YAML block, including strings, not only non-string values.
+ *
+ * @param value - The parsed YAML value to encode
+ * @returns The encoded string
+ */
+export function encodeYamlTypedValue(value: unknown): string {
+  return `${YAML_TYPED_VALUE_PREFIX}${JSON.stringify(value)}`
+}
+
+/**
+ * Restore a value encoded by `encodeYamlTypedValue`.
+ *
+ * @param value - The string to decode
+ * @returns The original value. Returns `value` unchanged if it has no encoding
+ * prefix, or if the encoded content is not valid JSON.
+ */
+export function decodeYamlTypedValue(value: string): unknown {
+  if (!value.startsWith(YAML_TYPED_VALUE_PREFIX)) {
+    return value
+  }
+  try {
+    return JSON.parse(value.slice(YAML_TYPED_VALUE_PREFIX.length))
+  } catch {
+    return value
+  }
+}
+
+/**
  * Stringify YAML data
  * @param data - The data to stringify
  * @returns The stringified data

--- a/packages/comark/src/plugins/components.ts
+++ b/packages/comark/src/plugins/components.ts
@@ -13,7 +13,7 @@ import type { MarkdownItPlugin } from '../types.ts'
 import { defineComarkPlugin } from '../utils/helpers.ts'
 import { findClosingBracket, parseBracketContent } from '../internal/parse/syntax/brackets.ts'
 import { parseBlockParams } from '../internal/parse/syntax/block-params.ts'
-import { parseYaml } from '../internal/yaml.ts'
+import { encodeYamlTypedValue, parseYaml } from '../internal/yaml.ts'
 
 /**
  * A component name must start with a letter or `$`, followed by word chars,
@@ -290,7 +290,7 @@ const markdownItComarkBlock: PluginSimple = (md) => {
       const token = state.env.comarkBlockTokens[0]
       Object.entries(data || {}).forEach(([key, value]) => {
         if (key === 'class') token.attrJoin(key, value as string)
-        else token.attrSet(key, typeof value === 'string' ? value : JSON.stringify(value))
+        else token.attrSet(key, encodeYamlTypedValue(value))
       })
     }
 

--- a/packages/comark/test/empty-props.test.ts
+++ b/packages/comark/test/empty-props.test.ts
@@ -61,8 +61,8 @@ describe('empty component props block (#319)', () => {
     const hero = result.nodes[0] as Node
 
     expect(isElement(hero, 'hero')).toBe(true)
-    // Non-string attribute values are JSON-stringified onto the element (see components.ts)
-    expect(getAttrs(hero).count).toBe('3')
+    // Non-string attribute values keep their native YAML type (see #364).
+    expect(getAttrs(hero).count).toBe(3)
     expect(getAttrs(hero).label).toBe('hello')
   })
 

--- a/packages/comark/test/nested-component-blank-lines.test.ts
+++ b/packages/comark/test/nested-component-blank-lines.test.ts
@@ -24,7 +24,7 @@ describe('nested component with a run of blank lines between siblings', () => {
       [
         'outer',
         {},
-        ['mid', { columns: '3' }, ['a', { display: 'flex' }], ['b', { display: 'flex' }], ['c', { display: 'flex' }]],
+        ['mid', { columns: 3 }, ['a', { display: 'flex' }], ['b', { display: 'flex' }], ['c', { display: 'flex' }]],
       ],
     ]
 
@@ -37,7 +37,7 @@ describe('nested component with a run of blank lines between siblings', () => {
       // `mid` must still close at its own `::`, not swallow `after` too.
       const src = '::outer\n  ::mid\n  ---\n  columns: 3\n  ---\n    ::A\n    ::\n\n\n  ::\nafter\n::'
       const tree = await parseMarkdown(src)
-      expect(tree.nodes).toEqual([['outer', {}, ['mid', { columns: '3' }, ['a', {}]], ['p', {}, 'after']]])
+      expect(tree.nodes).toEqual([['outer', {}, ['mid', { columns: 3 }, ['a', {}]], ['p', {}, 'after']]])
     })
   })
 

--- a/packages/comark/test/yaml-block-props-types.test.ts
+++ b/packages/comark/test/yaml-block-props-types.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { parseMarkdown } from '../src/index'
+import type { Node } from 'comark'
+
+// Helper to check if a node is an element with a specific tag
+function isElement(node: Node, tag: string): boolean {
+  return Array.isArray(node) && node[0] === tag
+}
+
+// Helper to get the attrs object of an element
+function getAttrs(node: Node): Record<string, unknown> {
+  return Array.isArray(node) ? ((node[1] as Record<string, unknown>) ?? {}) : {}
+}
+
+describe('YAML block props keep their native types (#364)', () => {
+  it('keeps top-level number, boolean, and null scalars typed', async () => {
+    const result = await parseMarkdown(
+      [
+        '::comp',
+        '---',
+        'a-string: "hello"',
+        'a-number: 3',
+        'a-negative-number: -1.5',
+        'a-true-bool: true',
+        'a-false-bool: false',
+        'a-null: null',
+        '---',
+        '::',
+      ].join('\n')
+    )
+    const comp = result.nodes[0] as Node
+
+    expect(isElement(comp, 'comp')).toBe(true)
+    const attrs = getAttrs(comp)
+    expect(attrs['a-string']).toBe('hello')
+    expect(attrs['a-number']).toBe(3)
+    expect(attrs['a-negative-number']).toBe(-1.5)
+    expect(attrs['a-true-bool']).toBe(true)
+    expect(attrs['a-false-bool']).toBe(false)
+    expect(attrs['a-null']).toBe(null)
+  })
+
+  it('keeps nested object and list values typed, matching top-level scalars', async () => {
+    const result = await parseMarkdown(
+      ['::comp', '---', 'a-nested-object:', '  x: 1', '  y: true', 'a-list:', '  - 1', '  - two', '  - false', '---', '::'].join(
+        '\n'
+      )
+    )
+    const comp = result.nodes[0] as Node
+    const attrs = getAttrs(comp)
+
+    expect(attrs['a-nested-object']).toEqual({ x: 1, y: true })
+    expect(attrs['a-list']).toEqual([1, 'two', false])
+  })
+
+  it('does not coerce explicitly-quoted strings that look like numbers or booleans', async () => {
+    const result = await parseMarkdown(
+      ['::comp', '---', 'a-quoted-number: "3"', 'a-quoted-bool: "false"', '---', '::'].join('\n')
+    )
+    const comp = result.nodes[0] as Node
+    const attrs = getAttrs(comp)
+
+    expect(attrs['a-quoted-number']).toBe('3')
+    expect(attrs['a-quoted-bool']).toBe('false')
+  })
+
+  it('does not corrupt a string value that collides with the internal type-encoding prefix', async () => {
+    // The internal encoding prefix starts with a NUL byte. A quoted YAML string
+    // can contain a NUL byte too, via the `\0` escape. This must not be treated
+    // as an encoded value.
+    const result = await parseMarkdown('::comp\n---\ntitle: "\\0yaml:true"\n---\n::')
+    const comp = result.nodes[0] as Node
+    const attrs = getAttrs(comp)
+
+    expect(attrs.title).toBe('\u0000yaml:true')
+  })
+
+  it('does not re-parse a quoted string that looks like a JSON array or object', async () => {
+    // `processAttributes` re-parses a `{...}`/`[...]` shaped string as JSON for
+    // other attribute syntaxes. A YAML-block string must not go through that a
+    // second time after it has already been restored to its real string type.
+    const result = await parseMarkdown(
+      ['::comp', '---', 'tags: "[1,2,3]"', 'title: "{\\"a\\":1}"', '---', '::'].join('\n')
+    )
+    const comp = result.nodes[0] as Node
+    const attrs = getAttrs(comp)
+
+    expect(attrs.tags).toBe('[1,2,3]')
+    expect(attrs.title).toBe('{"a":1}')
+  })
+
+  it('does not corrupt a nested string value that collides with the internal type-encoding prefix', async () => {
+    // The whole props object is encoded as one JSON unit, so a colliding
+    // string nested inside it must stay safe too, not only at the top level.
+    const result = await parseMarkdown('::comp\n---\nconfig:\n  inner: "\\0yaml:true"\n---\n::')
+    const comp = result.nodes[0] as Node
+    const attrs = getAttrs(comp)
+
+    expect(attrs.config).toEqual({ inner: '\u0000yaml:true' })
+  })
+
+  it('applies the `{`/`[` JSON heuristic only to the syntax that relies on it', async () => {
+    // Inline brace attrs have no real type information, so `{...}`/`[...]`
+    // shaped values are meant to be parsed as JSON there. A YAML-block string
+    // must keep its own real type instead, even on the same component.
+    const result = await parseMarkdown('::comp{list="[1,2,3]"}\n---\ntags: "[1,2,3]"\n---\n::')
+    const comp = result.nodes[0] as Node
+    const attrs = getAttrs(comp)
+
+    expect(attrs.list).toEqual([1, 2, 3])
+    expect(attrs.tags).toBe('[1,2,3]')
+  })
+
+  it('keeps types through the alternate ```yaml [props] fence delimiter', async () => {
+    const result = await parseMarkdown('::comp\n```yaml [props]\ncount: 3\nflag: true\n```\n::')
+    const comp = result.nodes[0] as Node
+    const attrs = getAttrs(comp)
+
+    expect(attrs.count).toBe(3)
+    expect(attrs.flag).toBe(true)
+  })
+
+  it('matches the real-world apis-list regression case from the migration issue', async () => {
+    const result = await parseMarkdown(
+      [
+        '::apis-list',
+        '---',
+        'cta-text: "View APIs"',
+        'page-size: 3',
+        'pagination: false',
+        'grid-columns-breakpoints:',
+        '  mobile: 3',
+        '  phablet: 3',
+        '  tablet: 3',
+        '  desktop: 3',
+        '---',
+        '::',
+      ].join('\n')
+    )
+    const comp = result.nodes[0] as Node
+    const attrs = getAttrs(comp)
+
+    expect(attrs).toEqual({
+      'cta-text': 'View APIs',
+      'page-size': 3,
+      pagination: false,
+      'grid-columns-breakpoints': { mobile: 3, phablet: 3, tablet: 3, desktop: 3 },
+    })
+  })
+})

--- a/packages/comark/test/yaml.test.ts
+++ b/packages/comark/test/yaml.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseYaml } from '../src/internal/yaml'
+import { decodeYamlTypedValue, encodeYamlTypedValue, parseYaml } from '../src/internal/yaml'
 
 describe('parseYaml', () => {
   describe('empty documents resolve to undefined', () => {
@@ -83,6 +83,92 @@ meta:
 
     it('throws when the input contains more than one document', () => {
       expect(() => parseYaml('x: 1\n---\ny: 2')).toThrow()
+    })
+  })
+})
+
+describe('encodeYamlTypedValue / decodeYamlTypedValue', () => {
+  describe('round-trips every YAML value type', () => {
+    it.each([
+      ['number', 3],
+      ['negative number', -1.5],
+      ['zero', 0],
+      ['true', true],
+      ['false', false],
+      ['null', null],
+      ['object', { x: 1, y: true }],
+      ['array', [1, 'two', false]],
+      ['empty object', {}],
+      ['empty array', []],
+    ] as const)('restores a %s value to its original type', (_label, value) => {
+      const encoded = encodeYamlTypedValue(value)
+      expect(typeof encoded).toBe('string')
+      expect(decodeYamlTypedValue(encoded)).toEqual(value)
+    })
+  })
+
+  describe('leaves genuine strings unchanged', () => {
+    it('does not alter a plain string', () => {
+      expect(decodeYamlTypedValue('hello')).toBe('hello')
+    })
+
+    it('does not alter an empty string', () => {
+      expect(decodeYamlTypedValue('')).toBe('')
+    })
+
+    it('does not alter a string that looks like JSON but has no encoding prefix', () => {
+      // This is the case `processAttributes`'s `{`/`[` heuristic already handles
+      // for object/array values from other syntaxes. Decoding must not touch it.
+      expect(decodeYamlTypedValue('{"a":1}')).toBe('{"a":1}')
+      expect(decodeYamlTypedValue('[1,2,3]')).toBe('[1,2,3]')
+    })
+
+    it('does not alter a string that looks like a number or boolean', () => {
+      // Explicitly-quoted YAML scalars (e.g. `count: "3"`) must stay strings.
+      expect(decodeYamlTypedValue('3')).toBe('3')
+      expect(decodeYamlTypedValue('false')).toBe('false')
+    })
+  })
+
+  describe('fails safe on a malformed encoded value', () => {
+    it('returns the original string when the encoded JSON is invalid', () => {
+      const malformed = `${encodeYamlTypedValue(1)}garbage`
+      expect(decodeYamlTypedValue(malformed)).toBe(malformed)
+    })
+  })
+
+  describe('does not collide with a string containing the encoding prefix', () => {
+    it('round-trips a string that starts with the raw prefix bytes', () => {
+      // A quoted YAML scalar can contain a NUL byte via the `\0` escape, so a
+      // genuine string value can start with the same bytes as the prefix.
+      // `encodeYamlTypedValue` must still round-trip it correctly.
+      const collidingString = `${String.fromCharCode(0)}yaml:true`
+      const encoded = encodeYamlTypedValue(collidingString)
+      expect(decodeYamlTypedValue(encoded)).toBe(collidingString)
+    })
+  })
+
+  describe('values that JSON cannot represent', () => {
+    // `parseYaml` can never produce these values (its `JSON_SCHEMA` has no
+    // `NaN`/`Infinity`/`undefined` tag), so these document known behavior for
+    // any future caller of these functions, not a live parsing path.
+
+    it('collapses NaN to null, matching JSON.stringify', () => {
+      expect(JSON.stringify(Number.NaN)).toBe('null')
+      expect(decodeYamlTypedValue(encodeYamlTypedValue(Number.NaN))).toBeNull()
+    })
+
+    it('collapses Infinity to null, matching JSON.stringify', () => {
+      expect(JSON.stringify(Number.POSITIVE_INFINITY)).toBe('null')
+      expect(decodeYamlTypedValue(encodeYamlTypedValue(Number.POSITIVE_INFINITY))).toBeNull()
+    })
+
+    it('fails safe on undefined instead of round-tripping it', () => {
+      // `JSON.stringify(undefined)` returns `undefined`, not a string, so the
+      // encoded value degrades to the literal text "undefined", which is not
+      // valid JSON. `decodeYamlTypedValue` then returns it unchanged.
+      const encoded = encodeYamlTypedValue(undefined)
+      expect(decodeYamlTypedValue(encoded)).toBe(encoded)
     })
   })
 })


### PR DESCRIPTION
### What

- Add `encodeYamlTypedValue`/`decodeYamlTypedValue` in `internal/yaml.ts`. These functions tag a value with a prefix before it is stored as a token attribute string, then restore the value to its real type later.
- Update `comark_block_yaml` to encode every value from a YAML props block, not only non-string values.
- Update `processAttributes` to decode a tagged value, and skip the existing `{}`/`[]` JSON re-parse heuristic for values already restored this way. This prevents a YAML string that looks like JSON (e.g. `tags: "[1,2,3]"`) from getting parsed a second time.

### Why

A YAML block props value lost its real type. The parser converted every value to a string with `JSON.stringify`. A later step restored objects and arrays, but not numbers, booleans, or null. This caused prop type mismatches in framework components (e.g. Vue prop validation warnings). Fixes #364.