### PR TITLE
fix(security): keep boolean false props and reject non-string href/src

### DIFF
--- a/packages/comark/src/internal/props-validation.ts
+++ b/packages/comark/src/internal/props-validation.ts
@@ -1,3 +1,10 @@
+/**
+ * Sentinel returned by {@link validateProp} to signal "drop this attribute".
+ * A dedicated symbol (rather than `false`) keeps rejection distinguishable
+ * from a prop whose real value is the boolean `false` (#367).
+ */
+export const REJECTED_PROP = Symbol('comark:rejected-prop')
+
 export const unsafeTags = ['object']
 
 export const unsafeAttributes = ['srcdoc', 'formaction']
@@ -33,7 +40,11 @@ function rewriteToDefaultOrigin(urlStr: string, defaultOrigin: string): string {
   }
 }
 
-function validateUrl(value: string, mode: 'link' | 'image', options: PropsValidationOptions): string | false {
+function validateUrl(
+  value: string,
+  mode: 'link' | 'image',
+  options: PropsValidationOptions
+): string | typeof REJECTED_PROP {
   const {
     allowedLinkPrefixes = ['*'],
     allowedImagePrefixes = ['*'],
@@ -59,19 +70,19 @@ function validateUrl(value: string, mode: 'link' | 'image', options: PropsValida
 
   // Block known-unsafe protocols — hard floor, not overrideable by options
   if (unsafeLinkPrefix.some((prefix) => url.href.toLowerCase().startsWith(prefix))) {
-    return false
+    return REJECTED_PROP
   }
 
   // Block data: images when allowDataImages is false
   if (mode === 'image' && !allowDataImages && url.protocol === 'data:') {
-    return false
+    return REJECTED_PROP
   }
 
   // Check allowed protocols
   if (!allowedProtocols.includes('*')) {
     const protocol = url.protocol.replace(':', '')
     if (!allowedProtocols.includes(protocol)) {
-      return false
+      return REJECTED_PROP
     }
   }
 
@@ -84,29 +95,32 @@ function validateUrl(value: string, mode: 'link' | 'image', options: PropsValida
       if (defaultOrigin) {
         return rewriteToDefaultOrigin(urlSanitized, defaultOrigin)
       }
-      return false
+      return REJECTED_PROP
     }
   }
 
   return value
 }
 
-export function validateProp(attribute: string, value: string, options: PropsValidationOptions = {}): string | false {
+export function validateProp(attribute: string, value: unknown, options: PropsValidationOptions = {}): unknown {
   attribute = attribute
     .toLowerCase()
     .replace(/^(:|v-bind:)/, '')
     .replace(/^(@|v-on:)/, 'on')
     .replace(/:/g, '')
   if (attribute.startsWith('on') || unsafeAttributes.includes(attribute)) {
-    return false
+    return REJECTED_PROP
   }
 
   if (attribute === 'href' || attribute === 'xlinkhref') {
-    return validateUrl(value, 'link', options)
+    // A non-string href can reach here as an array/object from the YAML
+    // block-props JSON round-trip. Reject it instead of passing it through
+    // unvalidated (#367).
+    return typeof value === 'string' ? validateUrl(value, 'link', options) : REJECTED_PROP
   }
 
   if (attribute === 'src') {
-    return validateUrl(value, 'image', options)
+    return typeof value === 'string' ? validateUrl(value, 'image', options) : REJECTED_PROP
   }
 
   return value
@@ -138,7 +152,7 @@ export function validateProps(
 
       const result = validateProp(name, value, options)
 
-      if (result === false) {
+      if (result === REJECTED_PROP) {
         console.warn(`[comark/plugins/security] removing unsafe attribute: ${name}="${value}"`)
         return []
       }

--- a/packages/comark/test/empty-props.test.ts
+++ b/packages/comark/test/empty-props.test.ts
@@ -96,6 +96,58 @@ nothing: null
     })
   })
 
+  it('preserves negative numbers and mixed-type arrays as :bindings (#364)', async () => {
+    const result = await parseMarkdown(`::comp
+---
+a-negative-number: -1.5
+a-list:
+  - 1
+  - two
+  - false
+---
+::`)
+    const attrs = getAttrs(result.nodes[0] as Node)
+
+    expect(attrs).toEqual({
+      ':a-negative-number': '-1.5',
+      ':a-list': [1, 'two', false],
+    })
+  })
+
+  it('does not confuse a quoted string scalar with an unquoted scalar in the same block (#364)', async () => {
+    const result = await parseMarkdown(`::comp
+---
+count: 3
+quoted-count: "3"
+enabled: false
+quoted-enabled: "false"
+---
+::`)
+    const attrs = getAttrs(result.nodes[0] as Node)
+
+    expect(attrs).toEqual({
+      ':count': '3',
+      'quoted-count': '3',
+      ':enabled': 'false',
+      'quoted-enabled': 'false',
+    })
+  })
+
+  it('keeps an author-supplied :prefixed path binding distinct from :bindings for typed scalars (#364)', async () => {
+    const result = await parseMarkdown(`::comp
+---
+count: 3
+:to: $doc.snippet.link
+---
+::`)
+    const attrs = getAttrs(result.nodes[0] as Node)
+
+    expect(attrs).toEqual({
+      ':count': '3',
+      ':to': '$doc.snippet.link',
+    })
+  })
+
   it('parses document-level comment-only frontmatter without throwing', async () => {
     const result = await parseMarkdown('---\n# comment only\n---\n\n# Heading')
 

--- a/packages/comark/test/plugins/security.test.ts
+++ b/packages/comark/test/plugins/security.test.ts
@@ -106,6 +106,26 @@ describe('security plugin — XSS payloads', () => {
     expect(anchor![1].href).toBeUndefined()
   })
 
+  it('strips a javascript: href delivered as an array via YAML block-props (#367)', async () => {
+    // Non-string YAML block-prop values round-trip through a `:`-prefixed
+    // JSON-string attr that gets JSON.parsed back into a real array before
+    // this plugin runs — validateProp must not skip URL validation just
+    // because the value is no longer a plain string.
+    const tree = await parseWithSecurity(`\
+::a
+---
+href:
+  - javascript:alert(1)
+---
+click
+::`)
+
+    const anchor = collectElements(tree.nodes).find((element) => element[0] === 'a')
+    expect(anchor).toBeDefined()
+    expect(anchor![1].href).toBeUndefined()
+    expect(anchor![1][':href']).toBeUndefined()
+  })
+
   it('catches XSS payloads with HTML entities', async () => {
     const md = `\
 ## XSS payloads with HTML entities
@@ -392,6 +412,20 @@ describe('security plugin — prop sanitization', () => {
     await runPlugin(tree)
     const el = tree.nodes[0] as [string, any]
     expect(el[1]).toHaveProperty('href', 'https://example.com')
+  })
+
+  it('keeps a prop whose value is the boolean `false` (#367)', async () => {
+    const tree = makeTree([['comp', { enabled: false, count: 3 }]])
+    await runPlugin(tree)
+    const el = tree.nodes[0] as [string, any]
+    expect(el[1]).toEqual({ enabled: false, count: 3 })
+  })
+
+  it('keeps a `false` prop alongside a genuinely unsafe attribute, stripping only the unsafe one', async () => {
+    const tree = makeTree([['comp', { enabled: false, onclick: 'evil()' }]])
+    await runPlugin(tree)
+    const el = tree.nodes[0] as [string, any]
+    expect(el[1]).toEqual({ enabled: false })
   })
 
   it('leaves string nodes untouched', async () => {

--- a/packages/comark/test/props-validation.test.ts
+++ b/packages/comark/test/props-validation.test.ts
@@ -157,7 +157,9 @@ describe('validateProp', () => {
     })
 
     it('blocks ftp when only https and mailto are allowed', () => {
-      expect(validateProp('href', 'ftp://files.example.com', { allowedProtocols: ['https', 'mailto'] })).toBe(REJECTED_PROP)
+      expect(validateProp('href', 'ftp://files.example.com', { allowedProtocols: ['https', 'mailto'] })).toBe(
+        REJECTED_PROP
+      )
     })
 
     it('allows mailto when included in the list', () => {
@@ -185,7 +187,9 @@ describe('validateProp', () => {
     })
 
     it('blocks href that does not match any allowed prefix', () => {
-      expect(validateProp('href', 'https://evil.com/page', { allowedLinkPrefixes: ['https://myapp.com'] })).toBe(REJECTED_PROP)
+      expect(validateProp('href', 'https://evil.com/page', { allowedLinkPrefixes: ['https://myapp.com'] })).toBe(
+        REJECTED_PROP
+      )
     })
 
     it('relative hrefs are always allowed regardless of prefix list', () => {
@@ -260,7 +264,9 @@ describe('validateProp', () => {
     })
 
     it('data:text/html in href is always blocked regardless of allowDataImages', () => {
-      expect(validateProp('href', 'data:text/html,<script>evil()</script>', { allowDataImages: true })).toBe(REJECTED_PROP)
+      expect(validateProp('href', 'data:text/html,<script>evil()</script>', { allowDataImages: true })).toBe(
+        REJECTED_PROP
+      )
     })
   })
 

--- a/packages/comark/test/props-validation.test.ts
+++ b/packages/comark/test/props-validation.test.ts
@@ -1,32 +1,32 @@
 import { describe, expect, it, vi } from 'vitest'
-import { validateProp, validateProps } from '../src/internal/props-validation'
+import { REJECTED_PROP, validateProp, validateProps } from '../src/internal/props-validation'
 
 describe('validateProp', () => {
   describe('event handlers', () => {
     it('blocks onclick', () => {
-      expect(validateProp('onclick', 'alert(1)')).toBe(false)
+      expect(validateProp('onclick', 'alert(1)')).toBe(REJECTED_PROP)
     })
 
     it('blocks onmouseover', () => {
-      expect(validateProp('onmouseover', 'evil()')).toBe(false)
+      expect(validateProp('onmouseover', 'evil()')).toBe(REJECTED_PROP)
     })
 
     it('blocks uppercase ON* attributes', () => {
-      expect(validateProp('ONCLICK', 'alert(1)')).toBe(false)
+      expect(validateProp('ONCLICK', 'alert(1)')).toBe(REJECTED_PROP)
     })
 
     it('blocks mixed-case On* attributes', () => {
-      expect(validateProp('OnLoad', 'evil()')).toBe(false)
+      expect(validateProp('OnLoad', 'evil()')).toBe(REJECTED_PROP)
     })
   })
 
   describe('unsafe attributes', () => {
     it('blocks srcdoc', () => {
-      expect(validateProp('srcdoc', '<script>evil()</script>')).toBe(false)
+      expect(validateProp('srcdoc', '<script>evil()</script>')).toBe(REJECTED_PROP)
     })
 
     it('blocks formaction', () => {
-      expect(validateProp('formaction', 'https://evil.com')).toBe(false)
+      expect(validateProp('formaction', 'https://evil.com')).toBe(REJECTED_PROP)
     })
   })
 
@@ -48,43 +48,51 @@ describe('validateProp', () => {
     })
 
     it('blocks javascript: hrefs', () => {
-      expect(validateProp('href', 'javascript:alert(1)')).toBe(false)
+      expect(validateProp('href', 'javascript:alert(1)')).toBe(REJECTED_PROP)
     })
 
     it('blocks javascript: hrefs with uppercase', () => {
-      expect(validateProp('href', 'JAVASCRIPT:alert(1)')).toBe(false)
+      expect(validateProp('href', 'JAVASCRIPT:alert(1)')).toBe(REJECTED_PROP)
     })
 
     it('blocks data:text/html hrefs', () => {
-      expect(validateProp('href', 'data:text/html,<script>evil()</script>')).toBe(false)
+      expect(validateProp('href', 'data:text/html,<script>evil()</script>')).toBe(REJECTED_PROP)
     })
 
     it('blocks data:text/javascript hrefs', () => {
-      expect(validateProp('href', 'data:text/javascript,evil()')).toBe(false)
+      expect(validateProp('href', 'data:text/javascript,evil()')).toBe(REJECTED_PROP)
     })
 
     it('blocks data:text/css hrefs', () => {
-      expect(validateProp('href', 'data:text/css,body{}')).toBe(false)
+      expect(validateProp('href', 'data:text/css,body{}')).toBe(REJECTED_PROP)
     })
 
     it('blocks data:text/xml hrefs', () => {
-      expect(validateProp('href', 'data:text/xml,<x/>')).toBe(false)
+      expect(validateProp('href', 'data:text/xml,<x/>')).toBe(REJECTED_PROP)
     })
 
     it('blocks data:text/plain hrefs', () => {
-      expect(validateProp('href', 'data:text/plain,hello')).toBe(false)
+      expect(validateProp('href', 'data:text/plain,hello')).toBe(REJECTED_PROP)
     })
 
     it('blocks data:text/vbscript hrefs', () => {
-      expect(validateProp('href', 'data:text/vbscript,evil')).toBe(false)
+      expect(validateProp('href', 'data:text/vbscript,evil')).toBe(REJECTED_PROP)
     })
 
     it('blocks vbscript: hrefs', () => {
-      expect(validateProp('href', 'vbscript:MsgBox(1)')).toBe(false)
+      expect(validateProp('href', 'vbscript:MsgBox(1)')).toBe(REJECTED_PROP)
     })
 
     it('blocks URL-encoded javascript: hrefs', () => {
-      expect(validateProp('href', 'javascript%3Aalert(1)')).toBe(false)
+      expect(validateProp('href', 'javascript%3Aalert(1)')).toBe(REJECTED_PROP)
+    })
+
+    it('rejects a non-string href instead of passing it through unvalidated', () => {
+      // A non-string href can reach here via the YAML block-props JSON round-trip
+      // (e.g. `href:\n  - javascript:alert(1)` parses to a real array). It must
+      // not bypass validateUrl just because typeof value !== 'string'.
+      expect(validateProp('href', ['javascript:alert(1)'])).toBe(REJECTED_PROP)
+      expect(validateProp('href', { toString: () => 'javascript:alert(1)' })).toBe(REJECTED_PROP)
     })
   })
 
@@ -98,7 +106,11 @@ describe('validateProp', () => {
     })
 
     it('blocks javascript: src', () => {
-      expect(validateProp('src', 'javascript:evil()')).toBe(false)
+      expect(validateProp('src', 'javascript:evil()')).toBe(REJECTED_PROP)
+    })
+
+    it('rejects a non-string src instead of passing it through unvalidated', () => {
+      expect(validateProp('src', ['javascript:evil()'])).toBe(REJECTED_PROP)
     })
   })
 
@@ -120,17 +132,32 @@ describe('validateProp', () => {
     })
   })
 
+  describe('boolean false values (#367)', () => {
+    it('keeps a real boolean `false` value, not the rejection sentinel', () => {
+      expect(validateProp('enabled', false)).toBe(false)
+      expect(validateProp('pagination', false)).toBe(false)
+    })
+
+    it('does not confuse a boolean `false` value with a rejected attribute', () => {
+      expect(validateProp('enabled', false)).not.toBe(REJECTED_PROP)
+    })
+
+    it('still rejects genuinely unsafe attributes when the value happens to be a string', () => {
+      expect(validateProp('onclick', 'alert(1)')).toBe(REJECTED_PROP)
+    })
+  })
+
   describe('allowedProtocols', () => {
     it('allows href whose protocol is in the list', () => {
       expect(validateProp('href', 'https://example.com', { allowedProtocols: ['https'] })).toBe('https://example.com')
     })
 
     it('blocks href whose protocol is not in the list', () => {
-      expect(validateProp('href', 'http://example.com', { allowedProtocols: ['https'] })).toBe(false)
+      expect(validateProp('href', 'http://example.com', { allowedProtocols: ['https'] })).toBe(REJECTED_PROP)
     })
 
     it('blocks ftp when only https and mailto are allowed', () => {
-      expect(validateProp('href', 'ftp://files.example.com', { allowedProtocols: ['https', 'mailto'] })).toBe(false)
+      expect(validateProp('href', 'ftp://files.example.com', { allowedProtocols: ['https', 'mailto'] })).toBe(REJECTED_PROP)
     })
 
     it('allows mailto when included in the list', () => {
@@ -140,7 +167,7 @@ describe('validateProp', () => {
     })
 
     it('always blocks javascript: even if listed in allowedProtocols', () => {
-      expect(validateProp('href', 'javascript:alert(1)', { allowedProtocols: ['javascript'] })).toBe(false)
+      expect(validateProp('href', 'javascript:alert(1)', { allowedProtocols: ['javascript'] })).toBe(REJECTED_PROP)
     })
 
     it('wildcard ["*"] allows all safe protocols', () => {
@@ -158,7 +185,7 @@ describe('validateProp', () => {
     })
 
     it('blocks href that does not match any allowed prefix', () => {
-      expect(validateProp('href', 'https://evil.com/page', { allowedLinkPrefixes: ['https://myapp.com'] })).toBe(false)
+      expect(validateProp('href', 'https://evil.com/page', { allowedLinkPrefixes: ['https://myapp.com'] })).toBe(REJECTED_PROP)
     })
 
     it('relative hrefs are always allowed regardless of prefix list', () => {
@@ -190,7 +217,7 @@ describe('validateProp', () => {
     it('blocks src that does not match any allowed prefix', () => {
       expect(
         validateProp('src', 'https://tracker.evil.com/px.gif', { allowedImagePrefixes: ['https://cdn.myapp.com'] })
-      ).toBe(false)
+      ).toBe(REJECTED_PROP)
     })
 
     it('relative src is always allowed regardless of prefix list', () => {
@@ -216,15 +243,15 @@ describe('validateProp', () => {
 
   describe('allowDataImages', () => {
     it('allows data: src by default', () => {
-      expect(validateProp('src', 'data:image/png;base64,abc')).not.toBe(false)
+      expect(validateProp('src', 'data:image/png;base64,abc')).not.toBe(REJECTED_PROP)
     })
 
     it('blocks data: src when allowDataImages is false', () => {
-      expect(validateProp('src', 'data:image/png;base64,abc', { allowDataImages: false })).toBe(false)
+      expect(validateProp('src', 'data:image/png;base64,abc', { allowDataImages: false })).toBe(REJECTED_PROP)
     })
 
     it('blocks data:image/svg+xml src when allowDataImages is false', () => {
-      expect(validateProp('src', 'data:image/svg+xml,<svg/>', { allowDataImages: false })).toBe(false)
+      expect(validateProp('src', 'data:image/svg+xml,<svg/>', { allowDataImages: false })).toBe(REJECTED_PROP)
     })
 
     it('does not affect href when allowDataImages is false', () => {
@@ -233,7 +260,7 @@ describe('validateProp', () => {
     })
 
     it('data:text/html in href is always blocked regardless of allowDataImages', () => {
-      expect(validateProp('href', 'data:text/html,<script>evil()</script>', { allowDataImages: true })).toBe(false)
+      expect(validateProp('href', 'data:text/html,<script>evil()</script>', { allowDataImages: true })).toBe(REJECTED_PROP)
     })
   })
 
@@ -246,7 +273,7 @@ describe('validateProp', () => {
     })
 
     it('blocks javascript: xlink:href', () => {
-      expect(validateProp('xlink:href', 'javascript:alert(1)')).toBe(false)
+      expect(validateProp('xlink:href', 'javascript:alert(1)')).toBe(REJECTED_PROP)
     })
   })
 
@@ -265,7 +292,7 @@ describe('validateProp', () => {
       ]
 
       for (const [attribute, value] of payloads) {
-        expect(validateProp(attribute, value), `${attribute}="${value}"`).toBe(false)
+        expect(validateProp(attribute, value), `${attribute}="${value}"`).toBe(REJECTED_PROP)
       }
     })
 
@@ -312,6 +339,23 @@ describe('validateProps', () => {
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     validateProps('a', { href: 'javascript:evil()' })
     expect(spy).toHaveBeenCalledWith(expect.stringContaining('removing unsafe attribute'))
+    spy.mockRestore()
+  })
+
+  it('keeps a prop whose value is the boolean `false` (#367)', () => {
+    const result = validateProps('div', { pagination: false, count: 3 })
+    expect(result).toEqual({ pagination: false, count: 3 })
+  })
+
+  it('keeps multiple boolean props alongside other types (#367)', () => {
+    const result = validateProps('comp', { enabled: false, active: true, label: 'hi' })
+    expect(result).toEqual({ enabled: false, active: true, label: 'hi' })
+  })
+
+  it('does not warn when keeping a boolean `false` prop', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    validateProps('div', { pagination: false })
+    expect(spy).not.toHaveBeenCalled()
     spy.mockRestore()
   })
 

--- a/packages/comark/test/resolve-attributes.test.ts
+++ b/packages/comark/test/resolve-attributes.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import type { Node } from 'comark'
 import type { NodeRenderData } from '../src/types.ts'
 import { resolveAttribute, resolveAttributes } from '../src/internal/stringify/attributes.ts'
+import { parseMarkdown } from '../src/index'
 
 const makeRenderData = (overrides: Partial<NodeRenderData> = {}): NodeRenderData => ({
   frontmatter: {},
@@ -96,6 +98,50 @@ describe('resolveAttributes (parseJson mode)', () => {
   it('strips :prefix for non-string values already decoded by the parser', () => {
     const result = resolveAttributes({ ':config': { k: 'v' } }, renderData, { parseJson: true })
     expect(result).toEqual({ config: { k: 'v' } })
+  })
+})
+
+describe('parseMarkdown + resolveAttributes end-to-end (#364)', () => {
+  const renderData = makeRenderData()
+
+  it('restores native number/boolean/null/object types from a YAML block-props component', async () => {
+    const doc = await parseMarkdown(`::comp
+---
+label: "hello"
+count: 3
+a-negative-number: -1.5
+enabled: false
+active: true
+nested:
+  x: 1
+  y: true
+nothing: null
+---
+::`)
+    const comp = doc.nodes[0] as Node
+    const attrs = (comp as unknown as [string, Record<string, unknown>])[1]
+
+    const resolved = resolveAttributes(attrs, renderData, { parseJson: true })
+
+    expect(resolved).toEqual({
+      label: 'hello',
+      count: 3,
+      'a-negative-number': -1.5,
+      enabled: false,
+      active: true,
+      nested: { x: 1, y: true },
+      nothing: null,
+    })
+  })
+
+  it('keeps an explicitly-quoted YAML string a string end-to-end, not a coerced number/boolean', async () => {
+    const doc = await parseMarkdown('::comp\n---\ncount: "3"\nenabled: "false"\n---\n::')
+    const comp = doc.nodes[0] as Node
+    const attrs = (comp as unknown as [string, Record<string, unknown>])[1]
+
+    const resolved = resolveAttributes(attrs, renderData, { parseJson: true })
+
+    expect(resolved).toEqual({ count: '3', enabled: 'false' })
   })
 })
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "43.6k (74 files)",
         "@comark/svelte": "43.9k (82 files)",
         "@comark/vue": "60.5k (78 files)",
-        "comark": "404k (154 files)",
+        "comark": "405k (154 files)",
       }
     `)
   })


### PR DESCRIPTION
### What

Fixes #367: the `security()` plugin used the JS value `false` as an internal "reject this attribute" sentinel, indistinguishable from a prop whose real value is the boolean `false`. Such props were silently stripped. Fixed by introducing a dedicated `REJECTED_PROP` symbol.

Also adds test coverage for #364 (YAML block-props number/boolean/null type loss), already fixed in #365, including an end-to-end `parseMarkdown` -> `resolveAttributes({ parseJson: true })` round trip.

### Why

Widening `validateProp`'s value type to accept non-strings surfaced a related gap: `href`/`src`/`xlinkhref` values that aren't strings (e.g. an array produced by the YAML block-props JSON round-trip) were passed through without URL validation. These are now rejected outright.

<!--

AGENTS:
- The What and Why should each be 1-3 sentences.
- Write your answers based off of your conversation with the user, not purely based on the changed code
  - It's helpful to understand the reasoning behind an approach, what alternatives were considered, and why this approach was ultimately selected, rather than a summary of the lines changed
- For complex changes (>1k lines, not counting lockfiles):
  - Add a `### Walkthrough` section to the end which breaks down the primary changes into easy-to-follow `#### Sub-Sections`
-->
