### PR TITLE
docs: fix inaccuracies and align style across docs content

### DIFF
--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -133,11 +133,9 @@ This is an important message!
 
 The `::alert` block supports properties, children, and named slots. The renderer only uses components you explicitly register, so the source remains portable data rather than framework-specific code. Learn more in [Component Syntax](/syntax/components) and [Attributes](/syntax/attributes).
 
-::callout
-Editor and browser tooling:
+Editor and browser tooling when working with Comark components:
 - [Comark for VS Code extension](/getting-started/installation#ide-extension) for components and attributes syntax highlighting and autocomplete
 - [Comark for GitHub browser extension](/getting-started/installation#browser-extension) to visualize Comark syntax directly on GitHub Markdown pages
-::
 
 ## When to use Comark
 

--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -133,7 +133,7 @@ This is an important message!
 
 The `::alert` block supports properties, children, and named slots. The renderer only uses components you explicitly register, so the source remains portable data rather than framework-specific code. Learn more in [Component Syntax](/syntax/components) and [Attributes](/syntax/attributes).
 
-::callout{icon="i-simple-icons-visualstudiocode"}
+::callout
 Editor and browser tooling: install the [Comark for VS Code extension](/getting-started/installation#ide-extension) for components and attributes syntax highlighting and autocomplete, and the [Comark for GitHub browser extension](/getting-started/installation#browser-extension) to visualize Comark syntax directly on GitHub Markdown pages.
 ::
 

--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -95,7 +95,7 @@ export class AppComponent {
 Learn why we created Comark and the principles behind its design in [Why Comark](/kb/why-comark).
 ::
 
-## How It Works
+## How it works
 
 ::div{.border .border-default .rounded .bg-muted .p-4}
 ```mermaid
@@ -117,7 +117,7 @@ graph LR
 2. **Transform** - Inspect, transform, cache, or serialize the document
 3. **Render** - Convert the document to HTML, ANSI, Markdown, Vue, React, Svelte, or Angular
 
-## Extend Markdown When Needed
+## Extend Markdown when needed
 
 Plain Markdown works without any component syntax. When your content needs richer structure, Comark adds readable components and attributes without embedding verbose HTML or executable framework code:
 
@@ -133,15 +133,11 @@ This is an important message!
 
 The `::alert` block supports properties, children, and named slots. The renderer only uses components you explicitly register, so the source remains portable data rather than framework-specific code. Learn more in [Component Syntax](/syntax/components) and [Attributes](/syntax/attributes).
 
-::callout{to="/getting-started/installation#ide-extension" icon="i-simple-icons-visualstudiocode"}
-Install the Comark for VS Code extension to have components and attributes syntax highlighting and autocomplete.
+::callout{icon="i-simple-icons-visualstudiocode"}
+Editor and browser tooling: install the [Comark for VS Code extension](/getting-started/installation#ide-extension) for components and attributes syntax highlighting and autocomplete, and the [Comark for GitHub browser extension](/getting-started/installation#browser-extension) to visualize Comark syntax directly on GitHub Markdown pages.
 ::
 
-::callout{to="/getting-started/installation#browser-extension" icon="i-lucide-app-window"}
-Install the Comark for GitHub browser extension to visualize Comark components and attributes syntax directly on GitHub Markdown pages.
-::
-
-## When to Use Comark
+## When to use Comark
 
 Comark is ideal for:
 
@@ -151,7 +147,7 @@ Comark is ideal for:
 - **Documentation and blogs** - Combine standard Markdown with callouts, embeds, diagrams, and interactive UI
 - **Content pipelines** - Inspect, transform, cache, or serialize a compact document before rendering
 
-## Comparison with Other Tools
+## Comparison with other tools
 
 For detailed, honest comparisons, see [Comark vs MDX](/compare/comark-vs-mdx), [Comark vs react-markdown](/compare/comark-vs-react-markdown), [Comark vs Streamdown](/compare/comark-vs-streamdown), and [Comark vs Markdoc](/compare/comark-vs-markdoc).
 
@@ -169,7 +165,7 @@ For detailed, honest comparisons, see [Comark vs MDX](/compare/comark-vs-mdx), [
 | Auto-close for streams | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} |
 | Decoupled parsing & rendering | :icon{name="i-lucide-check" class="text-green-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-x" class="text-red-500"} | :icon{name="i-lucide-check" class="text-green-500"} |
 
-## Core Capabilities
+## Core capabilities
 
 ::card-group
 #default

--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -134,7 +134,9 @@ This is an important message!
 The `::alert` block supports properties, children, and named slots. The renderer only uses components you explicitly register, so the source remains portable data rather than framework-specific code. Learn more in [Component Syntax](/syntax/components) and [Attributes](/syntax/attributes).
 
 ::callout
-Editor and browser tooling: install the [Comark for VS Code extension](/getting-started/installation#ide-extension) for components and attributes syntax highlighting and autocomplete, and the [Comark for GitHub browser extension](/getting-started/installation#browser-extension) to visualize Comark syntax directly on GitHub Markdown pages.
+Editor and browser tooling:
+- [Comark for VS Code extension](/getting-started/installation#ide-extension) for components and attributes syntax highlighting and autocomplete
+- [Comark for GitHub browser extension](/getting-started/installation#browser-extension) to visualize Comark syntax directly on GitHub Markdown pages
 ::
 
 ## When to use Comark

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -15,7 +15,7 @@ links:
 ---
 
 
-## Quick Start
+## Quick start
 
 Choose the output you need and render your first Markdown document in minutes.
 
@@ -49,7 +49,7 @@ Choose the output you need and render your first Markdown document in minutes.
   ::
 ::
 
-## Agent Skill
+## Agent skill
 
 To give coding agents the Comark skill (syntax, AST, renderers, streaming), install it from production:
 
@@ -57,7 +57,7 @@ To give coding agents the Comark skill (syntax, AST, renderers, streaming), inst
 npx skills add https://comark.dev
 ```
 
-## IDE Extension
+## IDE extension
 
 Install the [Comark extension](https://marketplace.visualstudio.com/items?itemName=Nuxt.mdc) in **VS Code** or **Cursor** for syntax highlighting, bracket matching, document folding, and auto-completion in `.md` files using Comark syntax.
 
@@ -80,7 +80,7 @@ Or within your editor, open Quick Open (`Ctrl+P` / `Cmd+P`) and run:
 ext install Nuxt.mdc
 ```
 
-## Browser Extension
+## Browser extension
 
 Install **Comark for GitHub** to better visualize Markdown files that use Comark components and attributes syntax on GitHub.
 
@@ -121,7 +121,7 @@ target: "_blank"
 
 Comark packages share one pipeline. The core parser produces a serializable `MarkdownDocument`, while string and UI renderers consume that document. Install the package that matches your output:
 
-### UI Frameworks
+### UI frameworks
 
 Use these when you need to render Markdown as an interactive document in Vue, React, Nuxt, Svelte, or Angular.
 
@@ -197,7 +197,7 @@ Use these when you need to render Markdown as an interactive document in Vue, Re
   ::
 ::
 
-### String Renderers
+### String renderers
 
 Use these when you need a string output with no UI framework involved like server-side HTML generation, static site builds, or CLI tooling.
 
@@ -275,7 +275,7 @@ const parseDoc = createMarkdownParser({ plugins: [shiki(), toc()] })
 
 See the [Parse API](/reference/parse) and [Render API](/reference/render) for full options.
 
-## Learn More
+## Learn more
 
 Learn more about Comark features and syntax:
 

--- a/docs/content/1.getting-started/2.document-model.md
+++ b/docs/content/1.getting-started/2.document-model.md
@@ -40,7 +40,7 @@ title: Hello Comark
 
 The document is the shared boundary between parsing and rendering. You can parse once, serialize or cache the result, inspect or transform its nodes, and render it with HTML, ANSI, Vue, React, Svelte, or Angular.
 
-## Document Structure
+## Document structure
 
 The root object has three fields:
 
@@ -80,7 +80,7 @@ document.frontmatter
 
 ::
 
-### Plugin Metadata
+### Plugin metadata
 
 Plugins store derived document data in `document.meta`. For example, the table-of-contents plugin adds `meta.toc`:
 
@@ -97,7 +97,7 @@ console.log(document.meta.toc)
 
 Plugin types flow into `MarkdownDocument`, so metadata and frontmatter can stay strongly typed throughout your application.
 
-## Node Model
+## Node model
 
 Comark uses compact tuples instead of an object for every syntax node. A `Node` is a text string, an element tuple, or a comment tuple:
 
@@ -113,7 +113,7 @@ type CommentNode = [null, ElementNodeAttributes, string]
 
 This format follows the shape of rendered markup: the tag is at index `0`, attributes are at index `1`, and child nodes start at index `2`.
 
-### Text Nodes
+### Text nodes
 
 Text is stored directly as a string:
 
@@ -121,7 +121,7 @@ Text is stored directly as a string:
 "Hello, world!"
 ```
 
-### Element Nodes
+### Element nodes
 
 Elements use `[tag, attributes, ...children]`:
 
@@ -157,7 +157,7 @@ Check your configuration.
 [
   "alert",
   { "type": "warning" },
-  ["p", {}, "Check your configuration."]
+  "Check your configuration."
 ]
 ```
 
@@ -180,7 +180,7 @@ interface ElementNodeAttributes {
 
 Treat `$` as structural metadata. Component props and standard HTML attributes live alongside it.
 
-### Comment Nodes
+### Comment nodes
 
 Comments use `null` as their tag:
 
@@ -196,7 +196,7 @@ Comments use `null` as their tag:
 
 ::
 
-## Parse Once, Render Many
+## Parse once, render many
 
 Every renderer accepts the same `MarkdownDocument`. Parsing once is useful for server rendering, build pipelines, content APIs, caches, and multiple output targets.
 
@@ -235,11 +235,11 @@ Framework renderers expose a `MarkdownDocument` component for the same workflow:
 
 These components render a parsed document without importing or running the parser in the client bundle.
 
-## Inspect Documents
+## Inspect documents
 
 Use the utilities from `comark/utils` instead of writing traversal logic for common operations.
 
-### Extract Text
+### Extract text
 
 `textContent()` returns the plain text inside a node:
 
@@ -250,7 +250,7 @@ const heading = document.nodes[0]
 console.log(textContent(heading)) // Hello world
 ```
 
-### Visit Nodes
+### Visit nodes
 
 `visit()` walks every node that matches a checker. A visitor can inspect, replace, or remove matching nodes:
 
@@ -269,7 +269,7 @@ visit(document, isExternalLink, (node) => {
 
 The visitor mutates `document.nodes` when a node is replaced or removed. Create a copy first when your application requires immutable updates.
 
-## Serialize and Cache Documents
+## Serialize and cache documents
 
 A `MarkdownDocument` contains only plain arrays, objects, strings, and values contributed by plugins. You can send it over an API boundary or persist it as JSON:
 
@@ -285,7 +285,7 @@ const cachedDocument = JSON.parse(await cache.get(key)) as MarkdownDocument
 
 Use the same Comark and plugin versions when reading persisted documents. Rebuild cached documents after an upgrade that changes node output or plugin metadata.
 
-## Type Documents
+## Type documents
 
 Pass metadata and frontmatter types to `MarkdownDocument` when documents cross application boundaries:
 

--- a/docs/content/2.syntax/1.markdown.md
+++ b/docs/content/2.syntax/1.markdown.md
@@ -36,7 +36,7 @@ All headings automatically get ID attributes generated from their content for li
 <!-- Becomes: <h1 id="hello-world">Hello World</h1> -->
 ```
 
-## Text Formatting
+## Text formatting
 
 ::code-preview
 ::div
@@ -57,7 +57,7 @@ All headings automatically get ID attributes generated from their content for li
 ::
 
 ::callout
-Text nodes in Comark are simple strings, similar to HTML text nodes. To add custom styles, attributes, or metadata to specific parts of text, use the [Span Attributes](/syntax/attributes#span-attributes) syntax: `Hello [world]{data-world="earth" style="color: blue"}`. :br :br This creates a `<span>` element with custom attributes, allowing you to style or add metadata to inline text.
+Text nodes in Comark are plain strings, similar to HTML text nodes. To add custom styles, attributes, or metadata to specific parts of text, use the [Span Attributes](/syntax/attributes#span-attributes) syntax: `Hello [world]{data-world="earth" style="color: blue"}`. :br :br This creates a `<span>` element with custom attributes, so you can style or add metadata to inline text.
 ::
 
 ## Lists
@@ -82,7 +82,7 @@ Text nodes in Comark are simple strings, similar to HTML text nodes. To add cust
 3. Third item
 ```
 
-## Links and Images
+## Links and images
 
 ```mdc
 [Link text](https://example.com)
@@ -136,7 +136,7 @@ The [alerts plugin](/plugins/defaults/alert) is built-in and transforms special 
 
 Supported markers: `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`.
 
-### Horizontal Rules
+### Horizontal rules
 
 Any of these create a horizontal rule:
 
@@ -150,11 +150,11 @@ ___
 
 
 
-## Code Blocks
+## Code blocks
 
 Comark provides advanced code block features with metadata support.
 
-### Basic Code Block
+### Basic code block
 
 ::code-preview
 ```javascript
@@ -173,7 +173,7 @@ function hello() {
 ````
 ::
 
-### Filename Metadata
+### Filename metadata
 
 Add a filename using `[...]` brackets:
 
@@ -192,7 +192,7 @@ const app = express()
 ````
 ::
 
-### Line Highlighting
+### Line highlighting
 
 Highlight specific lines using `{...}` syntax:
 
@@ -226,7 +226,7 @@ function example() {
 | `{1,3,5}` | Multiple specific lines |
 | `{1-3,7,10-12}` | Combined ranges and lines |
 
-### Combined Metadata
+### Combined metadata
 
 All metadata can be combined in any order:
 
@@ -247,7 +247,7 @@ function hello() {
 ````
 ::
 
-### Special Characters in Filename
+### Special characters in filename
 
 Use backslash to escape special characters:
 
@@ -264,7 +264,7 @@ Use backslash to escape special characters:
 ````
 ::
 
-### AST Structure
+### AST structure
 
 Code blocks produce this AST structure:
 
@@ -283,7 +283,7 @@ Code blocks produce this AST structure:
 
 ---
 
-## Task Lists
+## Task lists
 
 Comark supports GitHub Flavored Markdown task lists:
 
@@ -328,7 +328,7 @@ Comark supports GitHub Flavored Markdown task lists:
 ```
 ::
 
-### Aligned Tables
+### Aligned tables
 
 ::code-preview
 | Left Aligned | Center Aligned | Right Aligned |
@@ -351,7 +351,7 @@ Comark supports GitHub Flavored Markdown task lists:
 | `:---:` | Center |
 | `---:` | Right |
 
-### Inline Markdown in Tables
+### Inline Markdown in tables
 
 ::code-preview
 | Feature      | Status          | Link                    |
@@ -393,7 +393,7 @@ Comments are represented in the [document model](/getting-started/document-model
 
 ## Emojis
 
-Comark includes built-in emoji support using the `:emoji_name:` syntax:
+Emoji shortcodes use the `:emoji_name:` syntax and require the [emoji plugin](/plugins/built-in/emoji):
 
 ::code-preview
 Hello :wave: Welcome to our docs! :rocket:
@@ -404,7 +404,7 @@ Hello :wave: Welcome to our docs! :rocket:
 ```
 ::
 
-### Popular Emojis
+### Popular emojis
 
 ::code-preview
 :smile: :heart: :fire: :rocket: :sparkles: :tada: :thinking: :eyes: :100: :star: :zap: :bulb: :warning:

--- a/docs/content/2.syntax/2.components.md
+++ b/docs/content/2.syntax/2.components.md
@@ -78,9 +78,9 @@ The status is :badge[Active]{color="green"} right now.
 
 Components support two property syntaxes: inline attributes and YAML frontmatter.
 
-### Inline Attributes
+### Inline attributes
 
-Use the `{...}` syntax for simple properties:
+Use the `{...}` syntax for scalar properties:
 
 ```mdc
 ::component{prop="value"}
@@ -112,7 +112,7 @@ Use the `{...}` syntax for simple properties:
 ::
 ```
 
-### Block Props
+### Block props
 
 For components with many properties, use YAML block syntax inside the component. Two styles are supported:
 
@@ -162,20 +162,20 @@ With full **markdown** support
 Objects remain objects, arrays remain arrays, and numbers/booleans are parsed as their respective types rather than strings. Your components receive fully typed props.
 ::
 
-#### Key Rules
+#### Key rules
 
 - Must be at the very beginning of the component content
 - Enclosed by `---` delimiters (frontmatter style) or `` ```yaml [props] `` fences (codeblock style)
-- Merged with inline attributes (inline attributes take precedence)
+- Merged with inline attributes (YAML props take precedence, `class` values are merged)
 - Full support for complex data structures
 
 ::tip
 The default style can be configured with the [`blockAttributesStyle`](/reference/render#options) option.
 ::
 
-### Combine Both Syntaxes
+### Combine both syntaxes
 
-Inline attributes and YAML props can be combined. Inline attributes take precedence:
+Inline attributes and YAML props can be combined. YAML props take precedence, except `class` values which are merged:
 
 ~~~mdc
 ::card{.featured}
@@ -190,7 +190,7 @@ This combines inline class `.featured` with YAML props
 ::
 ~~~
 
-### Use Cases
+### Use cases
 
 **Configuration-heavy components:**
 
@@ -234,7 +234,7 @@ response:
 ::
 ~~~
 
-## Data Binding
+## Data binding
 
 Props prefixed with `:` are JSON-parsed at render time. When the value isn't valid JSON, the renderer looks it up as a dot-path against an ambient **render context**, letting authors reference runtime data, frontmatter, meta, or the enclosing component's props without hardcoding them.
 
@@ -305,7 +305,7 @@ Nested components can read the enclosing component's resolved props through the 
 
 ### Resolution rules
 
-- If the `:prefixed` value is a valid JSON literal (e.g. `5`, `true`, `"foo"`, `{"a":1}`), it's used as-is.
+- If the `:prefixed` value is a valid JSON literal (for example `5`, `true`, `"foo"`, `{"a":1}`), it's used as-is.
 - Otherwise, the value is treated as a dot-path and resolved against `{ frontmatter, meta, data, props }`.
 - Unknown paths resolve to `undefined`: the prop is passed as `undefined` rather than the raw string.
 - Only props authored with the `:` prefix participate in data binding. Plain `prop="value"` attributes are always passed as literal strings.
@@ -318,7 +318,7 @@ Need to interpolate a value directly into text rather than a prop? The [Binding 
 
 Block components support slots for passing structured content to components.
 
-### Default Slot
+### Default slot
 
 Content placed directly inside a component goes to the default slot, no prefix needed:
 
@@ -340,7 +340,7 @@ Footer content here.
 ::
 ```
 
-### Named Slots
+### Named slots
 
 ```mdc
 ::card

--- a/docs/content/2.syntax/3.attributes.md
+++ b/docs/content/2.syntax/3.attributes.md
@@ -18,9 +18,9 @@ navigation:
 
 Comark allows adding custom attributes to native Markdown elements using `{...}` syntax after the element. Parsing is provided by the built-in [`attributes` plugin](/plugins/defaults/attributes) (enabled by default).
 
-## Element Attributes
+## Element attributes
 
-### Strong/Bold
+### Strong/bold
 
 ```mdc
 **bold text**{.highlight #important}
@@ -28,7 +28,7 @@ Comark allows adding custom attributes to native Markdown elements using `{...}`
 **bold text**{bool}
 ```
 
-### Italic/Emphasis
+### Italic/emphasis
 
 ```mdc
 *italic text*{.emphasized}
@@ -50,14 +50,14 @@ _italic text_{#custom-id}
 ![Logo](logo.svg){.logo #site-logo}
 ```
 
-### Inline Code
+### Inline code
 
 ```mdc
 `code snippet`{.language-js}
 `variable`{data-type="string"}
 ```
 
-### Attribute Types Summary
+### Attribute types summary
 
 | Syntax                     | Output                | Description           |
 | -------------------------- | --------------------- | --------------------- |
@@ -67,7 +67,7 @@ _italic text_{#custom-id}
 | `{key="value"}`            | `key="value"`         | Key-value attribute   |
 | `{:data='{"key": "val"}'}` | `data={"key": "val"}` | JSON object attribute |
 
-## Span Attributes
+## Span attributes
 
 Wrap inline text in a `<span>` element with custom attributes. This is useful for styling specific parts of text or adding metadata without creating custom components.
 
@@ -153,7 +153,7 @@ Reference this [specific text]{#ref-1} later.
 ```
 ::
 
-### Common Use Cases
+### Common use cases
 
 1. **Styling with utility classes:**
    ```mdc
@@ -186,7 +186,7 @@ Span syntax supports nested markdown formatting:
 ```
 ::
 
-## Block Attributes
+## Block attributes
 
 A trailing `{...}` on the last line of a block-level element attaches the attributes to that block. This works on paragraphs, headings, list items (bullet, ordered, and task list), and blockquote paragraphs.
 

--- a/docs/content/3.rendering/2.html.md
+++ b/docs/content/3.rendering/2.html.md
@@ -230,7 +230,7 @@ const html = await renderHtmlFromDocument(document)
 
 ---
 
-## Overriding HTML Elements
+## Overriding HTML elements
 
 Pass native HTML tag names as keys in `components` to override how standard elements render:
 
@@ -253,7 +253,7 @@ const renderHtml = createHtmlRenderer({
 
 ---
 
-## TypeScript Support
+## TypeScript support
 
 ```typescript
 import type { ElementNode, Node } from 'comark'
@@ -277,9 +277,9 @@ const renderHtml = createHtmlRenderer({ components })
 
 ---
 
-## Use Cases
+## Use cases
 
-### Static Site Generation
+### Static site generation
 
 ```typescript [build.ts]
 import { readFile, writeFile } from 'node:fs/promises'
@@ -302,7 +302,7 @@ async function buildPage(filePath: string) {
 }
 ```
 
-### RSS Feed
+### RSS feed
 
 ```typescript [rss.ts]
 import { createHtmlRenderer } from '@comark/html'
@@ -319,7 +319,7 @@ async function generateRSSItem(source: string) {
 }
 ```
 
-### API Response
+### API response
 
 ```typescript [server.ts]
 import { createHtmlRenderer } from '@comark/html'

--- a/docs/content/3.rendering/3.vue.md
+++ b/docs/content/3.rendering/3.vue.md
@@ -658,8 +658,8 @@ Pass the component to the `components` prop:
 When Comark encounters a tag, it looks for a matching Vue component in this order, stopping at the first match:
 
 1. **`Prose{PascalTag}`**: for example, `ProseH1` for `h1`. Follows the Nuxt Content prose component convention.
-2. **`{tag}`**: for example, `alert`. Exact tag name as-is.
-3. **`{PascalTag}`**: for example, `Alert` for `alert`. PascalCase version of the tag name.
+2. **`{PascalTag}`**: for example, `Alert` for `alert`. PascalCase version of the tag name.
+3. **`{tag}`**: for example, `alert`. Exact tag name as-is.
 4. **Global**: any component registered via `app.component()`.
 
 If none match, the tag renders as a native HTML element.

--- a/docs/content/3.rendering/3.vue.md
+++ b/docs/content/3.rendering/3.vue.md
@@ -43,15 +43,13 @@ bun add @comark/vue
 
 ## `<Markdown>`
 
-The `<Markdown>` component is the simplest way to render markdown in Vue. It handles parsing and rendering automatically.
+The `<Markdown>` component is the quickest way to render markdown in Vue. It handles parsing and rendering automatically.
 
 ::warning
 `<Markdown>` is an **async** component and must always be wrapped in `<Suspense>`
 ::
 
-::tip{to="/rendering/vue#code-markdowndocument"}
-For server-side rendering, use the `MarkdownDocument` component combined with parsing on the server instead.
-::
+For server-side rendering, use the [`MarkdownDocument`](#code-markdowndocument) component combined with parsing on the server instead.
 
 ```vue [App.vue]
 <script setup lang="ts">
@@ -113,7 +111,7 @@ Passing a document to `<Markdown>` skips parsing at runtime, but the **parser is
 | `value` | `string \| MarkdownDocument` | `undefined` | Markdown string or pre-parsed document (alternative to default slot) |
 | [`options`](#code-markdown-props-code-options) | `ParserOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
 | [`plugins`](#code-markdown-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
-| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
+| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, for example `"ul li"` |
 | [`components`](#code-markdown-props-code-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
 | [`componentsManifest`](#code-markdown-props-code-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
@@ -444,7 +442,7 @@ const document = await res.json()
 
 ::
 
-### Renderer Props
+### Renderer props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
@@ -498,7 +496,7 @@ const document = await res.json()
 
 ::
 
-#### Renderer Options
+#### Renderer options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -538,7 +536,7 @@ export const CommentMarkdownDocument = defineMarkdownDocumentComponent({
 
 ---
 
-## Live Documents
+## Live documents
 
 `MarkdownDocument` can subscribe to an ambient **context** so external sources can drive a mounted renderer: an HMR signal, a collaboration socket, an agent editing the document while you chat with it, or devtools. The listen key is the document's own `meta.key` (set by a plugin) or the `document-key` prop, so a parsed document can carry its own identity. If `globalThis.comarkContext` exists the renderer listens for updates on that key and re-renders; on unmount it cleans up. With no context, the key is ignored at zero cost.
 
@@ -564,11 +562,11 @@ A `path` is a node-index path into `document.nodes`: the first segment indexes t
 
 ---
 
-## Component Bindings
+## Component bindings
 
 Comark automatically bridges the gap between Comark syntax and your component's interface.
 
-### Prop Binding
+### Prop binding
 
 Attributes in Comark syntax are passed as props to your component. Use the `:` prefix to pass typed values:
 
@@ -579,12 +577,12 @@ Attributes in Comark syntax are passed as props to your component. Use the `:` p
 | `{:active="true"}` | `true` (boolean) |
 | `{:config='{"key":"val"}'}` | `{ key: 'val' }` (object) |
 
-### Named Slots
+### Named slots
 
 Named slots in Comark (`#slotname`) map to Vue named slots:
 
 - **Default slot** → `<slot />`
-- **Named slots** → `<slot name="slotname" />` (e.g., `#footer` → `<slot name="footer" />`)
+- **Named slots** → `<slot name="slotname" />` (for example, `#footer` → `<slot name="footer" />`)
 
 ::code-group
 
@@ -619,7 +617,7 @@ Footer slot content.
 
 ---
 
-## Overriding HTML Elements
+## Overriding HTML elements
 
 Override how native HTML elements render by mapping a component to their tag name via the `components` prop in both the `Markdown` and `MarkdownDocument` components.
 
@@ -655,24 +653,24 @@ Pass the component to the `components` prop:
 ```
 ::
 
-### Resolution Order
+### Resolution order
 
 When Comark encounters a tag, it looks for a matching Vue component in this order, stopping at the first match:
 
-1. **`Prose{PascalTag}`**: e.g., `ProseH1` for `h1`. Follows the Nuxt Content prose component convention.
-2. **`{PascalTag}`**: e.g., `Alert` for `alert`. PascalCase version of the tag name.
-3. **`{tag}`**: e.g., `alert`. Exact tag name as-is.
+1. **`Prose{PascalTag}`**: for example, `ProseH1` for `h1`. Follows the Nuxt Content prose component convention.
+2. **`{tag}`**: for example, `alert`. Exact tag name as-is.
+3. **`{PascalTag}`**: for example, `Alert` for `alert`. PascalCase version of the tag name.
 4. **Global**: any component registered via `app.component()`.
 
 If none match, the tag renders as a native HTML element.
 
 ---
 
-## Nuxt UI Integration
+## Nuxt UI integration
 
 When [`@nuxt/ui`](https://ui.nuxt.com) is installed, Comark automatically uses Nuxt UI's prose components for enhanced styling.
 
-### Vite Setup
+### Vite setup
 
 Enable prose components by setting `prose: true` in the Nuxt UI Vite plugin:
 
@@ -691,7 +689,7 @@ export default defineConfig({
 })
 ```
 
-### CSS Setup
+### CSS setup
 
 ```css [src/assets/css/main.css]
 @import "tailwindcss";
@@ -778,7 +776,7 @@ The `caret` prop appends a blinking cursor to the last text node while `streamin
 
 ---
 
-## TypeScript Support
+## TypeScript support
 
 Use `ComarkPlugin` from `comark` to type plugin arrays, and `ElementNode` to type the `__node` prop in components that override HTML elements:
 

--- a/docs/content/3.rendering/4.nuxt.md
+++ b/docs/content/3.rendering/4.nuxt.md
@@ -96,10 +96,10 @@ Pass markdown via the default slot or the `value` prop:
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `value` | `string` | `undefined` | Alternative to default slot |
+| `value` | `string \| MarkdownDocument` | `undefined` | Markdown string or pre-parsed document (alternative to default slot) |
 | [`options`](#code-markdown-props-code-options) | `ParserOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
 | [`plugins`](#code-markdown-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
-| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
+| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, for example `"ul li"` |
 | [`components`](#code-markdown-props-code-components) | `Record<string, Component>` | `{}` | Custom Vue component mappings |
 | [`componentsManifest`](#code-markdown-props-code-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
@@ -214,7 +214,7 @@ This is a warning message!
 ::
 
 ::tip
-To override how native HTML elements render (e.g. `h1`, `pre`), place components in `~/components/prose` instead. See [Overriding HTML Elements](#overriding-html-elements).
+To override how native HTML elements render (such as `h1` or `pre`), place components in `~/components/prose` instead. See [Overriding HTML elements](#overriding-html-elements).
 ::
 
 #### `componentsManifest`
@@ -235,11 +235,11 @@ const manifest = (name: string) => {
 
 ---
 
-## Server-Side Rendering
+## Server-side rendering
 
 Comark fully supports multiple rendering modes in Nuxt:
 
-### Static Generation
+### Static generation
 
 ```vue [pages/index.vue]
 <script setup lang="ts">
@@ -283,11 +283,11 @@ export default defineNuxtConfig({
 
 ---
 
-## Overriding HTML Elements
+## Overriding HTML elements
 
 Place Vue components in `~/components/prose` to override how native HTML elements render. They are automatically registered, no imports or `components` prop needed.
 
-### Directory Structure
+### Directory structure
 
 ```
 ~/components/
@@ -315,24 +315,24 @@ defineProps<{
 </template>
 ```
 
-### Resolution Order
+### Resolution order
 
 When Comark encounters a tag, it looks for a matching component in this order, stopping at the first match:
 
-1. **`Prose{PascalTag}`**: e.g., `ProseH1` for `h1`. Nuxt auto-registers all components from `~/components/prose` matching this convention.
-2. **`{PascalTag}`**: e.g., `Alert` for `alert`. PascalCase version of the tag name.
-3. **`{tag}`**: e.g., `alert`. Exact tag name as-is.
+1. **`Prose{PascalTag}`**: for example, `ProseH1` for `h1`. Nuxt auto-registers all components from `~/components/prose` matching this convention.
+2. **`{tag}`**: for example, `alert`. Exact tag name as-is.
+3. **`{PascalTag}`**: for example, `Alert` for `alert`. PascalCase version of the tag name.
 4. **Global**: any component registered via `app.component()` or Nuxt auto-imports.
 
 If none match, the tag renders as a native HTML element.
 
 ---
 
-## Component Bindings
+## Component bindings
 
 Comark automatically bridges the gap between Comark syntax and your component's interface.
 
-### Prop Binding
+### Prop binding
 
 Attributes in Comark syntax are passed as props to your component. Use the `:` prefix to pass typed values:
 
@@ -343,12 +343,12 @@ Attributes in Comark syntax are passed as props to your component. Use the `:` p
 | `{:active="true"}` | `true` (boolean) |
 | `{:config='{"key":"val"}'}` | `{ key: 'val' }` (object) |
 
-### Named Slots
+### Named slots
 
 Named slots in Comark (`#slotname`) map to Vue named slots:
 
 - **Default slot** → `<slot />`
-- **Named slots** → `<slot name="slotname" />` (e.g., `#footer` → `<slot name="footer" />`)
+- **Named slots** → `<slot name="slotname" />` (for example, `#footer` → `<slot name="footer" />`)
 
 ::code-group
 
@@ -383,7 +383,7 @@ Footer slot content.
 
 ---
 
-## Nuxt UI Integration
+## Nuxt UI integration
 
 When [`@nuxt/ui`](https://ui.nuxt.com) is installed, Comark automatically uses Nuxt UI's prose components for enhanced styling.
 
@@ -397,7 +397,7 @@ export default defineNuxtConfig({
 })
 ```
 
-### CSS Setup
+### CSS setup
 
 ```css [app/assets/css/main.css]
 @import "tailwindcss";
@@ -488,7 +488,7 @@ The `caret` prop appends a blinking cursor to the last text node while `streamin
 
 ---
 
-## TypeScript Support
+## TypeScript support
 
 Use `ComarkPlugin` from `comark` to type plugin arrays, and `ElementNode` to type the `__node` prop in components that override HTML elements:
 

--- a/docs/content/3.rendering/4.nuxt.md
+++ b/docs/content/3.rendering/4.nuxt.md
@@ -320,8 +320,8 @@ defineProps<{
 When Comark encounters a tag, it looks for a matching component in this order, stopping at the first match:
 
 1. **`Prose{PascalTag}`**: for example, `ProseH1` for `h1`. Nuxt auto-registers all components from `~/components/prose` matching this convention.
-2. **`{tag}`**: for example, `alert`. Exact tag name as-is.
-3. **`{PascalTag}`**: for example, `Alert` for `alert`. PascalCase version of the tag name.
+2. **`{PascalTag}`**: for example, `Alert` for `alert`. PascalCase version of the tag name.
+3. **`{tag}`**: for example, `alert`. Exact tag name as-is.
 4. **Global**: any component registered via `app.component()` or Nuxt auto-imports.
 
 If none match, the tag renders as a native HTML element.

--- a/docs/content/3.rendering/5.react.md
+++ b/docs/content/3.rendering/5.react.md
@@ -622,8 +622,8 @@ export default function Heading({ __node, id, children }: HeadingProps) {
 Components are resolved in this order:
 
 1. **`Prose{PascalTag}`**: for example, `ProseH1` for `h1`
-2. **`{tag}`**: for example, `alert`
-3. **`{PascalTag}`**: for example, `Alert` for `alert`
+2. **`{PascalTag}`**: for example, `Alert` for `alert`
+3. **`{tag}`**: for example, `alert`
 
 If no custom component matches, the tag renders as a native HTML element.
 

--- a/docs/content/3.rendering/5.react.md
+++ b/docs/content/3.rendering/5.react.md
@@ -43,7 +43,7 @@ bun add @comark/react
 
 ## `<Markdown>`
 
-The `<Markdown>` component is the simplest way to render markdown in React. It handles parsing and rendering automatically.
+The `<Markdown>` component is the quickest way to render markdown in React. It handles parsing and rendering automatically.
 
 ::warning{to="#code-markdowndocument"}
 `<Markdown>` is an **async** component. You can also use the `<MarkdownDocument>` component to handle parsing yourself.
@@ -98,7 +98,7 @@ Passing a document to `<Markdown>` skips parsing at runtime, but the **parser is
 | `value` | `string \| MarkdownDocument` | `''` | Markdown string or pre-parsed document (alternative to children) |
 | [`options`](#code-markdown-props-code-options) | `ParserOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
 | [`plugins`](#code-markdown-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
-| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
+| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, for example `"ul li"` |
 | [`components`](#code-markdown-props-code-components) | `Record<string, ComponentType>` | `{}` | Custom React component mappings |
 | [`componentsManifest`](#code-markdown-props-code-componentsmanifest) | `(name: string) => Promise<Component>` | `undefined` | Dynamic component resolver |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
@@ -407,7 +407,7 @@ export default async function DocsPage({ params }: { params: { slug: string } })
 }
 ```
 
-### Renderer Props
+### Renderer props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
@@ -459,7 +459,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
 ::
 
-#### Renderer Options
+#### Renderer options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -499,12 +499,14 @@ export const CommentMarkdownDocument = defineMarkdownDocumentComponent({
 
 ---
 
-## Live Documents
+## Live documents
 
-`MarkdownDocument` can subscribe to an ambient **context** so external sources can drive a mounted renderer: an HMR signal, a collaboration socket, an agent editing the document while you chat with it, or devtools. Pass a `documentKey`, and if `globalThis.comarkContext` exists the renderer listens for updates on that key and re-renders; on unmount it cleans up. The key falls back to the document's own `meta.key` when a plugin sets it. With no context, it's a no-op at zero cost.
+`MarkdownLive` is a client wrapper around `MarkdownDocument` that subscribes to an ambient **context** so external sources can drive a mounted renderer: an HMR signal, a collaboration socket, an agent editing the document while you chat with it, or devtools. It accepts the same props as `MarkdownDocument` plus a `documentKey`. The listen key is the document's own `meta.key` (set by a plugin) or the `documentKey` prop; if `globalThis.comarkContext` exists the renderer listens for updates on that key and re-renders, cleaning up on unmount. `MarkdownDocument` itself stays free of client-only hooks so it can render in a React Server Component. With no context, the key is ignored at zero cost.
 
 ```tsx
-<MarkdownDocument documentKey="page" value={document} />
+import { MarkdownLive } from '@comark/react'
+
+<MarkdownLive documentKey="page" value={document} />
 ```
 
 A **driver** installs the context once and pushes updates by key with `set()` (replace the whole document) or `patch()` (surgical node edits, with structural sharing so only the changed branch re-renders):
@@ -523,11 +525,11 @@ A `path` is a node-index path into `document.nodes`: the first segment indexes t
 
 ---
 
-## Component Bindings
+## Component bindings
 
 Comark automatically bridges the gap between Comark syntax and your component's interface.
 
-### Prop Binding
+### Prop binding
 
 Attributes in Comark syntax are passed as props to your component. Use the `:` prefix to pass typed values. HTML attribute names are automatically converted to their React equivalents:
 
@@ -537,16 +539,16 @@ Attributes in Comark syntax are passed as props to your component. Use the `:` p
 | `{:count="5"}` | `count={5}` (number) |
 | `{:active="true"}` | `active={true}` (boolean) |
 | `{:config='{"key":"val"}'}` | `config={{ key: 'val' }}` (object) |
-| `{class="foo"}` | `className="foo"` |
+| `{class="highlight"}` | `className="highlight"` |
 | `{tabindex="0"}` | `tabIndex={0}` |
 | `{style="color: red"}` | `style={{ color: 'red' }}` |
 
-### Named Slots
+### Named slots
 
 Named slots in Comark (`#slotname`) map to `slot{Name}` props in React:
 
 - **Default slot** → `children`
-- **Named slots** → `slot{Name}` (e.g., `#footer` → `slotFooter`)
+- **Named slots** → `slot{Name}` (for example, `#footer` → `slotFooter`)
 
 ::code-group
 
@@ -581,7 +583,7 @@ Footer slot content.
 
 ---
 
-## Overriding HTML Elements
+## Overriding HTML elements
 
 Override how native HTML elements render by mapping a component to their tag name via the `components` prop.
 
@@ -615,13 +617,13 @@ export default function Heading({ __node, id, children }: HeadingProps) {
 ```
 ::
 
-### Resolution Order
+### Resolution order
 
 Components are resolved in this order:
 
-1. **`Prose{PascalTag}`**: e.g., `ProseH1` for `h1`
-2. **`{PascalTag}`**: e.g., `Alert` for `alert`
-3. **`{tag}`**: e.g., `alert`
+1. **`Prose{PascalTag}`**: for example, `ProseH1` for `h1`
+2. **`{tag}`**: for example, `alert`
+3. **`{PascalTag}`**: for example, `Alert` for `alert`
 
 If no custom component matches, the tag renders as a native HTML element.
 
@@ -707,7 +709,7 @@ The `caret` prop appends a blinking cursor to the last text node while `streamin
 
 ---
 
-## TypeScript Support
+## TypeScript support
 
 Use `ComarkPlugin` from `comark` to type plugin arrays, and `ElementNode` to type the `__node` prop in components that override HTML elements:
 

--- a/docs/content/3.rendering/6.svelte.md
+++ b/docs/content/3.rendering/6.svelte.md
@@ -44,7 +44,7 @@ bun add @comark/svelte
 
 ## `<Markdown>`
 
-The `<Markdown>` component is the simplest way to render markdown in Svelte 5. It handles parsing and rendering automatically using `$state` and `$effect`.
+The `<Markdown>` component is the quickest way to render markdown in Svelte 5. It handles parsing and rendering automatically using `$state` and `$effect`.
 
 ::warning
 `<Markdown>` uses `$effect` internally and **will not render during SSR**. For SvelteKit, parse in your `load()` function and use [`<MarkdownDocument>`](#code-markdowndocument) instead.
@@ -90,7 +90,7 @@ Passing a document to `<Markdown>` skips parsing at runtime, but the **parser is
 | `value` | `string \| MarkdownDocument` | `''` | Markdown string or pre-parsed document |
 | [`options`](#code-markdown-props-code-options) | `ParserOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
 | [`plugins`](#code-markdown-props-code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
-| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
+| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, for example `"ul li"` |
 | [`components`](#code-markdown-props-code-components) | `Record<string, Component>` | `{}` | Custom Svelte component mappings |
 | [`componentsManifest`](#code-markdown-props-code-componentsmanifest) | `ComponentManifest` | `undefined` | Dynamic component resolver |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
@@ -335,19 +335,13 @@ export default config
 The `experimental.async` feature is still experimental in Svelte 5. For production SSR without experimental async, prefer `<MarkdownDocument>` with eager/static components.
 ::
 
-::tip
-Use `<MarkdownAsync>` when you need SSR HTML for non-eager, lazy-loaded Svelte components. Use `<MarkdownDocument>` with eager/static components when you want stable, non-experimental SSR.
-::
-
-::callout{icon="i-lucide-square-play" color="info" to="/examples/frameworks/sveltekit"}
-See the SvelteKit example for a complete local app with lazy SSR and stable SSR routes.
-::
+Use `<MarkdownAsync>` when you need SSR HTML for non-eager, lazy-loaded Svelte components. Use `<MarkdownDocument>` with eager/static components when you want stable, non-experimental SSR. See the [SvelteKit example](/examples/frameworks/sveltekit) for a complete local app with lazy SSR and stable SSR routes.
 
 ---
 
 ## `<MarkdownDocument>`
 
-Renders a pre-parsed `MarkdownDocument` without any parsing. Use it when you parse on the server (e.g., in a SvelteKit `load` function), so no parser or plugin code is shipped to the browser.
+Renders a pre-parsed `MarkdownDocument` without any parsing. Use it when you parse on the server (for example, in a SvelteKit `load` function), so no parser or plugin code is shipped to the browser.
 
 ### Integration
 
@@ -381,7 +375,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
 
 ::
 
-### Renderer Props
+### Renderer props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
@@ -419,7 +413,7 @@ During SSR, `<MarkdownDocument>` can only render manifest entries synchronously.
 
 ---
 
-## Live Documents
+## Live documents
 
 `MarkdownDocument` can subscribe to an ambient **context** so external sources can drive a mounted renderer: an HMR signal, a collaboration socket, an agent editing the document while you chat with it, or devtools. Pass a `documentKey`, and if `globalThis.comarkContext` exists the renderer listens for updates on that key and re-renders; on unmount it cleans up. The key falls back to the document's own `meta.key` when a plugin sets it. With no context, it's a no-op at zero cost.
 
@@ -443,11 +437,11 @@ A `path` is a node-index path into `document.nodes`: the first segment indexes t
 
 ---
 
-## Component Bindings
+## Component bindings
 
 Comark automatically bridges the gap between Comark syntax and your component's interface.
 
-### Prop Binding
+### Prop binding
 
 Attributes in Comark syntax are passed as props to your component. Use the `:` prefix to pass typed values:
 
@@ -458,12 +452,12 @@ Attributes in Comark syntax are passed as props to your component. Use the `:` p
 | `{:active="true"}` | `true` (boolean) |
 | `{:config='{"key":"val"}'}` | `{ key: 'val' }` (object) |
 
-### Named Snippets
+### Named snippets
 
 Named slots in Comark (`#slotname`) map to Svelte 5 snippets:
 
 - **Default content** → `children` snippet
-- **Named snippets** → named snippet prop (e.g., `#footer` → `footer` snippet)
+- **Named snippets** → named snippet prop (for example, `#footer` → `footer` snippet)
 
 ::code-group
 
@@ -500,7 +494,7 @@ Footer slot content.
 
 ---
 
-## Overriding HTML Elements
+## Overriding HTML elements
 
 Use the `Prose` prefix to override how native HTML elements render:
 
@@ -528,13 +522,13 @@ Use the `Prose` prefix to override how native HTML elements render:
 
 ::
 
-### Resolution Order
+### Resolution order
 
 Components are resolved in this order:
 
-1. `Prose{PascalTag}`: e.g., `ProseH1` for `h1`
-2. `{PascalTag}`: e.g., `Alert` for `alert`
-3. `{tag}`: e.g., `alert`
+1. `Prose{PascalTag}`: for example, `ProseH1` for `h1`
+2. `{PascalTag}`: for example, `Alert` for `alert`
+3. `{tag}`: for example, `alert`
 
 If no custom component matches, the tag renders as a native HTML element (via `<svelte:element>`).
 
@@ -611,7 +605,7 @@ The `caret` prop appends a blinking cursor to the last text node while `streamin
 
 ---
 
-## TypeScript Support
+## TypeScript support
 
 ```svelte [ComarkWrapper.svelte]
 <script lang="ts">

--- a/docs/content/3.rendering/7.angular.md
+++ b/docs/content/3.rendering/7.angular.md
@@ -521,14 +521,13 @@ import math, { Math } from '@comark/angular/plugins/math'
 import mermaid, { Mermaid } from '@comark/angular/plugins/mermaid'
 
 export const DocsMarkdown = defineMarkdownComponent({
-  name: 'docs-markdown',
   plugins: [shiki(), math(), mermaid()],
   components: { Math, Mermaid },
   class: 'prose dark:prose-invert',
 })
 ```
 
-Then use it like any other component. The returned component always uses the `comark-markdown-defined` selector; the `name` option is a display name for debugging and does not change the selector:
+Then use it like any other component. The returned component always uses the `comark-markdown-defined` selector:
 
 ```typescript [page.component.ts]
 import { Component } from '@angular/core'
@@ -556,7 +555,6 @@ import { defineMarkdownDocumentComponent } from '@comark/angular'
 import { Math } from '@comark/angular/plugins/math'
 
 export const DocsMarkdownDocument = defineMarkdownDocumentComponent({
-  name: 'docs-markdown-document',
   components: { Math },
   class: 'prose',
 })

--- a/docs/content/3.rendering/7.angular.md
+++ b/docs/content/3.rendering/7.angular.md
@@ -23,7 +23,7 @@ The `@comark/angular` package provides standalone components for rendering Comar
 
 | Dependency | Version |
 |------------|---------|
-| **Angular** | `>=17.0.0` |
+| **Angular** | `>=17.0.0 <22.0.0` |
 | **TypeScript** | `>=5.5.0` |
 
 ::callout{icon="i-lucide-info" color="info"}
@@ -54,7 +54,7 @@ bun add @comark/angular
 
 ## `<comark-markdown>`
 
-The `<comark-markdown>` component is the simplest way to render markdown in Angular. It handles parsing and rendering automatically. The `value` input accepts a markdown **string** or a pre-parsed [`MarkdownDocument`](/getting-started/document-model).
+The `<comark-markdown>` component is the quickest way to render markdown in Angular. It handles parsing and rendering automatically. The `value` input accepts a markdown **string** or a pre-parsed [`MarkdownDocument`](/getting-started/document-model).
 
 ```typescript [app.component.ts]
 import { Component } from '@angular/core'
@@ -78,14 +78,14 @@ This is **markdown** with Comark components.
 Passing a document to `<comark-markdown>` skips parsing at runtime, but the **parser is still bundled** because `Markdown` imports it. To keep the client bundle free of the parser, use [`<comark-markdown-document>`](#code-comark-markdown-document) instead.
 ::
 
-### Props (Inputs)
+### Props (inputs)
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `value` | `string \| MarkdownDocument` | `''` | Markdown string or pre-parsed document |
 | [`options`](#code-options) | `ParserOptions` | `{}` | Parser options (autoUnwrap, autoClose, etc.) |
 | [`plugins`](#code-plugins) | `ComarkPlugin[]` | `[]` | Array of plugins |
-| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, e.g. `"ul li"` |
+| `unwrap` | `boolean \| string \| string[]` | `false` | Strip wrapper tags (MDC `unwrap`) — `true` unwraps `<p>`; a comma/space-separated string or array peels tags sequentially, for example `"ul li"` |
 | [`components`](#components) | `Record<string, Type<any>>` | `{}` | Custom Angular component mappings |
 | [`streaming`](#streaming) | `boolean` | `false` | Enable streaming mode |
 | `summary` | `boolean` | `false` | Only render content before `<!-- more -->` |
@@ -272,7 +272,7 @@ export class DocsComponent implements OnInit {
 }
 ```
 
-### Renderer Props (Inputs)
+### Renderer props (inputs)
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -284,11 +284,11 @@ export class DocsComponent implements OnInit {
 
 ---
 
-## Component Bindings
+## Component bindings
 
 Comark automatically bridges the gap between Comark syntax and your Angular component's interface.
 
-### Prop Binding
+### Prop binding
 
 Attributes in Comark syntax are passed as `@Input()` values to your component. Use the `:` prefix to pass typed values:
 
@@ -299,7 +299,7 @@ Attributes in Comark syntax are passed as `@Input()` values to your component. U
 | `{:active="true"}` | `true` (boolean) |
 | `{:config='{"key":"val"}'}` | `{ key: 'val' }` (object) |
 
-### Content Projection
+### Content projection
 
 Default content in Comark maps to Angular's content projection (`<ng-content />`):
 
@@ -333,7 +333,7 @@ Default content goes here.
 
 ---
 
-## Overriding HTML Elements
+## Overriding HTML elements
 
 Use the `Prose` prefix to override how native HTML elements render:
 
@@ -371,13 +371,13 @@ export class AppComponent {
 
 ::
 
-### Resolution Order
+### Resolution order
 
 Components are resolved in this order:
 
-1. `Prose{PascalTag}`: e.g., `ProseH1` for `h1`
-2. `{tag}`: e.g., `alert`
-3. `{PascalTag}`: e.g., `Alert` for `alert`
+1. `Prose{PascalTag}`: for example, `ProseH1` for `h1`
+2. `{tag}`: for example, `alert`
+3. `{PascalTag}`: for example, `Alert` for `alert`
 
 If no custom component matches, the tag renders as a native HTML element.
 
@@ -465,7 +465,7 @@ The `caret` input appends a blinking cursor to the last text node while `streami
 
 ---
 
-## TypeScript Support
+## TypeScript support
 
 Use `ComarkPlugin` from `comark` to type plugin arrays, and `ElementNode` to type the `__node` input in components that override HTML elements:
 
@@ -508,7 +508,7 @@ export class HeadingComponent {
 
 ---
 
-## Pre-configured Components
+## Pre-configured components
 
 Use `defineMarkdownComponent` and `defineMarkdownDocumentComponent` to create pre-configured wrappers with default plugins, components, and styling baked in, so there is no need to repeat the same config on every instance.
 
@@ -528,7 +528,7 @@ export const DocsMarkdown = defineMarkdownComponent({
 })
 ```
 
-Then use it like any other component:
+Then use it like any other component. The returned component always uses the `comark-markdown-defined` selector; the `name` option is a display name for debugging and does not change the selector:
 
 ```typescript [page.component.ts]
 import { Component } from '@angular/core'
@@ -538,7 +538,7 @@ import { DocsMarkdown } from './components/docs-markdown'
   selector: 'app-page',
   standalone: true,
   imports: [DocsMarkdown],
-  template: `<docs-markdown [value]="content" />`,
+  template: `<comark-markdown-defined [value]="content" />`,
 })
 export class PageComponent {
   content = '# Hello\n\n$E = mc^2$'
@@ -549,7 +549,7 @@ Instance-level `[plugins]` and `[components]` inputs are merged with (and overri
 
 ### `defineMarkdownDocumentComponent`
 
-Same idea, but for the low-level renderer:
+Same idea, but for the low-level renderer. The returned component always uses the `comark-markdown-document-defined` selector:
 
 ```typescript [components/docs-markdown-document.ts]
 import { defineMarkdownDocumentComponent } from '@comark/angular'

--- a/docs/content/3.rendering/7.angular.md
+++ b/docs/content/3.rendering/7.angular.md
@@ -376,8 +376,8 @@ export class AppComponent {
 Components are resolved in this order:
 
 1. `Prose{PascalTag}`: for example, `ProseH1` for `h1`
-2. `{tag}`: for example, `alert`
-3. `{PascalTag}`: for example, `Alert` for `alert`
+2. `{PascalTag}`: for example, `Alert` for `alert`
+3. `{tag}`: for example, `alert`
 
 If no custom component matches, the tag renders as a native HTML element.
 

--- a/docs/content/3.rendering/8.ansi.md
+++ b/docs/content/3.rendering/8.ansi.md
@@ -273,7 +273,7 @@ process.stdout.write(output)
 
 ---
 
-## Overriding Terminal Output
+## Overriding terminal output
 
 Pass native markdown tag names as keys in `components` to override how standard elements render in the terminal:
 
@@ -295,13 +295,13 @@ const renderAnsi = createAnsiRenderer({
 
 ---
 
-## Syntax Support
+## Syntax support
 
 ### Headings
 
 Headings are styled by level: bold + underline for `h1`, with distinct colors per level down to `h6`.
 
-### GitHub Alerts
+### GitHub alerts
 
 Blockquotes with `[!TYPE]` markers render as colored alerts matching GitHub's style:
 
@@ -324,9 +324,9 @@ Blockquotes with `[!TYPE]` markers render as colored alerts matching GitHub's st
 
 Each type has its own color: NOTE → blue, TIP → green, IMPORTANT → magenta, WARNING → yellow, CAUTION → red.
 
-### Code Blocks
+### Code blocks
 
-Code blocks show the language and filename in a header line. When the `highlight` plugin is used, tokens are rendered with true-color ANSI (`\x1b[38;2;R;G;Bm`) derived from Shiki's dark theme:
+Code blocks show the language and filename in a header line. When the `shiki` plugin is used, tokens are rendered with true-color ANSI (`\x1b[38;2;R;G;Bm`) derived from Shiki's dark theme:
 
 ```typescript
 import { createAnsiWriter } from '@comark/ansi'
@@ -367,7 +367,7 @@ Tables render with box-drawing characters:
 
 ---
 
-## TypeScript Support
+## TypeScript support
 
 ```typescript
 import type { AnsiRendererOptions } from '@comark/ansi'

--- a/docs/content/4.plugins/0.defaults/alert.md
+++ b/docs/content/4.plugins/0.defaults/alert.md
@@ -64,7 +64,7 @@ The plugin tags the blockquote in the AST and leaves the visuals to your rendere
 
 ## Features
 
-### Alert Types
+### Alert types
 
 | Marker | Color | Use for |
 |---|---|---|
@@ -74,7 +74,7 @@ The plugin tags the blockquote in the AST and leaves the visuals to your rendere
 | `[!WARNING]` | Yellow | Potential issues and gotchas |
 | `[!CAUTION]` | Red | Dangerous actions or destructive operations |
 
-### Multi-line Content
+### Multi-line content
 
 Alerts can span multiple lines and contain inline markdown:
 
@@ -86,7 +86,7 @@ Alerts can span multiple lines and contain inline markdown:
 
 ---
 
-## How It Works
+## How it works
 
 The plugin transforms the alert blockquote in the AST: the `[!NOTE]` marker is removed and an `as` attribute is added to the `blockquote` node.
 
@@ -104,7 +104,7 @@ console.log(tree.nodes)
 
 The Vue, React, and Angular renderers resolve the `as` attribute against your components map first, then fall back to the tag name (`blockquote`). This means you can render each alert type with its own component. In the HTML renderer, register a `blockquote` component and read the alert type from `attrs.as`.
 
-## Custom Components
+## Custom components
 
 Register a component for each alert type you want to customize:
 
@@ -158,6 +158,6 @@ Alert types without a registered component render as a regular `<blockquote as="
 
 ---
 
-## Nuxt UI Integration
+## Nuxt UI integration
 
 When using the [Nuxt module](/rendering/nuxt) alongside `@nuxt/ui`, alert blocks are automatically mapped to Nuxt UI's `<Note>`, `<Warning>`, `<Caution>`, and `<Tip>` components. No extra configuration needed.

--- a/docs/content/4.plugins/0.defaults/attributes.md
+++ b/docs/content/4.plugins/0.defaults/attributes.md
@@ -118,7 +118,7 @@ md.use(markdownItAttributes)
 
 ## How it works
 
-The plugin registers `comark_inline_props` for `{class="foo" id="x"}` after a preceding token.
+The plugin registers `comark_inline_props` for `{class="highlight" id="intro"}` after a preceding token.
 
 Hidden `mdc_inline_props` tokens are merged onto the previous token (or a wrapping span for bare text). Parent-level props on headings, paragraphs, and list items are lifted during `md.parse`.
 

--- a/docs/content/4.plugins/0.defaults/task-list.md
+++ b/docs/content/4.plugins/0.defaults/task-list.md
@@ -1,6 +1,6 @@
 ---
-title: Task List
-description: Plugin for rendering interactive checkboxes from GitHub-style task list syntax.
+title: Task list
+description: Plugin for rendering GitHub-style task list syntax as disabled checkboxes.
 seo:
   title: Task List Plugin
 navigation:
@@ -18,46 +18,33 @@ links:
     variant: soft
 ---
 
-The `comark/plugins/task-list` plugin converts GitHub-style task list syntax into interactive checkboxes. It runs before inline parsing to prevent Comark from misinterpreting `[ ]` and `[x]` as component syntax.
+The `comark/plugins/task-list` plugin converts GitHub-style task list syntax into disabled checkboxes. It runs before inline parsing to prevent Comark from misinterpreting `[ ]` and `[x]` as component syntax.
+
+The plugin is **enabled by default** via `registerDefaultPlugins`. No installation or registration required.
 
 ## Usage
 
 ```typescript
 import { parseMarkdown } from 'comark'
-import taskList from 'comark/plugins/task-list'
 
 const result = await parseMarkdown(`
 - [x] Write the docs
 - [ ] Fix the bug
 - [x] Ship it
-`, {
+`)
+```
+
+Explicit registration is only needed when default plugins are disabled:
+
+```typescript
+import { parseMarkdown } from 'comark'
+import taskList from 'comark/plugins/task-list'
+
+const result = await parseMarkdown(content, {
+  registerDefaultPlugins: false,
   plugins: [taskList()]
 })
 ```
-
-With framework components:
-
-::code-group
-
-```vue [Vue]
-<script setup lang="ts">
-import { Markdown } from '@comark/vue'
-import taskList from '@comark/vue/plugins/task-list'
-</script>
-
-<template>
-  <Markdown :plugins="[taskList()]">{{ content }}</Markdown>
-</template>
-```
-
-```tsx [React]
-import { Markdown } from '@comark/react'
-import taskList from '@comark/react/plugins/task-list'
-
-<Markdown plugins={[taskList()]}>{content}</Markdown>
-```
-
-::
 
 ---
 
@@ -82,7 +69,7 @@ Task lists also work in nested lists:
 - [ ] Another parent task
 ```
 
-### CSS Classes
+### CSS classes
 
 The plugin adds classes to help with styling:
 
@@ -108,6 +95,6 @@ The plugin adds classes to help with styling:
 
 ### `taskList()`
 
-Returns a `ComarkPlugin` that converts task list syntax to checkboxes. Takes no options.
+Returns a `ComarkPlugin` that converts task list syntax to disabled checkboxes. Takes no options.
 
 **Returns:** `ComarkPlugin`

--- a/docs/content/4.plugins/1.built-in/binding.md
+++ b/docs/content/4.plugins/1.built-in/binding.md
@@ -22,9 +22,9 @@ The `comark/plugins/binding` plugin adds a `{{ path || default }}` inline shorth
 
 Under the hood it emits a `binding` component node whose `:value` attribute points at a dot-path. The [data binding](/syntax/components#data-binding) layer resolves that path against the ambient render context, so bindings work seamlessly across HTML, ANSI, React, Svelte, and Vue, and round-trip back to their source form via `renderMarkdown`.
 
-## Basic Usage
+## Basic usage
 
-### Registering the Plugin
+### Registering the plugin
 
 ```typescript [parse.ts]
 import { parseMarkdown } from 'comark'
@@ -55,7 +55,7 @@ Rendered HTML:
 <p>Welcome, Ada (admin).</p>
 ```
 
-## Render Handlers
+## Render handlers
 
 The plugin ships a renderer-specific `Binding` export for every first-party package so the `<binding>` AST node turns into the resolved value (falling back to the `|| default`) rather than a literal `<binding>` tag.
 
@@ -179,7 +179,7 @@ const source = await renderMarkdown(document, {
 // → "Hi {{ user.name }}!\n"
 ```
 
-## Resolution Scope
+## Resolution scope
 
 A binding value (`{{ path }}`) is resolved as a dot-path against the same render context used by `:prefix` component bindings:
 
@@ -192,7 +192,7 @@ A binding value (`{{ path }}`) is resolved as a dot-path against the same render
 
 See [Data Binding](/syntax/components#data-binding) for the full contract and additional examples.
 
-## Default Values
+## Default values
 
 Use `|| default` to specify a fallback that's emitted when the dot-path does not resolve:
 
@@ -203,7 +203,7 @@ Hello {{ data.user.name || guest }}!
 - If `data.user.name` resolves, its value is rendered.
 - Otherwise the literal text after `||` is rendered (trim and quote as you see fit; YAML rules don't apply here).
 
-## Custom Tag Name
+## Custom tag name
 
 You can swap the emitted element tag via the plugin's `tag` option. This is handy if you already use `binding` as a custom component name:
 
@@ -219,7 +219,7 @@ const tree = await parseMarkdown('{{ x }}', {
 
 Pair this with a `components: { prop: Binding }` mapping to preserve the render behavior.
 
-## API Reference
+## API reference
 
 ### `binding(options?: MdcInlineBindingOptions): ComarkPlugin`
 
@@ -257,7 +257,7 @@ import { Binding } from '@comark/svelte/plugins/binding'
 import { Binding } from '@comark/vue/plugins/binding'
 ```
 
-## Use Cases
+## Use cases
 
 1. **Personalized content**: greet users by name from frontmatter or runtime data:
 
@@ -298,7 +298,7 @@ import { Binding } from '@comark/vue/plugins/binding'
    ::
    ```
 
-## See Also
+## See also
 
 - [Data Binding](/syntax/components#data-binding): the underlying `:prefix` resolution contract
 - [Component Syntax](/syntax/components): the full Comark component API

--- a/docs/content/4.plugins/1.built-in/breaks.md
+++ b/docs/content/4.plugins/1.built-in/breaks.md
@@ -18,7 +18,7 @@ The Breaks plugin transforms soft line breaks into `<br>` components.
 
 No peer dependencies are required.
 
-## Basic Usage
+## Basic usage
 
 ### With Vue
 
@@ -52,7 +52,7 @@ function App() {
   return (
     <Markdown plugins={[breaks()]}>{markdown}</Markdown>
   )
-  // <p>Hello<br>world</p>
+  // <p>Hello<br>World</p>
 }
 ```
 
@@ -91,7 +91,7 @@ world`
 }
 ```
 
-### With Parse API
+### With parse API
 
 ```typescript [parse.ts]
 import { parseMarkdown } from 'comark'
@@ -104,7 +104,7 @@ const result = await parseMarkdown('Hello\nWorld', {
 {
   frontmatter: {},
   meta: {},
-  nodes: [ [ 'p', {}, 'Hello', ['br', {}], 'world'] ]
+  nodes: [ [ 'p', {}, 'Hello', ['br', {}], 'World'] ]
 }
  */
 ```

--- a/docs/content/4.plugins/1.built-in/emoji.md
+++ b/docs/content/4.plugins/1.built-in/emoji.md
@@ -18,7 +18,7 @@ links:
     variant: soft
 ---
 
-The `comark/plugins/emoji` plugin converts emoji shortcodes (e.g. `:smile:`) into their corresponding emoji characters. It ships with a curated set of common emojis, and you can add the full GitHub set or your own shortcodes with the [`extend`](#extend) option.
+The `comark/plugins/emoji` plugin converts emoji shortcodes (for example, `:smile:`) into their corresponding emoji characters. It ships with a curated set of common emojis, and you can add the full GitHub set or your own shortcodes with the [`extend`](#extend) option.
 
 ## Usage
 
@@ -72,7 +72,7 @@ import emoji from '@comark/react/plugins/emoji'
 ::
 
 ::tip
-Shortcodes are case-sensitive and must use exact names. Invalid or unknown shortcodes are left unchanged in the output.
+Shortcodes are case-sensitive and must use exact names. Unknown shortcodes are not converted; with the default plugins, the [components plugin](/plugins/defaults/components) parses them as inline component syntax instead.
 ::
 
 ---
@@ -107,7 +107,7 @@ Some emojis have multiple valid shortcodes:
 
 ### Custom shortcodes
 
-Use the `extend` option to add your own shortcodes or override built-in ones. This is handy for team-specific emojis or GitHub custom shortcodes that aren't part of the Unicode set (e.g. `:shipit:`):
+Use the `extend` option to add your own shortcodes or override built-in ones. This is handy for team-specific emojis or GitHub custom shortcodes that aren't part of the Unicode set (such as `:shipit:`):
 
 ```typescript
 import emoji from 'comark/plugins/emoji'
@@ -160,15 +160,15 @@ A map of shortcode names (without colons) to emoji characters. Added on top of t
 
 ## Examples
 
-### Documentation Markers
+### Documentation markers
 
 ```mdc
 :white_check_mark: Completed
-:construction: In Progress
+:hammer: In Progress
 :x: Blocked
 ```
 
-### Status Indicators
+### Status indicators
 
 ```mdc
 Build status: :white_check_mark:
@@ -176,10 +176,10 @@ Test coverage: 95% :fire:
 Deployment: :rocket:
 ```
 
-### Task Lists
+### Task lists
 
 ```mdc
 - :white_check_mark: Setup project
-- :construction: Write docs
+- :memo: Write docs
 - :bulb: Add examples
 ```

--- a/docs/content/4.plugins/1.built-in/footnotes.md
+++ b/docs/content/4.plugins/1.built-in/footnotes.md
@@ -23,7 +23,7 @@ The Footnotes plugin adds support for footnote references and definitions. Refer
 
 No peer dependencies are required.
 
-## Basic Usage
+## Basic usage
 
 ### With Vue
 
@@ -85,7 +85,7 @@ Comark supports footnotes[^1] with back-references[^2].
 <Markdown value={markdown} plugins={[footnotes()]} />
 ```
 
-### With Parse API
+### With parse API
 
 ```typescript [parse.ts]
 import { parseMarkdown } from 'comark'
@@ -98,7 +98,7 @@ const result = await parseMarkdown('Hello[^1]\n\n[^1]: World', {
 
 ## Syntax
 
-### Footnote References
+### Footnote references
 
 Use `[^label]` anywhere inline to insert a footnote reference:
 
@@ -110,7 +110,7 @@ Einstein also contributed to quantum mechanics[^qm].
 
 Labels can be numbers or text; they serve as identifiers and are replaced with sequential numbers in the output.
 
-### Footnote Definitions
+### Footnote definitions
 
 Define footnotes with `[^label]: content` on its own line:
 
@@ -121,7 +121,7 @@ Define footnotes with `[^label]: content` on its own line:
 
 Definitions can appear anywhere in the document. They are removed from their original position and collected into the footnotes section.
 
-### Complete Example
+### Complete example
 
 ```mdc
 # Research Notes
@@ -136,7 +136,7 @@ Dark matter[^dm] accounts for approximately 27% of the universe.
 [^dm]: Dark matter is inferred from gravitational effects on visible matter.
 ```
 
-## Rendered Output
+## Rendered output
 
 The plugin produces the following AST structure:
 
@@ -179,7 +179,7 @@ footnotes({
 | `hr` | `boolean` | `true` | Whether to render a horizontal rule before the section |
 | `backRef` | `string` | `'↩'` | Symbol used for the back-reference link |
 
-### Custom Configuration
+### Custom configuration
 
 ```typescript
 import footnotes from 'comark/plugins/footnotes'
@@ -192,7 +192,7 @@ const plugin = footnotes({
 })
 ```
 
-## CSS Classes
+## CSS classes
 
 The plugin adds CSS classes for styling:
 
@@ -203,7 +203,7 @@ The plugin adds CSS classes for styling:
 | `<ol>` | `footnotes-list` | The ordered list of footnote definitions |
 | `<a>` | `footnote-backref` | The back-reference link in each definition |
 
-### Example Styles
+### Example styles
 
 ```css
 .footnote-ref {
@@ -252,7 +252,7 @@ Second definition referenced first[^b], then first[^a].
 
 Referencing the same footnote multiple times reuses the same number.
 
-## Footnotes in Inline Formatting
+## Footnotes in inline formatting
 
 Footnote references work inside bold, italic, and other inline formatting:
 
@@ -263,7 +263,7 @@ Footnote references work inside bold, italic, and other inline formatting:
 [^2]: Works inside italic too.
 ```
 
-## Stringify (Markdown Rendering)
+## Stringify (Markdown rendering)
 
 The plugin exports a `Footnote` conditional handler that converts the footnote AST back into standard markdown footnote syntax. This is useful when you want to render a `MarkdownDocument` back to markdown and preserve footnotes.
 

--- a/docs/content/4.plugins/1.built-in/headings.md
+++ b/docs/content/4.plugins/1.built-in/headings.md
@@ -104,7 +104,7 @@ headings({ remove: true })
 
 ## Examples
 
-### Default Extraction
+### Default extraction
 
 ::code-group
 
@@ -133,7 +133,7 @@ console.log(result.meta.description) // "This is the opening paragraph used as t
 
 ::
 
-### Blockquote as Description
+### Blockquote as description
 
 ```typescript
 const result = await parseMarkdown(content, {
@@ -143,7 +143,7 @@ const result = await parseMarkdown(content, {
 console.log(result.meta.description) // "A highlighted lead-in sentence shown as the description."
 ```
 
-### Combining with the TOC Plugin
+### Combining with the TOC plugin
 
 ```typescript
 import { parseMarkdown } from 'comark'

--- a/docs/content/4.plugins/1.built-in/json-render.md
+++ b/docs/content/4.plugins/1.built-in/json-render.md
@@ -59,7 +59,7 @@ import jsonRender from '@comark/react/plugins/json-render'
 
 ## Features
 
-### Full Spec
+### Full spec
 
 A full spec defines a tree of named elements with a root entry point. Both JSON and YAML are supported and produce identical output:
 
@@ -106,7 +106,7 @@ elements:
 - **`root`**: Key of the root element in the `elements` map
 - **`elements`**: Map of element definitions, each with `type`, `props`, and optional `children`
 
-### Single Element
+### Single element
 
 When only one element is needed, omit `root` and `elements`:
 

--- a/docs/content/4.plugins/1.built-in/math.md
+++ b/docs/content/4.plugins/1.built-in/math.md
@@ -90,7 +90,7 @@ import math, { Math } from '@comark/react/plugins/math'
 
 ## Features
 
-### Inline Math
+### Inline math
 
 Use single `$` delimiters for inline expressions:
 
@@ -100,7 +100,7 @@ The formula $E = mc^2$ relates energy and mass.
 The Pythagorean theorem: $a^2 + b^2 = c^2$
 ```
 
-### Display Math
+### Display math
 
 Use double `$$` delimiters for block-level expressions:
 
@@ -110,7 +110,7 @@ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
 $$
 ```
 
-### Dollar Signs in Text
+### Dollar signs in text
 
 The plugin avoids matching dollar signs that are not math. It requires at least one character between `$` delimiters and content that does not start with a digit:
 
@@ -122,7 +122,7 @@ Prices like $100 or $200 won't be parsed as math.
 See the [KaTeX supported functions →](https://katex.org/docs/supported.html) for the full LaTeX reference.
 ::
 
-### Backslash Escaping
+### Backslash escaping
 
 In JavaScript strings, escape backslashes before LaTeX commands:
 
@@ -135,9 +135,15 @@ const wrong = '\frac{a}{b}'  // wrong: \f is a JS escape sequence
 
 ## API
 
-### `math()`
+### `math(options?)`
 
-Returns a `ComarkPlugin` that tokenizes `$...$` and `$$...$$` expressions. Takes no options.
+Returns a `ComarkPlugin` that tokenizes `$...$` and `$$...$$` expressions.
+
+**Parameters:**
+
+- `options?` - Optional `MathConfig`:
+  - `throwOnError?: boolean` - Throw on parse errors instead of returning an error message. Default: `false`
+  - `options?: Record<string, unknown>` - Additional [KaTeX render options](https://katex.org/docs/options.html)
 
 **Returns:** `ComarkPlugin`
 
@@ -145,11 +151,11 @@ The plugin stores LaTeX source as plain text in the AST. Rendering requires pass
 
 ---
 
-## Component Props
+## Component props
 
 Props accepted by the `<Math>` component:
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `content` | `string` | required | The LaTeX expression to render |
-| `class` | `string` | `''` | CSS classes. When set to `'block'`, renders in display mode; otherwise inline |
+| `class` | `string` | `''` | CSS classes. Renders inline when the classes include `'inline'`; otherwise display mode |

--- a/docs/content/4.plugins/1.built-in/mermaid.md
+++ b/docs/content/4.plugins/1.built-in/mermaid.md
@@ -1,5 +1,5 @@
 ---
-title: Mermaid Diagrams
+title: Mermaid diagrams
 description: Plugin for rendering Mermaid diagrams in Comark using code blocks.
 seo:
   title: Mermaid Diagrams Plugin
@@ -82,7 +82,7 @@ import mermaid, { Mermaid } from '@comark/react/plugins/mermaid'
 
 ## Features
 
-### Diagram Types
+### Diagram types
 
 Mermaid supports a wide range of diagram types:
 
@@ -182,7 +182,7 @@ erDiagram
 
 See the [Mermaid documentation →](https://mermaid.js.org/intro/) for full syntax reference on each diagram type.
 
-### Code Block Attributes
+### Code block attributes
 
 Pass component props directly on the opening fence:
 
@@ -197,9 +197,15 @@ graph TD
 
 ## API
 
-### `mermaid()`
+### `mermaid(options?)`
 
-Returns a `ComarkPlugin` that marks ` ```mermaid ` code blocks for custom rendering. Takes no options.
+Returns a `ComarkPlugin` that marks ` ```mermaid ` code blocks for custom rendering.
+
+**Parameters:**
+
+- `options?` - Optional `MermaidConfig`:
+  - `theme?: ThemeNames` - Sets the `theme` attribute on every diagram node, passed as a prop to the `<Mermaid>` component
+  - `themeDark?: ThemeNames` - Sets the `theme-dark` attribute, used in dark mode
 
 **Returns:** `ComarkPlugin`
 
@@ -207,14 +213,14 @@ The plugin converts mermaid code blocks into AST nodes that the `<Mermaid>` comp
 
 ---
 
-## Component Props
+## Component props
 
 Props accepted by the `<Mermaid>` component:
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `content` | `string` | required | The Mermaid diagram source |
-| `theme` | `string` | `'default'` | Mermaid theme, see [available themes](https://github.com/lukilabs/beautiful-mermaid#built-in-themes) |
+| `theme` | `string` | `undefined` | Mermaid theme, falls back to `tokyo-light` (`tokyo-night` in dark mode), see [available themes](https://github.com/lukilabs/beautiful-mermaid#built-in-themes) |
 | `themeDark` | `string` | `undefined` | Theme to use in dark mode |
 | `width` | `string` | `'100%'` | Container width |
 | `height` | `string` | `'auto'` | Container height |

--- a/docs/content/4.plugins/1.built-in/punctuation.md
+++ b/docs/content/4.plugins/1.built-in/punctuation.md
@@ -69,7 +69,7 @@ import punctuation from '@comark/react/plugins/punctuation'
 
 ## Features
 
-### Smart Quotes
+### Smart quotes
 
 Straight quotes are converted to curly (typographic) quotes:
 
@@ -101,7 +101,7 @@ Straight quotes are converted to curly (typographic) quotes:
 | `(tm)` | ™ |
 | `+-` | ± |
 
-### Code Preservation
+### Code preservation
 
 Text inside `code`, `pre`, `math`, `kbd`, `script`, and `style` elements is not transformed:
 
@@ -131,10 +131,11 @@ Returns a `ComarkPlugin` that applies typographic transformations to text nodes.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| [`quotes`](#options-quotes) | `boolean` | `true` | Convert straight quotes to smart quotes |
+| [`quotes`](#options-quotes) | `boolean \| string \| [string, string, string, string]` | `true` | Convert straight quotes to smart quotes |
 | [`dashes`](#options-dashes) | `boolean` | `true` | Convert `--` to en-dash and `---` to em-dash |
 | [`ellipsis`](#options-ellipsis) | `boolean` | `true` | Convert `...` to ellipsis character |
 | [`symbols`](#options-symbols) | `boolean` | `true` | Convert `(c)`, `(r)`, `(tm)`, `+-` |
+| [`normalize`](#options-normalize) | `boolean` | `true` | Collapse repeated punctuation: `????` → `???`, `,,` → `,` |
 
 ### `quotes`
 
@@ -142,6 +143,16 @@ Convert straight quotes (`"..."` and `'...'`) to typographic curly quotes.
 
 ```typescript
 punctuation({ quotes: false }) // disable smart quotes only
+```
+
+For locale-specific quotes, pass a string of four characters or an array of four strings, in the order open double, close double, open single, close single:
+
+```typescript
+// Russian quotes
+punctuation({ quotes: '«»„“' })
+
+// French quotes with non-breaking spaces
+punctuation({ quotes: ['«\xA0', '\xA0»', '‹\xA0', '\xA0›'] })
 ```
 
 **Default:** `true`
@@ -172,6 +183,16 @@ Convert `(c)` → ©, `(r)` → ®, `(tm)` → ™, `+-` → ±.
 
 ```typescript
 punctuation({ symbols: false })
+```
+
+**Default:** `true`
+
+### `normalize`
+
+Collapse repeated punctuation: `????` → `???`, `!!!!` → `!!!`, `,,` → `,`.
+
+```typescript
+punctuation({ normalize: false })
 ```
 
 **Default:** `true`

--- a/docs/content/4.plugins/1.built-in/rangi.md
+++ b/docs/content/4.plugins/1.built-in/rangi.md
@@ -150,7 +150,7 @@ Rangi ships aliases built-in (`javascript`→`js`, `typescript`→`ts`, `python`
 
 Fence info `{2-3,5}` wraps the code in line spans and marks the selected lines with the `.highlight` class — same as the Shiki plugin. No `lineNumbers` option is required.
 
-### Pre Styles
+### Pre styles
 
 Set `preStyles: true` to add inline background and foreground colors to `<pre>` elements based on the active theme.
 
@@ -218,7 +218,7 @@ rangi({ lineNumbers: true })
 
 ```typescript
 rangi({ classPrefix: 'code' })
-// → class="code shj-lang-js"
+// → class="code shiki shj-lang-js"
 ```
 
 ### `languages`
@@ -274,7 +274,7 @@ const renderHtml = createHtmlRenderer({
 })
 ```
 
-### Live Example
+### Live example
 
 ::card{icon="i-lucide-zap" title="Vue + Vite Rangi" to="https://github.com/comarkdown/comark/tree/main/examples/3.plugins/vue-vite-rangi"}
 Rangi dual themes as inline colors, line highlights, light/dark toggle.

--- a/docs/content/4.plugins/1.built-in/security.md
+++ b/docs/content/4.plugins/1.built-in/security.md
@@ -70,7 +70,7 @@ import security from '@comark/react/plugins/security'
 
 Several sanitizations are applied automatically and cannot be disabled:
 
-### Event Handlers
+### Event handlers
 
 All `on*` attributes are stripped regardless of case: `onclick`, `onerror`, `onload`, `onmouseover`, and any other `on*` attribute.
 
@@ -88,7 +88,7 @@ All `on*` attributes are stripped regardless of case: `onclick`, `onerror`, `onl
 
 ::
 
-### Dangerous Attributes
+### Dangerous attributes
 
 Attributes that can be abused regardless of value are always stripped:
 
@@ -97,7 +97,7 @@ Attributes that can be abused regardless of value are always stripped:
 | `srcdoc` | Can contain arbitrary HTML |
 | `formaction` | Can redirect form submissions |
 
-### Protocol Blocking
+### Protocol blocking
 
 `href` and `src` values are decoded (URL-encoded and HTML entity variants included) and checked against a hard-coded block list. These protocols are **always** blocked, even if `allowedProtocols: ['*']` is set:
 
@@ -139,7 +139,7 @@ Returns a `ComarkPlugin` that sanitizes the parsed AST.
 |---|---|---|---|
 | [`blockedTags`](#options-blockedtags) | `string[]` | `[]` | Tag names to remove entirely from the AST |
 | [`allowedTags`](#options-allowedtags) | `string[]` | `[]` | Tag names to allow exclusively in the AST |
-| [`tagFallback`](#options-tagfallback) | `function` | `false`  | Defines how to handle unallowed tags in the AST |
+| [`tagFallback`](#options-tagfallback) | `function` | `undefined`  | Defines how to handle unallowed tags in the AST |
 | [`allowedProtocols`](#options-allowedprotocols) | `string[]` | `['*']` | Protocols permitted in `href` and `src` |
 | [`allowedLinkPrefixes`](#options-allowedlinkprefixes) | `string[]` | `['*']` | URL prefixes permitted in `href` |
 | [`allowedImagePrefixes`](#options-allowedimageprefixes) | `string[]` | `['*']` | URL prefixes permitted in `src` |
@@ -260,7 +260,7 @@ security({
 
 ## Examples
 
-### User-Generated Content
+### User-generated content
 
 The most common use case: lock down everything that could execute code or phone home:
 
@@ -279,7 +279,7 @@ const result = await parseMarkdown(userInput, {
 })
 ```
 
-### Restrict Links to Your Domain
+### Restrict links to your domain
 
 Keep all links and images within your own infrastructure, rewriting external URLs instead of stripping them:
 
@@ -291,7 +291,7 @@ security({
 })
 ```
 
-### Block External Images
+### Block external images
 
 Prevent tracking pixels and externally-hosted images while keeping everything else permissive:
 
@@ -304,7 +304,7 @@ security({
 
 ---
 
-## Best Practices
+## Recommendations
 
 ### Block tags, not just attributes
 

--- a/docs/content/4.plugins/1.built-in/shiki.md
+++ b/docs/content/4.plugins/1.built-in/shiki.md
@@ -173,7 +173,7 @@ import githubDark from '@shikijs/themes/github-dark'
 
 ## Features
 
-### Dual-Theme Support
+### Dual-theme support
 
 Highlight code with different themes for light and dark modes. Both palettes are embedded as CSS custom properties, so there is no flash on theme switch. See all [available themes →](https://shiki.style/themes)
 
@@ -186,7 +186,7 @@ shiki({
 })
 ```
 
-### Language Detection
+### Language detection
 
 Comark reads the language from the code fence info string and highlights accordingly. On the standard entry, the default language set is pre-registered; pass extra grammars via `languages` (from `@shikijs/langs`). On `core`, only the languages you pass are available. See all [180+ supported languages →](https://shiki.style/languages)
 
@@ -196,7 +196,7 @@ const x: number = 42
 ```
 ````
 
-### Line Highlighting
+### Line highlighting
 
 Highlight specific lines using `{line-numbers}` syntax:
 
@@ -213,7 +213,7 @@ function example() {
 
 Lines receive the `.highlight` class; see [Styling](#styling) for the required CSS.
 
-### Filename Metadata
+### Filename metadata
 
 Display a filename label above the code block:
 
@@ -223,7 +223,7 @@ const app = express()
 ```
 ````
 
-### Language Loading
+### Language loading
 
 Install `@shikijs/langs` and import grammars to register extra languages (or all languages on `core`):
 
@@ -261,7 +261,7 @@ shiki({
 
 The most powerful transformer is [`@shikijs/twoslash`](/kb/twoslash): it runs the TypeScript compiler on your code blocks to add inline type tooltips and error annotations.
 
-### Pre Styles
+### Pre styles
 
 Set `preStyles: true` to add inline background and foreground colors to `<pre>` elements based on the active theme.
 
@@ -301,7 +301,7 @@ Two option types, one per entry:
 | Option | Type | Default | Description |
 |---|---|---|---|
 | [`themes`](#options-themes) | `object` | Material themes | Light and dark theme registrations |
-| [`languages`](#options-languages) | `LanguageRegistration[]` | `undefined` | Extra languages (merged onto the default set) |
+| [`languages`](#options-languages) | `Array<LanguageRegistration \| LanguageRegistration[]>` | `undefined` | Extra languages (merged onto the default set) |
 | [`transformers`](#options-transformers) | `ShikiTransformer[]` | `undefined` | Shiki transformers applied to every block |
 | [`preStyles`](#options-prestyles) | `boolean` | `false` | Add inline background/foreground styles to `<pre>` |
 | [`registerDefaultLanguages`](#options-registerdefaultlanguages) | `boolean` | `true` | Register the built-in default language set |
@@ -312,7 +312,7 @@ Two option types, one per entry:
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `themes` | `object` | **required** | Light and/or dark theme registrations |
-| `languages` | `LanguageRegistration[]` | **required** | Languages to register |
+| `languages` | `Array<LanguageRegistration \| LanguageRegistration[]>` | **required** | Languages to register |
 | `transformers` | `ShikiTransformer[]` | `undefined` | Shiki transformers applied to every block |
 | `preStyles` | `boolean` | `false` | Add inline background/foreground styles to `<pre>` |
 
@@ -414,7 +414,7 @@ shiki({
 
 ## Examples
 
-### GitHub Theme
+### GitHub theme
 
 ```typescript
 import { parseMarkdown } from 'comark'
@@ -427,7 +427,7 @@ const result = await parseMarkdown(content, {
 })
 ```
 
-### Minimal Bundle
+### Minimal bundle
 
 Install the standalone Shiki packages, use the `core` entry (`ShikiCoreOptions`), and import only what you need — `languages` and `themes` are required, and no defaults are bundled:
 
@@ -447,7 +447,7 @@ shiki({
 })
 ```
 
-### With Transformers
+### With transformers
 
 ```typescript
 import {
@@ -472,7 +472,7 @@ See the [Twoslash guide](/kb/twoslash) for TypeScript-powered type tooltips and 
 Need a copy button or collapse threshold on a custom `ProsePre`? After highlighting there is no `code` prop — reconstruct the source with `__node` and `textContent()`.
 ::
 
-### Live Examples
+### Live examples
 
 ::card{icon="i-lucide-code" title="Vue + Vite Highlight" to="https://github.com/comarkjs/comark/tree/main/examples/3.plugins/vue-vite-highlight"}
 Dual-theme support, 10+ languages, theme toggle. Includes JavaScript, TypeScript, Python, Rust, Go, SQL and more.
@@ -488,7 +488,7 @@ Browser-side twoslash with CDN-fetched TypeScript types and interactive type pop
 
 Shiki outputs tokens as `<span class="line">` elements inside a `<pre class="shiki">` block.
 
-### Line Highlight
+### Line highlight
 
 Lines set with `{1,3-5}` syntax receive the `.highlight` class:
 
@@ -502,7 +502,7 @@ Lines set with `{1,3-5}` syntax receive the `.highlight` class:
 }
 ```
 
-### Dark Mode
+### Dark mode
 
 When both `light` and `dark` themes are provided, Shiki embeds both palettes as CSS custom properties on every `<span>`. Activate the dark palette based on your project's dark-mode class:
 

--- a/docs/content/4.plugins/1.built-in/summary.md
+++ b/docs/content/4.plugins/1.built-in/summary.md
@@ -1,5 +1,5 @@
 ---
-title: Summary Extraction
+title: Summary extraction
 description: Plugin for extracting content summaries using the <!-- more --> delimiter.
 seo:
   title: Summary Extraction Plugin
@@ -62,18 +62,20 @@ const plugins = [summary()]
 ```
 
 ```tsx [React]
-import { Markdown } from '@comark/react'
+import { parseMarkdown } from 'comark'
+import { MarkdownDocument } from '@comark/react'
 import summary from '@comark/react/plugins/summary'
 
-<Markdown plugins={[summary()]} summary>
-  {content}
-</Markdown>
+const doc = await parseMarkdown(content, { plugins: [summary()] })
+
+// renders only the summary portion
+<MarkdownDocument value={{ ...doc, nodes: doc.meta.summary ?? doc.nodes }} />
 ```
 
 ::
 
 ::tip
-The `summary` prop on `<Markdown>` renders only the extracted summary nodes. Without it, the full content is rendered and `meta.summary` is available separately.
+The `summary` prop on the Vue `<Markdown>` component renders only the extracted summary nodes; without it, the full content is rendered and `meta.summary` is available separately. In React, read `meta.summary` from the parse result and render it with `<MarkdownDocument>`.
 ::
 
 ---
@@ -102,7 +104,7 @@ The extracted nodes are stored at `tree.meta.summary` as `Node[]`. If no delimit
 
 ### `delimiter`
 
-The HTML comment string that marks the end of the summary. The delimiter itself is removed from both the summary and the full content.
+The HTML comment string that marks the end of the summary. The extracted `meta.summary` nodes stop before the delimiter; the full content in `nodes` keeps the delimiter's comment node.
 
 ```typescript
 summary({ delimiter: '<!-- summary -->' })
@@ -112,7 +114,7 @@ summary({ delimiter: '<!-- summary -->' })
 
 ## Examples
 
-### Blog Listing
+### Blog listing
 
 Render summaries in a listing page and link to the full article:
 
@@ -138,18 +140,22 @@ const plugins = [summary()]
 ```
 
 ```tsx [React]
-import { Markdown } from '@comark/react'
+import { parseMarkdown } from 'comark'
+import { MarkdownDocument } from '@comark/react'
 import summary from '@comark/react/plugins/summary'
 
 const plugins = [summary()]
 
-export function ArticleList({ articles }) {
+export async function ArticleList({ articles }) {
+  const docs = await Promise.all(
+    articles.map(article => parseMarkdown(article.content, { plugins }))
+  )
   return (
     <div className="articles">
-      {articles.map(article => (
+      {articles.map((article, i) => (
         <article key={article.slug}>
           <h2>{article.title}</h2>
-          <Markdown plugins={plugins} summary>{article.content}</Markdown>
+          <MarkdownDocument value={{ ...docs[i], nodes: docs[i].meta.summary ?? docs[i].nodes }} />
           <a href={`/articles/${article.slug}`}>Read more →</a>
         </article>
       ))}

--- a/docs/content/4.plugins/1.built-in/toc.md
+++ b/docs/content/4.plugins/1.built-in/toc.md
@@ -1,5 +1,5 @@
 ---
-title: Table of Contents
+title: Table of contents
 description: Plugin for automatically generating a table of contents from document headings.
 seo:
   title: Table of Contents Plugin
@@ -30,7 +30,7 @@ const result = await parseMarkdown(content, {
   plugins: [toc()]
 })
 
-console.log(result.meta.toc) // TocTree
+console.log(result.meta.toc) // Toc
 ```
 
 ---
@@ -50,8 +50,8 @@ Returns a `ComarkPlugin` that generates a hierarchical TOC from headings.
 The result is stored at `tree.meta.toc`:
 
 ```typescript
-interface TocTree {
-  title: string       // TOC title (from options or frontmatter)
+interface Toc {
+  title: string       // TOC title (from the `title` option)
   depth: number       // Maximum heading depth included
   searchDepth: number // Search depth in nested structures
   links: TocLink[]    // Hierarchical list of links
@@ -73,11 +73,7 @@ interface TocLink {
 |---|---|---|---|
 | [`depth`](#options-depth) | `number` | `2` | Heading levels to include: `1` = h2 only, `2` = h2–h3, `3` = h2–h4, etc. |
 | [`searchDepth`](#options-searchdepth) | `number` | `2` | How deep to search for headings in nested component structures |
-| [`title`](#options-title) | `string` | `''` | Title field on the returned `TocTree` |
-
-::tip
-All three options can also be set via frontmatter: `depth`, `searchDepth`, and `title` keys are read automatically and override the plugin options.
-::
+| [`title`](#options-title) | `string` | `''` | Title field on the returned `Toc` |
 
 ### `depth`
 
@@ -101,7 +97,7 @@ toc({ searchDepth: 3 })
 
 ### `title`
 
-Sets the `title` field on the returned `TocTree`. Has no effect on rendering; use it to label the TOC in your layout component.
+Sets the `title` field on the returned `Toc`. Has no effect on rendering; use it to label the TOC in your layout component.
 
 ```typescript
 toc({ title: 'On This Page' })
@@ -113,7 +109,7 @@ toc({ title: 'On This Page' })
 
 ## Examples
 
-### Basic TOC Generation
+### Basic TOC generation
 
 ::code-group
 
@@ -158,7 +154,7 @@ console.log(result.meta.toc)
 
 ::
 
-### Docs Layout
+### Docs layout
 
 Parse once to get the TOC, then render it alongside the `<Markdown>` component:
 
@@ -252,27 +248,3 @@ export function DocsLayout({ content }: { content: string }) {
 ::tip
 For deeply nested TOCs, render `link.children` recursively: define a `TocLink` component that calls itself for each child.
 ::
-
-### With Frontmatter
-
-`depth`, `searchDepth`, and `title` can be set in the document's frontmatter and will override plugin options:
-
-```markdown
----
-title: My Guide
-depth: 3
-searchDepth: 3
----
-
-# My Guide
-
-## Section 1
-
-### Subsection 1.1
-```
-
-```typescript
-const result = await parseMarkdown(content, { plugins: [toc()] })
-console.log(result.meta.toc.depth) // 3 (from frontmatter)
-console.log(result.meta.toc.title) // "My Guide" (from frontmatter)
-```

--- a/docs/content/4.plugins/2.custom/1.plugin-api.md
+++ b/docs/content/4.plugins/2.custom/1.plugin-api.md
@@ -229,8 +229,8 @@ To traverse and transform `tree` nodes, see the AST API page for the `visit()` u
 |---|---|---|
 | `name` | `string` | A unique identifier for the plugin |
 | `markdownItPlugins` | [`MarkdownItPlugin[]`](https://markdown-it.github.io/markdown-it/#MarkdownIt) | markdown-it plugins to register on the parser, see [Markdown-it Plugins](/plugins/custom/markdown-it) |
-| `pre` | `(state: ComarkParsePreState) => void` | Hook called before parsing |
-| `post` | `(state: ComarkParsePostState<TMeta, TFrontmatter>) => void` | Hook called after the AST is built. `state.tree.meta` / `state.tree.frontmatter` are typed as the declared contribution, see [Typed contributions](#typed-contributions). |
+| `pre` | `(state: ComarkParsePreState) => Promise<void> \| void` | Hook called before parsing |
+| `post` | `(state: ComarkParsePostState<TMeta, TFrontmatter>) => Promise<void> \| void` | Hook called after the AST is built. `state.tree.meta` / `state.tree.frontmatter` are typed as the declared contribution, see [Typed contributions](#typed-contributions). |
 
 ---
 

--- a/docs/content/4.plugins/2.custom/2.ast-api.md
+++ b/docs/content/4.plugins/2.custom/2.ast-api.md
@@ -57,9 +57,9 @@ export default defineComarkPlugin(() => ({
 
 ---
 
-## Use Cases
+## Use cases
 
-### Replacing Nodes
+### Replacing nodes
 
 Return a new node to replace the matched one. The following example wraps bare URL text nodes in anchor elements:
 
@@ -85,7 +85,7 @@ export default defineComarkPlugin(() => ({
 }))
 ```
 
-### Mutating Attributes
+### Mutating attributes
 
 Return `void` and mutate the node in place when you only need to update attributes:
 
@@ -107,7 +107,7 @@ export default defineComarkPlugin(() => ({
 }))
 ```
 
-### Removing Nodes
+### Removing nodes
 
 Return `false` to remove matched nodes entirely:
 

--- a/docs/content/4.plugins/2.custom/3.markdown-it.md
+++ b/docs/content/4.plugins/2.custom/3.markdown-it.md
@@ -126,7 +126,7 @@ When you provide `markdownItPlugins`, they are registered directly on the underl
 - **Core rules**: [`md.core.ruler`](https://markdown-it.github.io/markdown-it/#Ruler)
 - **Renderer rules**: [`md.renderer.rules`](https://markdown-it.github.io/markdown-it/#Renderer) (limited, see below)
 
-### What Works
+### What works
 
 Most plugins that add **parsing rules** work out of the box:
 
@@ -134,7 +134,7 @@ Most plugins that add **parsing rules** work out of the box:
 - Plugins that add new block syntax (containers, definition lists, footnotes)
 - Plugins that transform tokens via core rules (abbreviations, replacements)
 
-### What Doesn't Work
+### What doesn't work
 
 ::warning
 Plugins that rely on markdown-it's **renderer** will not work as expected. Comark uses its own rendering pipeline instead of `md.renderer`, so any logic in `md.renderer.rules` is ignored.

--- a/docs/content/4.plugins/index.md
+++ b/docs/content/4.plugins/index.md
@@ -145,7 +145,7 @@ Optional plugins you register via `plugins: [...]`.
   ::
 ::
 
-## Use Plugins
+## Use plugins
 
 Pass plugins to `parseMarkdown()` or the `<Markdown>` component:
 

--- a/docs/content/5.reference/0.render.md
+++ b/docs/content/5.reference/0.render.md
@@ -152,14 +152,14 @@ const document = await parseMarkdown(source)
 
 const markdown = await renderMarkdown(document, {
   components: {
-    alert: ([, attrs, ...children], { render }) => {
-      return `::alert{type="${attrs.type}"}\n${render(children)}\n::`
+    alert: async ([, attrs, ...children], { render }) => {
+      return `::alert{type="${attrs.type}"}\n${await render(children)}\n::`
     }
   }
 })
 ```
 
-#### Conditional Handlers
+#### Conditional handlers
 
 When a handler should apply based on a node's attributes rather than its tag name, use a `ConditionalNodeHandler`:
 
@@ -198,11 +198,11 @@ Additional data passed to every component handler via the context object. Useful
 const markdown = await renderMarkdown(document, {
   data: { baseUrl: 'https://example.com' },
   components: {
-    a: ([, attrs, ...children], { render, data }) => {
+    a: async ([, attrs, ...children], { render, data }) => {
       const href = attrs.href?.startsWith('/')
         ? `${data.baseUrl}${attrs.href}`
         : attrs.href
-      return `[${render(children)}](${href})`
+      return `[${await render(children)}](${href})`
     }
   }
 })
@@ -210,9 +210,9 @@ const markdown = await renderMarkdown(document, {
 
 ---
 
-## Use Cases
+## Use cases
 
-### Round-trip Transformation
+### Round-trip transformation
 
 Parse markdown, programmatically transform the AST, then serialize back:
 
@@ -237,7 +237,7 @@ visit(document,
 const output = await renderMarkdown(document)
 ```
 
-### Content Migration
+### Content migration
 
 Convert between attribute styles or normalize formatting:
 
@@ -261,7 +261,7 @@ async function migrateToFrontmatter(source: string) {
 }
 ```
 
-### Programmatic Document Generation
+### Programmatic document generation
 
 Build a Comark document from data:
 

--- a/docs/content/5.reference/1.parse.md
+++ b/docs/content/5.reference/1.parse.md
@@ -27,7 +27,7 @@ Parses Markdown from a string and returns a complete `MarkdownDocument`. Default
 
 - `nodes` - The parsed Markdown AST nodes
 - `frontmatter` - Frontmatter data parsed from YAML
-- `meta` - Additional metadata from plugins (e.g., `toc`, `summary`)
+- `meta` - Additional metadata from plugins (for example, `toc`, `summary`)
 
 **Example:**
 
@@ -96,12 +96,14 @@ console.log(result.frontmatter)
 ```
 ::
 
-### Table of Contents
+### Table of contents
 
-The parse function automatically generates a table of contents based on headings:
+Register the [toc plugin](/plugins/built-in/toc) to generate a table of contents based on headings:
 
 ::code-group
 ```typescript [parse.ts]
+import toc from 'comark/plugins/toc'
+
 const content = `# Main Title
 
 ## Section 1
@@ -117,7 +119,7 @@ More content.
 Final content.
 `
 
-const result = await parseMarkdown(content)
+const result = await parseMarkdown(content, { plugins: [toc()] })
 console.log(result.meta.toc)
 ```
 
@@ -136,7 +138,7 @@ console.log(result.meta.toc)
 ```
 ::
 
-### HTML Parsing
+### HTML parsing
 
 HTML tags embedded in Comark content are parsed into AST nodes by default and can be mixed freely with Comark components and markdown syntax.
 
@@ -233,16 +235,16 @@ const parse = createMarkdownParser({
 })
 
 // Reuse the parser for multiple documents
-const doc1 = await parseMarkdown('# Document 1\n\nContent...')
-const doc2 = await parseMarkdown('# Document 2\n\nMore content...')
-const doc3 = await parseMarkdown('# Document 3\n\nEven more...')
+const doc1 = await parse('# Document 1\n\nContent...')
+const doc2 = await parse('# Document 2\n\nMore content...')
+const doc3 = await parse('# Document 3\n\nEven more...')
 ```
 
-### Use Cases
+### Use cases
 
 Here are some use cases for `createMarkdownParser()`:
 
-#### Static Site Generator
+#### Static site generator
 
 Use `Promise.all` to parse all files in parallel. Since `createMarkdownParser()` initializes the parser once, the returned function is safe to call concurrently.
 
@@ -276,7 +278,7 @@ async function buildSite(contentDir: string, outDir: string) {
   await Promise.all(
     mdFiles.map(async (file) => {
       const content = await readFile(join(contentDir, file), 'utf-8')
-      const doc = await parseMarkdown(content)
+      const doc = await parse(content)
       const html = await renderHtmlFromDocument(doc)
       await writeFile(join(outDir, file.replace('.md', '.html')), html)
     })
@@ -288,7 +290,7 @@ async function buildSite(contentDir: string, outDir: string) {
 await buildSite('./content', './dist')
 ```
 
-#### API Server
+#### API server
 
 ```typescript [server.ts]
 import { createMarkdownParser } from 'comark'
@@ -304,7 +306,7 @@ const parse = createMarkdownParser({
 // Reuse parser for every request
 app.post('/api/markdown', async (req, res) => {
   try {
-    const tree = await parseMarkdown(req.body.content)
+    const tree = await parse(req.body.content)
     res.json({ success: true, tree })
   } catch (error) {
     res.status(400).json({ error: 'Invalid markdown' })
@@ -343,7 +345,7 @@ const parse = createMarkdownParser({
   plugins: [shiki()]
 })
 for (let i = 0; i < 1000; i++) {
-  await parseMarkdown(content)
+  await parse(content)
 }
 console.timeEnd('createMarkdownParser x1000')
 // → ~800ms (10x faster! parser + highlighter created once)
@@ -369,7 +371,7 @@ Both `parseMarkdown()` and `createMarkdownParser()` accept the same `ParserOptio
 
 ### Timing the parse
 
-Pass a `tracer` to time each phase of the pipeline and every plugin hook, so you can see where parse time goes (e.g. a slow `post` shiki hook). The contract is a structural subset of [OpenTelemetry](https://opentelemetry.io/docs/languages/js/instrumentation/#creating-spans) `Tracer` — `startSpan` and `startActiveSpan` — so a real OTel tracer works as-is:
+Pass a `tracer` to time each phase of the pipeline and every plugin hook, so you can see where parse time goes (for example, a slow `post` shiki hook). The contract is a structural subset of [OpenTelemetry](https://opentelemetry.io/docs/languages/js/instrumentation/#creating-spans) `Tracer` — `startSpan` and `startActiveSpan` — so a real OTel tracer works as-is:
 
 ```ts
 import { trace } from '@opentelemetry/api'
@@ -386,9 +388,7 @@ const parse = createMarkdownParser({
 `@opentelemetry/api` defines the tracing API but does not export spans by itself. `trace.getTracer()` uses the globally registered OpenTelemetry provider; without one, it returns a no-op tracer. Hosting platforms often register and configure that provider for you. Otherwise, initialize an OpenTelemetry SDK and exporter before creating the parser.
 ::
 
-::callout{icon="i-lucide-square-play" color="info" to="https://github.com/comarkdown/comark/blob/main/examples/3.cli/perf-trace/otel.ts"}
-See the complete Node.js example, including an OTLP/HTTP exporter and commands for viewing traces locally with `otel-front`.
-::
+See the [complete Node.js example](https://github.com/comarkdown/comark/blob/main/examples/3.cli/perf-trace/otel.ts), including an OTLP/HTTP exporter and commands for viewing traces locally with `otel-front`.
 
 Or a minimal recorder:
 
@@ -423,7 +423,7 @@ Recorded spans: a root `comark:parse` active span enclosing `comark:autoclose`, 
 
 ### Inline rendering
 
-Use `unwrap: 'p'` (or just `unwrap: true`) to render markdown without the
+Use `unwrap: 'p'` (or `unwrap: true`) to render markdown without the
 wrapping `<p>`, which is handy for buttons, badges, and other inline hosts.
 Adjacent text is merged into a single string, matching MDC's `unwrap`:
 

--- a/docs/content/5.reference/2.auto-close.md
+++ b/docs/content/5.reference/2.auto-close.md
@@ -43,7 +43,7 @@ autoCloseMarkdown('**bold text')
 `autoCloseMarkdown` is also available as a parse option: set `autoClose: true` (default) in `parseMarkdown()` or `createMarkdownParser()` to apply it automatically.
 ::
 
-### Parser Integration
+### Parser integration
 
 `autoClose` is enabled by default in `parseMarkdown()` and `createMarkdownParser()`. You can disable it if you want to handle incomplete syntax yourself:
 
@@ -72,7 +72,7 @@ const result = await parseMarkdown(closed, { autoClose: false })
 ```
 ::
 
-### Supported Syntax
+### Supported syntax
 
 #### Inline Markdown
 
@@ -85,7 +85,7 @@ const result = await parseMarkdown(closed, { autoClose: false })
 | Link | `[text](url` | `[text](url)` |
 | Image | `![alt](url` | `![alt](url)` |
 
-#### Comark Components
+#### Comark components
 
 Block components are closed based on their marker count:
 
@@ -103,7 +103,7 @@ autoCloseMarkdown('::::outer\n:::inner\n::component')
 // '::::outer\n:::inner\n::component\n::\n:::\n::::'
 ```
 
-#### Props and Attributes
+#### Props and attributes
 
 Components with props are handled correctly:
 
@@ -119,9 +119,9 @@ autoCloseMarkdown(`::component\n---\nkey: value\n---\nContent`)
 
 ---
 
-## Use Cases
+## Use cases
 
-### AI Streaming
+### AI streaming
 
 When streaming AI-generated markdown, content arrives in chunks and may be incomplete at any point:
 
@@ -148,7 +148,7 @@ socket.on('end', async () => {
 
 ### AI SDK
 
-Build a streaming AI chat with live Comark rendering in just a few lines.
+Build a streaming AI chat with live Comark rendering in a few lines.
 The [`<Markdown>`](/rendering/vue) component applies `autoCloseMarkdown` on every render by default, so the AST stays valid at every chunk and you get smooth incremental rendering without any extra wiring.
 
 ::steps{level="4"}
@@ -241,7 +241,7 @@ See the full working example with server route and chat UI wired together.
 
 The `caret` prop on `<Markdown>` appends a blinking cursor to the last text node while streaming. See the [Vue rendering docs](/rendering/vue#streaming) for custom caret styling.
 
-### Real-time Editor
+### Real-time editor
 
 Show a live preview while the user types:
 
@@ -256,7 +256,7 @@ editor.addEventListener('input', async (e) => {
 })
 ```
 
-### Incremental File Upload
+### Incremental file upload
 
 Parse content progressively as a file uploads:
 

--- a/docs/content/5.reference/3.reference.md
+++ b/docs/content/5.reference/3.reference.md
@@ -14,7 +14,7 @@ links:
     variant: soft
 ---
 
-## `comark` (Core)
+## `comark` (core)
 
 ### `parseMarkdown(source, options?)`
 
@@ -45,8 +45,8 @@ import { createMarkdownParser } from 'comark'
 
 const parse = createMarkdownParser({ plugins: [shiki()] })
 
-const tree1 = await parseMarkdown('# Document 1')
-const tree2 = await parseMarkdown('# Document 2')
+const tree1 = await parse('# Document 1')
+const tree2 = await parse('# Document 2')
 ```
 
 ### `renderMarkdown(document, options?)`
@@ -76,7 +76,7 @@ autoCloseMarkdown('::alert\nText') // '::alert\nText\n::'
 
 ---
 
-## String Renderers
+## String renderers
 
 ### `@comark/html`
 
@@ -186,7 +186,7 @@ await writeAnsi('# Hello')
 
 ---
 
-## Framework Renderers
+## Framework renderers
 
 `@comark/vue` · `@comark/react` · `@comark/svelte` · `@comark/angular` · `@comark/nuxt`: same API, different import path.
 
@@ -208,9 +208,7 @@ Parses and renders markdown in one async step.
 ```
 
 ```svelte [Svelte]
-<Markdown plugins={[shiki()]} components={{ alert: Alert }}>
-  {content}
-</Markdown>
+<Markdown value={content} plugins={[shiki()]} components={{ alert: Alert }} />
 ```
 
 ```html [Angular]
@@ -245,7 +243,7 @@ Renders a pre-parsed `MarkdownDocument` with no parser shipped to the client.
 Creates a pre-configured `<Markdown>` with baked-in plugins and component mappings.
 
 ```typescript
-import { defineMarkdownComponent } // or @comark/react, @comark/svelte, @comark/angular
+import { defineMarkdownComponent } from '@comark/vue' // or @comark/react, @comark/angular
 
 export const AppMarkdown = defineMarkdownComponent({
   plugins: [shiki(), toc()],
@@ -264,7 +262,7 @@ interface MarkdownDocument {
   nodes: Node[]
   frontmatter: Record<string, any>
   meta: {
-    toc?: TOC
+    toc?: Toc
     summary?: Node[]
     [key: string]: any
   }
@@ -278,7 +276,7 @@ interface RenderMarkdownOptions {
   maxInlineAttributes?: number             // Max inline attributes before switching to YAML block (default: 3)
   blockAttributesStyle?: 'frontmatter' | 'codeblock'  // Block attribute syntax style (default: 'codeblock')
   frontmatterOptions?: DumpOptions         // js-yaml options for frontmatter serialization
-  components?: Record<string, NodeHandler> // Custom render handlers for specific elements
+  components?: Record<string, NodeHandler | ConditionalNodeHandler> // Custom render handlers for specific elements
   data?: Record<string, any>              // Additional data passed to render handlers
 }
 ```
@@ -288,8 +286,9 @@ interface RenderMarkdownOptions {
 
 ```typescript
 type Node =
-  | string
-  | [tag: string, props?: Record<string, any>, ...children: Node[]]
+  | string                                                        // TextNode
+  | [tag: string, attrs: ElementNodeAttributes, ...children: Node[]]  // ElementNode
+  | [tag: null, attrs: ElementNodeAttributes, comment: string]        // CommentNode
 ```
 
 ### `ParserOptions`
@@ -298,30 +297,33 @@ type Node =
 interface ParserOptions {
   autoUnwrap?: boolean              // default: true
   autoClose?: boolean               // default: true
+  unwrap?: boolean | string | string[]  // strip top-level wrapper tags, e.g. 'p' (default: false)
   /** @deprecated Prefer registerDefaultPlugins: false */
   html?: boolean                    // default: true
   linkify?: boolean                 // default: true
   headingIds?: boolean              // default: true
   registerDefaultPlugins?: boolean  // default: true
   plugins?: ComarkPlugin[]
+  tracer?: ComarkTracer             // OpenTelemetry-style tracer for parse spans
 }
 ```
 
-### `TOC`
+### `Toc`
 
 ```typescript
-interface TOC {
-  title?: string
+// Exported from 'comark/plugins/toc'
+interface Toc {
+  title: string
   depth: number
   searchDepth: number
-  links: TOCLink[]
+  links: TocLink[]
 }
 
-interface TOCLink {
+interface TocLink {
   id: string
   text: string
   depth: number
-  children?: TOCLink[]
+  children?: TocLink[]
 }
 ```
 

--- a/docs/content/6.compare/1.comark-vs-mdx.md
+++ b/docs/content/6.compare/1.comark-vs-mdx.md
@@ -20,7 +20,7 @@ links:
 
 **TL;DR**: Both let you use components inside Markdown. MDX compiles your content to JSX at build time, so it is tied to a bundler and (in practice) to React. Comark parses component syntax at runtime into a framework-agnostic AST, so content can come from a database, a CMS, or an AI stream, and render to Vue, React, Svelte, Angular, HTML, or ANSI.
 
-## At a Glance
+## At a glance
 
 | | Comark | MDX |
 |---|---|---|
@@ -34,7 +34,7 @@ links:
 | Imports/exports in content | No, components registered in the renderer | Yes |
 | Plugin ecosystem | Comark plugins + markdown-it plugins | remark/rehype plugins |
 
-## The Core Difference: Content vs Code
+## The core difference: content vs code
 
 An `.mdx` file is a JavaScript module. It can import components, export values, and embed arbitrary expressions. That power has a cost: your content must go through a compiler before it can render. Shipping a typo fix means triggering a rebuild and a redeploy, and storing MDX in a database means running a compiler on the server for every document.
 
@@ -55,7 +55,7 @@ Because `parseMarkdown(markdown)` returns a serializable [`MarkdownDocument`](/g
 
 Content is live the moment it is saved.
 
-## Syntax Side by Side
+## Syntax side by side
 
 ::code-group
 ```jsx [MDX]
@@ -100,7 +100,7 @@ autoCloseMarkdown('::alert\nContent') // '::alert\nContent\n::'
 
 Each framework renderer exposes this as a `streaming` prop that pipes AI output straight into your component tree, custom components included.
 
-## What MDX Does That Comark Doesn't
+## What MDX does that Comark doesn't
 
 Be aware of what you give up:
 

--- a/docs/content/6.compare/2.comark-vs-react-markdown.md
+++ b/docs/content/6.compare/2.comark-vs-react-markdown.md
@@ -20,7 +20,7 @@ links:
 
 **TL;DR**: `react-markdown` renders standard Markdown to React elements and lets you remap HTML tags to components. Comark does that too, and adds what react-markdown was never designed for: component syntax authors can write in the content itself, auto-close for token-by-token streaming, a serializable AST you can parse on the server, and renderers beyond React.
 
-## At a Glance
+## At a glance
 
 | | Comark | react-markdown |
 |---|---|---|
@@ -34,7 +34,7 @@ links:
 | Plugins | Comark plugins + markdown-it plugins | remark/rehype plugins |
 | Frontmatter | Parsed out of the box | Needs remark-frontmatter + custom handling |
 
-## Element Mapping Works the Same Way
+## Element mapping works the same way
 
 If you use react-markdown only to restyle elements, the model transfers directly:
 
@@ -66,7 +66,7 @@ import { Markdown } from '@comark/react'
 ```
 ::
 
-## What react-markdown Can't Express
+## What react-markdown can't express
 
 react-markdown maps existing HTML elements to components. It has no syntax for components that aren't HTML elements: a callout, a tabbed code group, a video embed. The usual workaround is raw HTML plus `rehype-raw`, which reintroduces the verbosity and XSS surface Markdown was meant to avoid.
 
@@ -97,7 +97,7 @@ export function Message({ text, isStreaming }: { text: string, isStreaming: bool
 }
 ```
 
-## Decoupled Parsing
+## Decoupled parsing
 
 react-markdown parses inside the React component, on every client that renders it. Comark separates the two: parse once (on the server, at build time, or in a worker) and render the compact AST anywhere:
 
@@ -115,7 +115,7 @@ import { MarkdownDocument } from '@comark/react'
 
 The document contains plain arrays like `['h1', { id: 'hello' }, 'Hello']`, which are cheap to serialize and cache. See the [document model](/getting-started/document-model).
 
-## What react-markdown Does Well
+## What react-markdown does well
 
 - **The unified ecosystem**: hundreds of remark/rehype plugins. Comark's answer is its own [plugin API](/plugins/custom/plugin-api) plus compatibility with [markdown-it plugins](/plugins/custom/markdown-it); check that your must-have plugins have an equivalent before switching.
 - **Maturity**: react-markdown has been battle-tested for years across a huge install base.

--- a/docs/content/6.compare/3.comark-vs-streamdown.md
+++ b/docs/content/6.compare/3.comark-vs-streamdown.md
@@ -20,7 +20,7 @@ links:
 
 **TL;DR**: [Streamdown](https://github.com/vercel/streamdown) is Vercel's React component for rendering AI-streamed Markdown, built to handle unterminated syntax gracefully. Comark solves the same streaming problem and goes further: authors (and LLMs) can use custom component syntax in the content, the parser is decoupled from rendering, and the same content renders in Vue, React, Svelte, Angular, HTML, and ANSI.
 
-## At a Glance
+## At a glance
 
 | | Comark | Streamdown |
 |---|---|---|
@@ -34,7 +34,7 @@ links:
 | Security hardening | [Security plugin](/plugins/built-in/security) | Hardened defaults built in |
 | AI SDK integration | Works with `useChat` in any framework | Designed around `@ai-sdk/react` |
 
-## Same Problem, Different Scope
+## Same problem, different scope
 
 Streamdown exists because LLMs stream token by token while classic renderers assume complete documents. It validates the exact problem Comark's [auto-close](/reference/auto-close) parser solves: unterminated bold, half-open code fences, and incomplete links render correctly at every frame in both tools.
 
@@ -49,7 +49,7 @@ const tree = await parseMarkdown(partialMarkdown, { autoClose: true })
 
 That split means you can parse AI output on the server and stream the AST, cache parsed content, post-process it with the [AST API](/plugins/custom/ast-api), or render the same stream to a terminal with [@comark/ansi](/rendering/ansi).
 
-## Components in the Stream
+## Components in the stream
 
 The bigger difference is what the model is allowed to say. With Streamdown, output is standard Markdown mapped to styled elements. With Comark, you can give the model component syntax, and it streams as plain text like everything else:
 
@@ -73,13 +73,13 @@ import { Markdown } from '@comark/react'
 </Markdown>
 ```
 
-Because `::flight-card` is text, not JSX, there is no code execution risk in model output. Unknown components are simply skipped or rendered as configured.
+Because `::flight-card` is text, not JSX, there is no code execution risk in model output. Unknown components are skipped or rendered as configured.
 
 ## Beyond React
 
 Streamdown is React-only by design. Comark ships the same streaming behavior for [Vue](/rendering/vue), [React](/rendering/react), [Svelte](/rendering/svelte), [Angular](/rendering/angular), and [Nuxt](/rendering/nuxt), plus string renderers for [HTML](/rendering/html) and [ANSI](/rendering/ansi). One content pipeline, whatever your stack looks like today or in three years.
 
-## What Streamdown Does Well
+## What Streamdown does well
 
 - **Zero-config for the AI SDK**: highlighting, math, Mermaid, and security hardening are built in rather than opt-in plugins. With Comark you compose the equivalent from [plugins](/plugins).
 - **Drop-in for react-markdown users**: it mirrors the `react-markdown` API surface.

--- a/docs/content/6.compare/4.comark-vs-markdoc.md
+++ b/docs/content/6.compare/4.comark-vs-markdoc.md
@@ -20,7 +20,7 @@ links:
 
 **TL;DR**: [Markdoc](https://markdoc.dev) (built by Stripe) and Comark share a philosophy: Markdown is data, components are declared in plain text, and parsing happens at runtime without a build step. They differ in what's built on top of the parser. Comark adds streaming auto-close for AI output, a more compact array-based AST, official renderers for Vue, Svelte, Angular, HTML, and ANSI, and compatibility with the markdown-it plugin ecosystem.
 
-## At a Glance
+## At a glance
 
 | | Comark | Markdoc |
 |---|---|---|
@@ -35,7 +35,7 @@ links:
 | Plugin ecosystem | Comark plugins + markdown-it plugins | Custom nodes/tags configuration |
 | Syntax lineage | [Markdown directives proposal](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444), 5 years of MDC in Nuxt Content | Stripe's internal docs platform |
 
-## Shared Philosophy
+## Shared philosophy
 
 Both tools reject the MDX model of compiling content into code. A Markdoc tag and a Comark component are declarations, not expressions:
 
@@ -68,7 +68,7 @@ autoCloseMarkdown('::callout\nStreaming in **prog')
 // '::callout\nStreaming in **prog**\n::'
 ```
 
-## AST Shape
+## AST shape
 
 Both produce trees; the shapes differ in weight. Comark nodes are plain arrays with a fixed layout:
 
@@ -78,11 +78,11 @@ Both produce trees; the shapes differ in weight. Comark nodes are plain arrays w
 
 Markdoc nodes are objects carrying `type`, `tag`, `attributes`, `children`, and transform metadata. Comark's document is designed to be sent over the wire: parse on the server, `JSON.stringify` the result, and hydrate any renderer with it. See the [document model](/getting-started/document-model).
 
-## Framework Coverage
+## Framework coverage
 
 Markdoc officially renders to React and HTML. Comark ships official renderers for [Vue](/rendering/vue), [React](/rendering/react), [Svelte](/rendering/svelte), [Angular](/rendering/angular), and [Nuxt](/rendering/nuxt), plus [HTML](/rendering/html) and [ANSI](/rendering/ansi) string output, all consuming the same AST.
 
-## What Markdoc Does Well
+## What Markdoc does well
 
 - **Schema validation**: Markdoc lets you declare each tag's allowed attributes and children, then validate documents against those schemas before rendering. Comark has no schema layer; invalid props surface in the component, and structural checks are yours to write with the [AST API](/plugins/custom/ast-api).
 - **Built-in variables, functions, and partials**: Markdoc resolves `$variables`, calls functions, and includes partials inside content. Comark keeps logic in the application: the [binding plugin](/plugins/built-in/binding) interpolates frontmatter and runtime data, and composition happens in your components.

--- a/docs/content/7.kb/0.why-comark.md
+++ b/docs/content/7.kb/0.why-comark.md
@@ -30,7 +30,7 @@ HTML is powerful but verbose. That verbosity costs even more in an era where AI 
 
 **Markdown occupies rare middle ground.** The source text is comfortable prose for a human author and token-efficient structured data for a machine consumer. That convergence wasn't part of [Gruber's original design](https://daringfireball.net/projects/markdown/). He was solving for readability in 2004. But it explains why Markdown has become the default format for both human authoring and AI consumption.
 
-### Why Machines Prefer Markdown
+### Why machines prefer Markdown
 
 The evidence is clearest in token economics.
 
@@ -38,7 +38,7 @@ The same page served as HTML versus Markdown to an AI agent can use **80% fewer 
 
 Beyond token count, Markdown's explicit structure maps cleanly to how language models reason. A `##` heading is unambiguously a section boundary. HTML carries the same information buried in `<h2 class="...">` but the signal-to-noise ratio is far worse.
 
-### AI as a First-Class Audience
+### AI as a first-class audience
 
 The tooling industry has converged on this conclusion. [Streamdown](https://github.com/vercel/streamdown) (an open-source renderer by Hayden Bleasel, DX Engineer at Vercel) was built precisely because LLMs stream token by token and existing renderers like `react-markdown` assume a complete document, making them unable to handle unterminated blocks gracefully. Because LLMs tend to produce Markdown by default, Streamdown is a React component designed to render it correctly as chunks arrive, pairing naturally with `useChat` and other streaming patterns from `@ai-sdk/react`. Together they reflect a deliberate recognition that AI agents are now a _primary_ consumer of content, not a secondary one ([Comark vs Streamdown](/compare/comark-vs-streamdown)).
 
@@ -52,13 +52,13 @@ The JavaScript ecosystem has excellent Markdown parsers and renderers, but most 
 
 Comark separates these concerns. It parses Markdown into a shared document model, lets you transform or store that document, and renders it through the output package you choose. The same API works at build time or runtime, on the server or in the browser, and with complete or streaming input.
 
-### Built on markdown-it Foundations
+### Built on markdown-it foundations
 
 Comark supports CommonMark and GitHub Flavored Markdown (GFM) through [markdown-exit](https://github.com/serkodev/markdown-exit), a TypeScript rewrite of markdown-it that preserves its plugin API. Existing Markdown stays familiar, and existing markdown-it plugins can work alongside [Comark plugins](/plugins).
 
 This foundation gives Comark a mature parsing model without limiting how or where the parsed document is rendered.
 
-### Markdown as Data, Not Code
+### Markdown as data, not code
 
 `parseMarkdown(markdown)` returns a compact, serializable [`MarkdownDocument`](/getting-started/document-model). Text stays as strings, elements use tuples such as `['tag', props, ...children]`, and plugins can attach structured metadata.
 
@@ -75,7 +75,7 @@ You can parse once and render many times without coupling stored content to a fr
 You can store the `MarkdownDocument` directly in the database to skip re-parsing on every request.
 ::
 
-### One Source, Every Renderer
+### One source, every renderer
 
 Most Markdown rendering libraries are designed around one output target. Comark decouples parsing from rendering so the same source can produce:
 
@@ -88,13 +88,13 @@ Most Markdown rendering libraries are designed around one output target. Comark 
 
 Your content outlasts your output target and framework choice.
 
-### Streaming Is Part of the Parser
+### Streaming is part of the parser
 
 AI models emit Markdown token by token, but conventional parsers expect complete documents. Comark's [auto-close](/reference/auto-close) support completes unterminated emphasis, links, code fences, and component blocks so each intermediate frame renders correctly.
 
 Framework renderers expose streaming directly, while the core parser lets any integration opt into the same behavior. You can display content as soon as it arrives without maintaining a separate streaming syntax or renderer.
 
-### Extend Markdown Without Embedding Code
+### Extend Markdown without embedding code
 
 Standard Markdown does not express a warning callout, tabbed code group, video embed, or pricing card. Raw HTML can represent them, but it adds verbosity and couples content to markup. MDX allows executable JSX, but it also makes content part of a framework-specific build pipeline ([full comparison](/compare/comark-vs-mdx)).
 
@@ -110,7 +110,7 @@ A human can read the source, while the parser sees a component named `alert` wit
 
 Attributes provide the same plain-text approach for adding classes, IDs, styles, and metadata to standard Markdown elements. Both extensions are available when you need them; plain CommonMark and GFM continue to work unchanged.
 
-### First-Class Slots
+### First-class slots
 
 Components can accept rich Markdown in named regions. `#slotname` markers let you compose full Markdown into each slot without falling back to HTML or framework templates:
 
@@ -124,7 +124,7 @@ Comark parses component syntax at runtime: no compiler, no rebuild.
 Renders to HTML, ANSI, Vue, React, Svelte, and Angular.
 
 #cta
-[Get started](/getting-started)
+[Get started](/getting-started/installation)
 ::
 ```
 

--- a/docs/content/7.kb/2.migration-from-mdc.md
+++ b/docs/content/7.kb/2.migration-from-mdc.md
@@ -18,7 +18,7 @@ links:
 
 Comark is the successor to `@nuxtjs/mdc`. The markdown syntax is fully compatible: your `.md` files need no changes. What changes is the JavaScript API: package names, parse functions, the AST format, and how plugins work.
 
-## Quick Overview
+## Quick overview
 
 - **Package**: `@nuxtjs/mdc` → `comark` (core) or `@comark/nuxt` (Nuxt module)
 - **Parse**: `parseMarkdown()` → `parseMarkdown()` · factory: `createMarkdownParser()` (sync, no await)
@@ -30,7 +30,7 @@ Comark is the successor to `@nuxtjs/mdc`. The markdown syntax is fully compatibl
 - **Plugins**: global `nuxt.config` → per-component `defineMarkdownComponent({ plugins })`
 - **Markdown files**: no changes needed
 
-## Agent Skill
+## Agent skill
 
 To give coding agents the MDC-to-Comark migration skill, install it from production:
 
@@ -38,7 +38,7 @@ To give coding agents the MDC-to-Comark migration skill, install it from product
 npx skills add https://comark.dev/skills/migrate-mdc-to-comark
 ```
 
-## Package Changes
+## Package changes
 
 If you only use the programmatic API (parse functions, plugins, AST manipulation), install `comark` alone:
 
@@ -82,11 +82,11 @@ bun add @comark/nuxt
 ```
 ::
 
-## Core Package
+## Core package
 
 The `comark` package is the foundation all other packages build on. The changes below apply to all programmatic usage, regardless of whether you use the Nuxt module.
 
-### Parse Functions
+### Parse functions
 
 #### One-shot parsing
 
@@ -116,15 +116,13 @@ const document = await parse(markdown)
 ```
 ::
 
-::note
-`createMarkdownParser` is synchronous. `createMarkdownParser` was async because it had to initialize the unified processor pipeline. Comark's plugin system is eagerly initialized, so the factory returns immediately.
-::
+Comark's `createMarkdownParser` is synchronous: the plugin system is eagerly initialized, so the factory returns immediately. MDC's factory was async because it had to initialize the unified processor pipeline.
 
 ::tip{to="/reference/parse"}
 See the Parse API for the full list of options and return types.
 ::
 
-### Render Functions
+### Render functions
 
 #### Serialize back to Markdown
 
@@ -141,7 +139,7 @@ const markdown = await renderMarkdown(document)
 
 `renderMarkdown` includes frontmatter automatically: it reads `document.frontmatter` and serializes it as YAML front matter. See the [Render API](/reference/render) for full options.
 
-### Return Type
+### Return type
 
 The shape of the parsed result changed.
 
@@ -183,7 +181,7 @@ The shape of the parsed result changed.
 | `result.toc` | `document.meta.toc` (requires `toc` plugin) |
 | `result.excerpt` | `document.meta.summary` (requires `summary` plugin) |
 
-### AST Format
+### AST format
 
 The node structure is fundamentally different. MDC uses objects; Comark uses compact tuples.
 
@@ -226,7 +224,7 @@ See the document model guide for the node types, parsed document structure, and 
 
 MDC used the `unified`/`remark`/`rehype` pipeline. Comark uses its own lighter plugin interface.
 
-#### Syntax Highlighting
+#### Syntax highlighting
 
 ::code-group
 ```typescript [Before]
@@ -262,7 +260,7 @@ const parse = createMarkdownParser({
 ```
 ::
 
-#### Table of Contents
+#### Table of contents
 
 ::code-group
 ```typescript [Before]
@@ -279,7 +277,7 @@ const tableOfContents = document.meta.toc
 ```
 ::
 
-#### Excerpt / Summary
+#### Excerpt / summary
 
 ::code-group
 ```typescript [Before]
@@ -310,7 +308,7 @@ const document = await parseMarkdown(md, { plugins: [emoji()] })
 ```
 ::
 
-### Parse Options
+### Parse options
 
 ::code-group
 ```typescript [Before]
@@ -362,7 +360,7 @@ export default defineNuxtConfig({
 
 `@comark/nuxt` auto-imports `Markdown`, `MarkdownDocument`, `defineMarkdownComponent`, and `defineMarkdownDocumentComponent`. Plugin and component configuration moves out of `nuxt.config.ts` and into dedicated component definitions.
 
-### Renderer Component
+### Renderer component
 
 ::code-group
 ```vue [Before]
@@ -484,7 +482,7 @@ const { data: document } = await useFetch(`/api/article/${slug}`)
 </template>
 ```
 
-### Slots in Custom Components
+### Slots in custom components
 
 MDC required a special `<MDCSlot>` component inside your custom Vue components to render children. Comark uses the native Vue `<slot>` element instead.
 
@@ -566,7 +564,7 @@ In Vue, render only the summary with the `summary` prop:
 ```
 ::
 
-### Prose Components
+### Prose components
 
 Both MDC and Comark support dropping custom Vue components into `components/prose/` to override how standard HTML elements render. The Nuxt module auto-registers them globally.
 
@@ -612,7 +610,7 @@ A critical warning.
 
 These are equivalent to `::callout` with the matching `color` and default icon. They are **only available with [Nuxt UI](https://ui.nuxt.com)**. Without it, continue using `::callout{...}` directly.
 
-## Component Syntax
+## Component syntax
 
 The MDC block and inline component syntax is identical. No changes needed in your markdown files.
 
@@ -635,11 +633,11 @@ Body content.
 See the Component Syntax reference for blocks, inline elements, props, slots, and nesting.
 ::
 
-## Unsupported Features
+## Unsupported features
 
 Comark does not currently support the following MDC features:
 
-### Binding Syntax
+### Binding syntax
 
 MDC's binding syntax (`{{ variable }}`) for interpolating data inside markdown content is not supported in Comark. This means you cannot reference variables or expressions inline within your markdown text.
 
@@ -651,7 +649,7 @@ Hello {{ user.name }}, you have {{ count }} messages.
 <!-- The {{ }} syntax will be rendered as plain text -->
 ```
 
-### Props Binding and Data Passing
+### Props binding and data passing
 
 Because Comark does not support binding syntax, dynamic props binding and data passing from a parent context into markdown content are also not supported. In MDC, you could pass data to the markdown parser and reference it inside the document. This pattern has no equivalent in Comark.
 
@@ -663,10 +661,10 @@ const result = await parseMarkdown(md, { data: { user, count } })
 ```
 
 ::warning
-These features may be added in a future release. If your project relies on binding syntax or data passing, please [create a feature request](https://github.com/comarkdown/comark/issues) on GitHub so we can prioritize accordingly.
+These features may be added in a future release. If your project relies on binding syntax or data passing, [create a feature request](https://github.com/comarkdown/comark/issues) on GitHub so we can prioritize accordingly.
 ::
 
-## Quick Reference
+## Quick reference
 
 | Task | MDC | Comark |
 |------|-----|--------|

--- a/docs/content/7.kb/3.migration-from-mdx.md
+++ b/docs/content/7.kb/3.migration-from-mdx.md
@@ -20,7 +20,7 @@ If you're coming from MDX, this guide maps every MDX concept to its Comark equiv
 
 ---
 
-## Quick Comparison
+## Quick comparison
 
 | Concept | MDX | Comark |
 |---------|-----|--------|
@@ -37,7 +37,7 @@ If you're coming from MDX, this guide maps every MDX concept to its Comark equiv
 
 ## Components
 
-### Block Components
+### Block components
 
 MDX uses JSX tags. Comark uses `::` fences:
 
@@ -55,7 +55,7 @@ This is an important message with **bold** text.
 ```
 ::
 
-### Inline Components
+### Inline components
 
 ::code-group
 ```js [MDX]
@@ -67,7 +67,7 @@ Status: :badge[Active]{color="green"}
 ```
 ::
 
-### Self-Closing Components
+### Self-closing components
 
 ::code-group
 ```js [MDX]
@@ -84,7 +84,7 @@ Status: :badge[Active]{color="green"}
 ```
 ::
 
-### Nested Components
+### Nested components
 
 ::code-group
 ```js [MDX]
@@ -110,9 +110,9 @@ Nesting in Comark uses increasing colons: `::` for outer, `:::` for inner, `::::
 
 ---
 
-## Props & Attributes
+## Props & attributes
 
-### Static Props
+### Static props
 
 ::code-group
 ```js [MDX]
@@ -128,7 +128,7 @@ Content
 ```
 ::
 
-### Dynamic / Expression Binding
+### Dynamic / expression binding
 
 MDX uses JSX curly-brace expressions. Comark uses `:prop="value"` binding syntax:
 
@@ -145,7 +145,7 @@ MDX uses JSX curly-brace expressions. Comark uses `:prop="value"` binding syntax
 
 The `:` prefix marks a prop as a dynamic binding: the value is treated as an expression rather than a literal string.
 
-### Numeric & Boolean Props
+### Numeric & boolean props
 
 ::code-group
 ```js [MDX]
@@ -162,7 +162,7 @@ Boolean props without a value default to `true` in both formats.
 
 ---
 
-## Imports & Component Registration
+## Imports & component registration
 
 MDX imports components per-file. In Comark, components are registered once in the renderer:
 
@@ -240,7 +240,7 @@ export const DocsMarkdown = defineMarkdownComponent({
 
 ---
 
-## Exports & State
+## Exports & state
 
 MDX uses `export` statements to define page-level variables:
 
@@ -277,7 +277,7 @@ const markdown = computed(() => `# Report for ${year.value}`)
 
 ---
 
-## Expressions in Text
+## Expressions in text
 
 MDX allows JavaScript expressions anywhere in text:
 
@@ -326,7 +326,7 @@ In Comark, wrap the renderer with your layout component:
 
 ---
 
-## Markdown Features
+## Markdown features
 
 Standard markdown works identically in both formats. No changes needed for:
 
@@ -340,7 +340,7 @@ Standard markdown works identically in both formats. No changes needed for:
 
 ---
 
-## Migration Checklist
+## Migration checklist
 
 1. **Replace JSX tags** with Comark `::component` / `:component` syntax
 2. **Move imports** from per-file `import` statements to renderer `components` option

--- a/docs/content/7.kb/4.twoslash.md
+++ b/docs/content/7.kb/4.twoslash.md
@@ -161,7 +161,7 @@ Add annotations directly in your code block. They are compiled and stripped from
 | `// ---cut-after---` | Any line | Everything below is compiled but hidden from output |
 | `// @filename: foo.ts` | Top of block | Treat block as a named virtual file (for multi-file examples) |
 
-### Type Hover · `^?`
+### Type hover · `^?`
 
 Point an arrow at any identifier to show its inferred type in a popup:
 
@@ -172,7 +172,7 @@ const message = "Hello from Twoslash"
 ```
 ````
 
-### Error Annotations · `@errors`
+### Error annotations · `@errors`
 
 Document intentional type errors, great for teaching correct API usage:
 
@@ -183,7 +183,7 @@ let count: number = "not a number"
 ```
 ````
 
-### Hide Setup · `// ---cut---`
+### Hide setup · `// ---cut---`
 
 Code above the cut compiles but is hidden from readers, useful for imports and shared types:
 
@@ -227,7 +227,7 @@ pre .twoslash-hover pre {
 pre .twoslash-hover pre .line { display: inline; }
 ```
 
-## Live Example
+## Live example
 
 ::card{icon="i-simple-icons-typescript" title="Vue + Vite Twoslash" to="https://github.com/comarkjs/comark/tree/main/examples/3.plugins/vue-vite-twoslash"}
 Browser-side Twoslash with CDN-fetched TypeScript types, dark mode toggle, and interactive type popups. Ready to run with `pnpm dev`.

--- a/docs/content/7.kb/5.custom-code-block.md
+++ b/docs/content/7.kb/5.custom-code-block.md
@@ -1,5 +1,5 @@
 ---
-title:  Custom Code Block
+title: Custom code block
 description: How to build copy buttons, collapse thresholds, and other code-block UI when Comark does not pass a raw `code` prop.
 seo:
   title: 'How to customize code block rendering'

--- a/docs/content/8.examples/2.vite/angular.md
+++ b/docs/content/8.examples/2.vite/angular.md
@@ -14,4 +14,4 @@ defaultValue: src/main.ts
 ---
 ::
 
-This example demonstrates the simplest way to use Comark with Angular - use the `Markdown` component and pass it markdown content via the `value` prop. The component handles parsing and rendering automatically.
+This example shows the quickest way to use Comark with Angular - use the `Markdown` component and pass it markdown content via the `value` prop. The component handles parsing and rendering automatically.

--- a/docs/content/8.examples/2.vite/html.md
+++ b/docs/content/8.examples/2.vite/html.md
@@ -1,5 +1,5 @@
 ---
-title: HTML Preview
+title: HTML preview
 description: A live markdown editor that renders Comark content to HTML and displays it in a sandboxed iframe preview, with syntax highlighting support.
 navigation:
   icon:  i-lucide-file-code

--- a/docs/content/8.examples/2.vite/react.md
+++ b/docs/content/8.examples/2.vite/react.md
@@ -14,4 +14,4 @@ defaultValue: src/App.tsx
 ---
 ::
 
-This example demonstrates the simplest way to use Comark with React - use the `Markdown` component and pass it markdown content. The component handles parsing and rendering automatically.
+This example shows the quickest way to use Comark with React - use the `Markdown` component and pass it markdown content. The component handles parsing and rendering automatically.

--- a/docs/content/8.examples/2.vite/svelte.md
+++ b/docs/content/8.examples/2.vite/svelte.md
@@ -17,4 +17,4 @@ defaultValue: src/App.svelte
 ::Browser{src="https://comark-svelte.vercel.app"}
 ::
 
-This example demonstrates the simplest way to use Comark with Svelte - use the `Markdown` component and pass it markdown content. The component handles parsing and rendering automatically using Svelte 5's `$state` and `$effect` runes.
+This example shows the quickest way to use Comark with Svelte - use the `Markdown` component and pass it markdown content. The component handles parsing and rendering automatically using Svelte 5's `$state` and `$effect` runes.

--- a/docs/content/8.examples/2.vite/vue.md
+++ b/docs/content/8.examples/2.vite/vue.md
@@ -17,4 +17,4 @@ defaultValue: content/posts/comark-syntax.md
 ::Browser{src="https://comark-vue.vercel.app/#/blog/comark-syntax"}
 ::
 
-This example demonstrates the simplest way to use Comark with Vue - use the `Markdown` component and pass it markdown content. The component handles parsing and rendering automatically.
+This example shows the quickest way to use Comark with Vue - use the `Markdown` component and pass it markdown content. The component handles parsing and rendering automatically.

--- a/docs/content/8.examples/3.plugins/react-vite-math.md
+++ b/docs/content/8.examples/3.plugins/react-vite-math.md
@@ -56,7 +56,7 @@ This example demonstrates how to use Comark with LaTeX math formulas in React:
    $$
    ```
 
-## Syntax Examples
+## Syntax examples
 
 **Inline Math**: Use single `$` delimiters
 ```markdown
@@ -85,7 +85,7 @@ $\alpha + \beta = \gamma$
 $x_1^2 + x_2^2$
 ```
 
-## Learn More
+## Learn more
 
 - [Math Plugin Documentation](/plugins/built-in/math)
 - [KaTeX Documentation](https://katex.org)

--- a/docs/content/8.examples/3.plugins/react-vite-mermaid.md
+++ b/docs/content/8.examples/3.plugins/react-vite-mermaid.md
@@ -53,7 +53,7 @@ This example demonstrates how to use Comark with Mermaid diagrams in React:
    ```
    ````
 
-## Theme Support
+## Theme support
 
 Pass a theme via the code block info string:
 
@@ -66,7 +66,7 @@ sequenceDiagram
 ```
 ````
 
-## Learn More
+## Learn more
 
 - [Mermaid Plugin Documentation](/plugins/built-in/mermaid)
 - [Mermaid Documentation](https://mermaid.js.org)

--- a/docs/content/8.examples/3.plugins/vue-vite-highlight.md
+++ b/docs/content/8.examples/3.plugins/vue-vite-highlight.md
@@ -1,5 +1,5 @@
 ---
-title: Syntax Highlighting
+title: Syntax highlighting
 description: Example showing how to use Comark with syntax highlighting using Shiki in Vue and Vite.
 navigation:
   icon:  i-lucide-code
@@ -27,13 +27,13 @@ This example demonstrates how to use Comark with syntax highlighting in Vue:
 
 ## Usage
 
-### 1. Install Dependencies
+### 1. Install dependencies
 
 ```bash
 npm install shiki @shikijs/themes @shikijs/langs
 ```
 
-### 2. Import Themes and Languages
+### 2. Import themes and languages
 
 Import directly from `@shikijs/themes` and `@shikijs/langs`:
 
@@ -46,7 +46,7 @@ import typescript from '@shikijs/langs/typescript'
 import python from '@shikijs/langs/python'
 ```
 
-### 3. Configure the Plugin
+### 3. Configure the plugin
 
 Pass the imported themes and languages to the plugin:
 
@@ -70,7 +70,7 @@ Pass the imported themes and languages to the plugin:
 </template>
 ```
 
-### 4. Use Code Blocks in Markdown
+### 4. Use code blocks in Markdown
 
 ````markdown
 ```javascript
@@ -86,14 +86,14 @@ print("Hello, Python!")
 ```
 ````
 
-## Why Import Directly?
+## Why import directly?
 
 - ✅ **Type Safety**: TypeScript autocomplete for themes and languages
 - ✅ **Tree Shaking**: Only bundle the themes/languages you use
 - ✅ **No Typos**: Import errors caught at build time
 - ✅ **Smaller Bundle**: Import only what you need
 
-## Configuration Options
+## Configuration options
 
 ```typescript
 import type { BundledLanguage, BundledTheme } from 'shiki'
@@ -110,7 +110,7 @@ interface HighlightOptions {
 }
 ```
 
-## Available Themes
+## Available themes
 
 Import themes from `@shikijs/themes`:
 
@@ -127,7 +127,7 @@ import monokai from '@shikijs/themes/monokai'
 
 [View all available themes →](https://shiki.style/themes)
 
-## Available Languages
+## Available languages
 
 Import languages from `@shikijs/langs`:
 
@@ -153,7 +153,7 @@ import bash from '@shikijs/langs/bash'
 
 [View all 180+ languages →](https://shiki.style/languages)
 
-## Learn More
+## Learn more
 
 - [Highlight Plugin Documentation](https://comark.dev/plugins/built-in/syntax-highlight)
 - [Shiki Documentation](https://shiki.style/)

--- a/docs/content/8.examples/3.plugins/vue-vite-json-render.md
+++ b/docs/content/8.examples/3.plugins/vue-vite-json-render.md
@@ -58,7 +58,7 @@ This example demonstrates how to use Comark with JSON Render and YAML Render in 
    ```
    ````
 
-## Learn More
+## Learn more
 
 - [JSON Render Plugin Documentation](/plugins/built-in/json-render)
 - [JSON Render](https://json-render.dev/)

--- a/docs/content/8.examples/3.plugins/vue-vite-math.md
+++ b/docs/content/8.examples/3.plugins/vue-vite-math.md
@@ -46,7 +46,7 @@ This example demonstrates how to use Comark with LaTeX math formulas in Vue:
    $$
    ```
 
-## Syntax Examples
+## Syntax examples
 
 **Inline Math**: Use single `$` delimiters
 ```markdown

--- a/docs/content/8.examples/3.plugins/vue-vite-punctuation.md
+++ b/docs/content/8.examples/3.plugins/vue-vite-punctuation.md
@@ -38,7 +38,7 @@ import punctuation from '@comark/vue/plugins/punctuation'
 </template>
 ```
 
-## Learn More
+## Learn more
 
 - [Punctuation Plugin Documentation](/plugins/built-in/punctuation)
 - [Comark Documentation](https://comark.dev)

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,9 +1,9 @@
 ---
 navigation: false
-title: Parse and Render Markdown Anywhere with Comark
+title: Parse and render Markdown anywhere with Comark
 description: 'A JavaScript library to parse and stream Markdown, with renderers for HTML, ANSI, Vue, React, Svelte and Angular, plus components, attributes, and plugins.'
 seo:
-  title: Parse and Render Markdown Anywhere with Comark
+  title: Parse and render Markdown anywhere with Comark
   description: 'Parse and render Markdown anywhere with one JavaScript library for HTML, ANSI, Vue, React, Svelte and Angular, plus plugins and streaming.'
   ogImage: /social-card.jpg
 ---

--- a/docs/skills/comark/SKILL.md
+++ b/docs/skills/comark/SKILL.md
@@ -205,7 +205,7 @@ Comprehensive guide for rendering in Angular 17+ applications:
 
 - **Basic Usage:** `Markdown` standalone component setup
 - **Custom Components:** mapping Angular components to Comark elements
-- **Component Resolution:** `Prose{PascalTag}`, `tag`, `PascalTag` priority order
+- **Component Resolution:** `Prose{PascalTag}`, `PascalTag`, `tag` priority order
 - **Content Projection:** named slots via `<ng-content select="[slot=name]">` 
 - **Streaming Mode:** real-time rendering with caret indicator
 - **Data Binding:** `:binding` resolution with ambient `data` input

--- a/docs/skills/comark/references/rendering-angular.md
+++ b/docs/skills/comark/references/rendering-angular.md
@@ -109,8 +109,8 @@ export class AppComponent {
 
 Components are resolved by checking these keys in order:
 1. `Prose{PascalTag}`, e.g., `ProseH1` for `<h1>` tags
-2. `tag`, e.g., `alert` for `::alert` components
-3. `PascalTag`, e.g., `Alert` for `::alert` components
+2. `PascalTag`, e.g., `Alert` for `::alert` components
+3. `tag`, e.g., `alert` for `::alert` components
 
 ### Custom Component Example
 
@@ -504,7 +504,6 @@ import math, { Math } from '@comark/angular/plugins/math'
 import mermaid, { Mermaid } from '@comark/angular/plugins/mermaid'
 
 export const DocsMarkdown = defineMarkdownComponent({
-  name: 'docs-markdown',
   plugins: [math(), mermaid()],
   components: { Math, Mermaid },
   class: 'prose dark:prose-invert',
@@ -539,7 +538,6 @@ import { defineMarkdownDocumentComponent } from '@comark/angular'
 import { Math } from '@comark/angular/plugins/math'
 
 export const DocsMarkdownDocument = defineMarkdownDocumentComponent({
-  name: 'docs-markdown-document',
   components: { Math },
 })
 ```

--- a/packages/comark-angular/src/components/markdown-node.component.ts
+++ b/packages/comark-angular/src/components/markdown-node.component.ts
@@ -54,7 +54,7 @@ function getChildren(node: MarkdownAstNode): MarkdownAstNode[] {
 function resolveComponent(tag: string, components: Record<string, Type<any>>): Type<any> | undefined {
   const pascalTag = pascalCase(tag)
   const proseTag = `Prose${pascalTag}`
-  return components[proseTag] || components[pascalTag] || components[tag]
+  return components[proseTag] || components[tag] || components[pascalTag]
 }
 
 /** Void (self-closing) HTML elements that must not have children. */

--- a/packages/comark-angular/src/components/markdown-node.component.ts
+++ b/packages/comark-angular/src/components/markdown-node.component.ts
@@ -54,7 +54,7 @@ function getChildren(node: MarkdownAstNode): MarkdownAstNode[] {
 function resolveComponent(tag: string, components: Record<string, Type<any>>): Type<any> | undefined {
   const pascalTag = pascalCase(tag)
   const proseTag = `Prose${pascalTag}`
-  return components[proseTag] || components[tag] || components[pascalTag]
+  return components[proseTag] || components[pascalTag] || components[tag]
 }
 
 /** Void (self-closing) HTML elements that must not have children. */

--- a/packages/comark-angular/src/define.ts
+++ b/packages/comark-angular/src/define.ts
@@ -4,7 +4,7 @@ import { Markdown } from './components/markdown.component.ts'
 import { MarkdownDocument } from './components/markdown-document.component.ts'
 
 export interface DefineMarkdownComponentOptions extends ParserOptions {
-  /** Display name for debugging (used as Angular selector). */
+  /** Display name for debugging. The Angular selector is always `comark-markdown-defined`. */
   name?: string
   /** Pre-configured component mappings. */
   components?: Record<string, Type<any>>
@@ -13,7 +13,7 @@ export interface DefineMarkdownComponentOptions extends ParserOptions {
 }
 
 export interface DefineMarkdownDocumentOptions {
-  /** Display name for debugging (used as Angular selector). */
+  /** Display name for debugging. The Angular selector is always `comark-markdown-document-defined`. */
   name?: string
   /** Pre-configured component mappings. */
   components?: Record<string, Type<any>>

--- a/packages/comark-angular/src/define.ts
+++ b/packages/comark-angular/src/define.ts
@@ -4,7 +4,7 @@ import { Markdown } from './components/markdown.component.ts'
 import { MarkdownDocument } from './components/markdown-document.component.ts'
 
 export interface DefineMarkdownComponentOptions extends ParserOptions {
-  /** Display name for debugging. The Angular selector is always `comark-markdown-defined`. */
+  /** Display name for debugging (used as Angular selector). */
   name?: string
   /** Pre-configured component mappings. */
   components?: Record<string, Type<any>>
@@ -13,7 +13,7 @@ export interface DefineMarkdownComponentOptions extends ParserOptions {
 }
 
 export interface DefineMarkdownDocumentOptions {
-  /** Display name for debugging. The Angular selector is always `comark-markdown-document-defined`. */
+  /** Display name for debugging (used as Angular selector). */
   name?: string
   /** Pre-configured component mappings. */
   components?: Record<string, Type<any>>

--- a/packages/comark-angular/test/component-resolution.test.ts
+++ b/packages/comark-angular/test/component-resolution.test.ts
@@ -3,12 +3,12 @@ import { pascalCase } from 'comark/utils'
 
 /**
  * Tests the component resolution logic used by MarkdownNode.
- * The resolution order is: Prose{PascalTag} > PascalTag > tag
+ * The resolution order is: Prose{PascalTag} > tag > PascalTag
  */
 function resolveComponent(tag: string, components: Record<string, any>): any | undefined {
   const pascalTag = pascalCase(tag)
   const proseTag = `Prose${pascalTag}`
-  return components[proseTag] || components[pascalTag] || components[tag]
+  return components[proseTag] || components[tag] || components[pascalTag]
 }
 
 describe('component resolution', () => {
@@ -63,13 +63,5 @@ describe('component resolution', () => {
       ProseAlert: 'ProseAlertComponent',
     }
     expect(resolveComponent('alert', components)).toBe('ProseAlertComponent')
-  })
-
-  it('prefers PascalCase over exact tag', () => {
-    const components = {
-      alert: 'ExactAlert',
-      Alert: 'PascalAlert',
-    }
-    expect(resolveComponent('alert', components)).toBe('PascalAlert')
   })
 })

--- a/packages/comark-angular/test/component-resolution.test.ts
+++ b/packages/comark-angular/test/component-resolution.test.ts
@@ -3,12 +3,12 @@ import { pascalCase } from 'comark/utils'
 
 /**
  * Tests the component resolution logic used by MarkdownNode.
- * The resolution order is: Prose{PascalTag} > tag > PascalTag
+ * The resolution order is: Prose{PascalTag} > PascalTag > tag
  */
 function resolveComponent(tag: string, components: Record<string, any>): any | undefined {
   const pascalTag = pascalCase(tag)
   const proseTag = `Prose${pascalTag}`
-  return components[proseTag] || components[tag] || components[pascalTag]
+  return components[proseTag] || components[pascalTag] || components[tag]
 }
 
 describe('component resolution', () => {
@@ -63,5 +63,13 @@ describe('component resolution', () => {
       ProseAlert: 'ProseAlertComponent',
     }
     expect(resolveComponent('alert', components)).toBe('ProseAlertComponent')
+  })
+
+  it('prefers PascalCase over exact tag', () => {
+    const components = {
+      alert: 'ExactAlert',
+      Alert: 'PascalAlert',
+    }
+    expect(resolveComponent('alert', components)).toBe('PascalAlert')
   })
 })

--- a/packages/comark-react/src/components/MarkdownDocument.tsx
+++ b/packages/comark-react/src/components/MarkdownDocument.tsx
@@ -76,7 +76,7 @@ function resolveComponent(tag: string, components: Record<string, any>, componen
   const pascalTag = pascalCase(tag)
   const proseTag = `Prose${pascalTag}`
 
-  let resolvedComponent = components[proseTag] || components[tag] || components[pascalTag]
+  let resolvedComponent = components[proseTag] || components[pascalTag] || components[tag]
 
   // If not in components map and manifest is provided, try dynamic resolution
   if (!resolvedComponent && componentsManifest) {

--- a/packages/comark-react/src/components/MarkdownDocument.tsx
+++ b/packages/comark-react/src/components/MarkdownDocument.tsx
@@ -76,7 +76,7 @@ function resolveComponent(tag: string, components: Record<string, any>, componen
   const pascalTag = pascalCase(tag)
   const proseTag = `Prose${pascalTag}`
 
-  let resolvedComponent = components[proseTag] || components[pascalTag] || components[tag]
+  let resolvedComponent = components[proseTag] || components[tag] || components[pascalTag]
 
   // If not in components map and manifest is provided, try dynamic resolution
   if (!resolvedComponent && componentsManifest) {

--- a/packages/comark-vue/src/components/MarkdownDocument.ts
+++ b/packages/comark-vue/src/components/MarkdownDocument.ts
@@ -75,8 +75,8 @@ function resolveComponent(
 
   let resolvedComponent =
     components[proseTag] ||
-    components[pascalTag] ||
     components[tag] ||
+    components[pascalTag] ||
     // If the component is not found in the components map, try to find it in the app context
     appComponents?.[proseTag] ||
     appComponents?.[pascalTag]

--- a/packages/comark-vue/src/components/MarkdownDocument.ts
+++ b/packages/comark-vue/src/components/MarkdownDocument.ts
@@ -75,8 +75,8 @@ function resolveComponent(
 
   let resolvedComponent =
     components[proseTag] ||
-    components[tag] ||
     components[pascalTag] ||
+    components[tag] ||
     // If the component is not found in the components map, try to find it in the app context
     appComponents?.[proseTag] ||
     appComponents?.[pascalTag]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,7 +418,7 @@ importers:
         version: link:../packages/comark
       comark-docs:
         specifier: github:comarkdown/comark-docs
-        version: https://codeload.github.com/comarkdown/comark-docs/tar.gz/afa7835620294a86ea2306384e58f63f3b6e418c(220f0ddf9cfd1e20158dd99d2aafec35)
+        version: https://codeload.github.com/comarkdown/comark-docs/tar.gz/2a710ca66923c248dbe401efba9909b4a8f8d101(220f0ddf9cfd1e20158dd99d2aafec35)
       katex:
         specifier: 'catalog:'
         version: 0.17.0
@@ -535,7 +535,7 @@ importers:
         version: link:../../../packages/comark-vue
       '@nuxt/ui':
         specifier: 'catalog:'
-        version: 4.10.0(b32e725db26535815163fe2768164e39)
+        version: 4.10.0(53ce81e6578ea1bced237539c68be375)
       nuxt:
         specifier: 'catalog:'
         version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@26.2.0)(@vercel/functions@3.9.3(ws@8.21.0))(@vue/compiler-sfc@3.5.41)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@13.2.0)(optionator@0.9.4)(oxlint@1.73.0)(rolldown@1.1.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2))(rollup@4.62.2)(sass@1.99.0)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
@@ -782,7 +782,7 @@ importers:
         version: link:../../../packages/comark-vue
       '@nuxt/ui':
         specifier: 'catalog:'
-        version: 4.10.0(b32e725db26535815163fe2768164e39)
+        version: 4.10.0(40b3500c669933c3fdb26f3afc4bcd7b)
       '@shikijs/langs':
         specifier: 'catalog:'
         version: 4.3.1
@@ -1007,7 +1007,7 @@ importers:
         version: link:../../../packages/comark-vue
       '@nuxt/ui':
         specifier: 'catalog:'
-        version: 4.10.0(b32e725db26535815163fe2768164e39)
+        version: 4.10.0(40b3500c669933c3fdb26f3afc4bcd7b)
       '@shikijs/themes':
         specifier: 'catalog:'
         version: 4.3.1
@@ -1159,7 +1159,7 @@ importers:
         version: link:../../../packages/comark-vue
       '@nuxt/ui':
         specifier: 'catalog:'
-        version: 4.10.0(b32e725db26535815163fe2768164e39)
+        version: 4.10.0(40b3500c669933c3fdb26f3afc4bcd7b)
       '@shikijs/langs':
         specifier: 'catalog:'
         version: 4.3.1
@@ -1211,7 +1211,7 @@ importers:
         version: link:../../../packages/comark-nuxt
       '@nuxt/ui':
         specifier: 'catalog:'
-        version: 4.10.0(cfab86304c8c93a677e1649ab0784bdf)
+        version: 4.10.0(5fbd3d308cd3ff2e3c1cc1f17d8e607e)
       ai:
         specifier: 'catalog:'
         version: 7.0.22(zod@4.4.3)
@@ -7169,8 +7169,8 @@ packages:
     version: 0.3.0
     hasBin: true
 
-  comark-docs@https://codeload.github.com/comarkdown/comark-docs/tar.gz/afa7835620294a86ea2306384e58f63f3b6e418c:
-    resolution: {gitHosted: true, integrity: sha512-L7hUhipigJqYfVIukJjHfndY1HU/gcNIyHoDsoslFtaeD7hbvpG1TjJrD641uq4sjwusPC9yu/uo8ZdnXXtdhw==, tarball: https://codeload.github.com/comarkdown/comark-docs/tar.gz/afa7835620294a86ea2306384e58f63f3b6e418c}
+  comark-docs@https://codeload.github.com/comarkdown/comark-docs/tar.gz/2a710ca66923c248dbe401efba9909b4a8f8d101:
+    resolution: {gitHosted: true, integrity: sha512-QWoHBwCvDR3epyjtjKfmQYYcWmtDXz+6sTC8tlSmMtKume9eKpZffZENWKCRPSQ4b3TY1f5Bp3aeQU/cklDNJQ==, tarball: https://codeload.github.com/comarkdown/comark-docs/tar.gz/2a710ca66923c248dbe401efba9909b4a8f8d101}
     version: 0.0.1
     peerDependencies:
       nuxt: ^4.5.0
@@ -13793,6 +13793,78 @@ snapshots:
       - magicast
       - supports-color
 
+  '@nuxt/content@3.15.0(better-sqlite3@12.10.0)(esbuild@0.28.1)(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(rollup@4.62.2)(supports-color@10.2.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxtjs/mdc': 0.22.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@shikijs/langs': 4.3.1
+      '@sqlite.org/sqlite-wasm': 3.50.4-build1
+      '@standard-schema/spec': 1.1.0
+      '@webcontainer/env': 1.1.1
+      c12: 3.3.4(magicast@0.5.4)
+      chokidar: 5.0.0
+      consola: 3.4.2
+      db0: 0.3.4(better-sqlite3@12.10.0)
+      defu: 6.1.7
+      destr: 2.0.5
+      git-url-parse: 16.1.0
+      h3: 1.15.11
+      hookable: 5.5.3
+      isomorphic-git: 1.38.7
+      jiti: 2.7.0
+      json-schema-to-typescript-lite: 15.0.0
+      mdast-util-to-hast: 13.2.1
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2(supports-color@10.2.2)
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromatch: 4.0.8
+      minimark: 0.2.0(patch_hash=1e0eaaab5c9ffee4dcf68d6e89d35546917e9c8033757789e7675f1a2ea323a9)
+      minimatch: 10.2.5
+      nuxt-component-meta: 0.17.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      nypm: 0.6.9
+      ohash: 2.0.12
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      remark-mdc: 3.11.1(supports-color@10.2.2)
+      scule: 1.3.0
+      shiki: 4.3.1
+      slugify: 1.6.9
+      socket.io-client: 4.8.3(supports-color@10.2.2)
+      std-env: 4.2.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      unctx: 2.5.0
+      unified: 11.0.5
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      better-sqlite3: 12.10.0
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bufferutil
+      - bun-types-no-globals
+      - drizzle-orm
+      - esbuild
+      - magic-string
+      - magicast
+      - mysql2
+      - oxc-parser
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+      - utf-8-validate
+      - vite
+      - webpack
+    optional: true
+
   '@nuxt/content@3.15.0(better-sqlite3@12.10.0)(esbuild@0.28.1)(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.133.0)(rolldown@1.1.5)(rollup@4.62.2)(supports-color@10.2.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.133.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -13865,10 +13937,10 @@ snapshots:
       - webpack
     optional: true
 
-  '@nuxt/content@3.15.0(better-sqlite3@12.10.0)(esbuild@0.28.1)(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(rollup@4.62.2)(supports-color@10.2.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@nuxt/content@3.15.0(better-sqlite3@12.10.0)(esbuild@0.28.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(rollup@4.62.2)(supports-color@10.2.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
-      '@nuxtjs/mdc': 0.22.1(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxtjs/mdc': 0.22.1(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@shikijs/langs': 4.3.1
       '@sqlite.org/sqlite-wasm': 3.50.4-build1
       '@standard-schema/spec': 1.1.0
@@ -13895,7 +13967,7 @@ snapshots:
       micromatch: 4.0.8
       minimark: 0.2.0(patch_hash=1e0eaaab5c9ffee4dcf68d6e89d35546917e9c8033757789e7675f1a2ea323a9)
       minimatch: 10.2.5
-      nuxt-component-meta: 0.17.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      nuxt-component-meta: 0.17.2(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
       nypm: 0.6.9
       ohash: 2.0.12
       pathe: 2.0.3
@@ -14706,6 +14778,126 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
+  '@nuxt/ui@4.10.0(40b3500c669933c3fdb26f3afc4bcd7b)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@iconify/vue': 5.0.1(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/fonts': 0.14.0(@vercel/functions@3.9.3(ws@8.21.0))(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.1)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@nuxt/icon': 2.3.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/kit': 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@nuxt/schema': 4.4.8
+      '@nuxtjs/color-mode': 4.0.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@standard-schema/spec': 1.1.0
+      '@tailwindcss/postcss': 4.3.2
+      '@tailwindcss/vite': 4.3.2(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@tanstack/vue-table': 8.21.3(vue@3.5.41(typescript@5.9.3))
+      '@tanstack/vue-virtual': 3.13.35(vue@3.5.41(typescript@5.9.3))
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/extension-bubble-menu': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-code': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-collaboration': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31)
+      '@tiptap/extension-drag-handle': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/extension-collaboration@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31))(@tiptap/extension-node-range@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))
+      '@tiptap/extension-drag-handle-vue-3': 3.24.0(@tiptap/extension-drag-handle@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/extension-collaboration@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31))(@tiptap/extension-node-range@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)))(@tiptap/pm@3.24.0)(@tiptap/vue-3@3.24.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(vue@3.5.41(typescript@5.9.3)))(vue@3.5.41(typescript@5.9.3))
+      '@tiptap/extension-floating-menu': 3.24.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-horizontal-rule': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-image': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-mention': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/suggestion@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/extension-node-range': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-placeholder': 3.24.0(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/markdown': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+      '@tiptap/starter-kit': 3.24.0
+      '@tiptap/suggestion': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/vue-3': 3.24.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(vue@3.5.41(typescript@5.9.3))
+      '@unhead/vue': 2.1.15(vue@3.5.41(typescript@5.9.3))
+      '@vueuse/core': 14.4.0(vue@3.5.41(typescript@5.9.3))
+      '@vueuse/integrations': 14.3.0(focus-trap@7.8.0)(fuse.js@7.5.0)(vue@3.5.41(typescript@5.9.3))
+      '@vueuse/shared': 14.4.0(vue@3.5.41(typescript@5.9.3))
+      colortranslator: 5.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      embla-carousel-auto-height: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-auto-scroll: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-vue: 8.6.0(vue@3.5.41(typescript@5.9.3))
+      embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
+      fuse.js: 7.5.0
+      hookable: 6.1.1
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      motion-v: 2.4.0(@vueuse/core@14.4.0(vue@3.5.41(typescript@5.9.3)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.41(typescript@5.9.3))
+      ohash: 2.0.12
+      pathe: 2.0.3
+      reka-ui: 2.10.1(vue@3.5.41(typescript@5.9.3))
+      scule: 1.3.0
+      tailwind-merge: 3.6.0
+      tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
+      tailwindcss: 4.3.3
+      tinyglobby: 0.2.17
+      typescript: 5.9.3
+      ufo: 1.6.4
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))))(@vueuse/core@14.4.0(vue@3.5.41(typescript@5.9.3)))
+      unplugin-vue-components: 32.1.0(@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      vaul-vue: 0.4.1(reka-ui@2.10.1(vue@3.5.41(typescript@5.9.3)))(vue@3.5.41(typescript@5.9.3))
+      vue-component-type-helpers: 3.3.7
+    optionalDependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@nuxt/content': 3.15.0(better-sqlite3@12.10.0)(esbuild@0.28.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(rollup@4.62.2)(supports-color@10.2.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      ai: 7.0.66(zod@4.4.3)
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@farmfe/core'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vue/composition-api'
+      - async-validator
+      - aws4fetch
+      - axios
+      - bun-types-no-globals
+      - change-case
+      - db0
+      - drauu
+      - embla-carousel
+      - esbuild
+      - focus-trap
+      - idb-keyval
+      - ioredis
+      - jwt-decode
+      - magicast
+      - nprogress
+      - oxc-parser
+      - qrcode
+      - react
+      - react-dom
+      - rolldown
+      - rollup
+      - sortablejs
+      - universal-cookie
+      - unloader
+      - uploadthing
+      - vite
+      - vue
+      - webpack
+
   '@nuxt/ui@4.10.0(4cef3a8264a4c6873b1ae0e59f34124b)':
     dependencies:
       '@floating-ui/dom': 1.8.0
@@ -14825,7 +15017,7 @@ snapshots:
       - vue
       - webpack
 
-  '@nuxt/ui@4.10.0(b32e725db26535815163fe2768164e39)':
+  '@nuxt/ui@4.10.0(53ce81e6578ea1bced237539c68be375)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@iconify/vue': 5.0.1(vue@3.5.41(typescript@5.9.3))
@@ -14894,7 +15086,7 @@ snapshots:
     optionalDependencies:
       '@internationalized/date': 3.12.2
       '@internationalized/number': 3.6.7
-      '@nuxt/content': 3.15.0(better-sqlite3@12.10.0)(esbuild@0.28.1)(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(rollup@4.62.2)(supports-color@10.2.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@nuxt/content': 3.15.0(better-sqlite3@12.10.0)(esbuild@0.28.1)(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(rollup@4.62.2)(supports-color@10.2.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
       ai: 7.0.66(zod@4.4.3)
       vue-router: 5.1.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       zod: 4.4.3
@@ -14945,7 +15137,7 @@ snapshots:
       - vue
       - webpack
 
-  '@nuxt/ui@4.10.0(cfab86304c8c93a677e1649ab0784bdf)':
+  '@nuxt/ui@4.10.0(5fbd3d308cd3ff2e3c1cc1f17d8e607e)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@iconify/vue': 5.0.1(vue@3.5.41(typescript@5.9.3))
@@ -15014,7 +15206,7 @@ snapshots:
     optionalDependencies:
       '@internationalized/date': 3.12.2
       '@internationalized/number': 3.6.7
-      '@nuxt/content': 3.15.0(better-sqlite3@12.10.0)(esbuild@0.28.1)(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(rollup@4.62.2)(supports-color@10.2.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@nuxt/content': 3.15.0(better-sqlite3@12.10.0)(esbuild@0.28.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(rollup@4.62.2)(supports-color@10.2.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
       ai: 7.0.22(zod@4.4.3)
       vue-router: 5.1.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       zod: 4.4.3
@@ -15296,6 +15488,61 @@ snapshots:
       - supports-color
       - unplugin
 
+  '@nuxtjs/mdc@0.22.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@shikijs/core': 4.3.1
+      '@shikijs/engine-javascript': 4.3.1
+      '@shikijs/langs': 4.3.1
+      '@shikijs/themes': 4.3.1
+      '@shikijs/transformers': 4.3.1
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@vue/compiler-core': 3.5.41
+      consola: 3.4.2
+      debug: 4.4.3(supports-color@10.2.2)
+      defu: 6.1.7
+      destr: 2.0.5
+      detab: 3.0.2
+      github-slugger: 2.0.0
+      hast-util-format: 1.1.0
+      hast-util-to-mdast: 10.1.2
+      hast-util-to-string: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      micromark-util-sanitize-uri: 2.0.1
+      parse5: 8.0.1
+      pathe: 2.0.3
+      property-information: 7.2.0
+      rehype-external-links: 3.0.0
+      rehype-minify-whitespace: 6.0.2
+      rehype-raw: 7.0.0
+      rehype-remark: 10.0.1
+      rehype-slug: 6.0.0
+      rehype-sort-attribute-values: 5.0.1
+      rehype-sort-attributes: 5.0.1
+      remark-emoji: 5.0.2
+      remark-gfm: 4.0.1(supports-color@10.2.2)
+      remark-mdc: 3.11.1(supports-color@10.2.2)
+      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-rehype: 11.1.2
+      remark-stringify: 11.0.0
+      scule: 1.3.0
+      shiki: 4.3.1
+      ufo: 1.6.4
+      unified: 11.0.5
+      unist-builder: 4.0.0
+      unist-util-visit: 5.1.0
+      unwasm: 0.5.3
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - supports-color
+      - unplugin
+    optional: true
+
   '@nuxtjs/mdc@0.22.1(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.133.0)(rolldown@1.1.5)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.133.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -15351,7 +15598,7 @@ snapshots:
       - unplugin
     optional: true
 
-  '@nuxtjs/mdc@0.22.1(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))':
+  '@nuxtjs/mdc@0.22.1(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
       '@shikijs/core': 4.3.1
@@ -18361,7 +18608,7 @@ snapshots:
       - shiki
       - uploadthing
 
-  comark-docs@https://codeload.github.com/comarkdown/comark-docs/tar.gz/afa7835620294a86ea2306384e58f63f3b6e418c(220f0ddf9cfd1e20158dd99d2aafec35):
+  comark-docs@https://codeload.github.com/comarkdown/comark-docs/tar.gz/2a710ca66923c248dbe401efba9909b4a8f8d101(220f0ddf9cfd1e20158dd99d2aafec35):
     dependencies:
       '@ai-sdk/gateway': 4.0.52(zod@4.4.3)
       '@ai-sdk/vue': 4.0.66(vue@3.5.41(typescript@5.9.3))(zod@4.4.3)
@@ -21411,6 +21658,24 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nuxt-component-meta@0.17.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))):
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      citty: 0.1.6
+      mlly: 1.8.2
+      ohash: 2.0.12
+      scule: 1.3.0
+      typescript: 5.9.3
+      ufo: 1.6.4
+      vue-component-meta: 3.3.7(typescript@5.9.3)
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+    optional: true
+
   nuxt-component-meta@0.17.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.133.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))):
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.133.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -21429,7 +21694,7 @@ snapshots:
       - unplugin
     optional: true
 
-  nuxt-component-meta@0.17.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))):
+  nuxt-component-meta@0.17.2(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))):
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.1.5)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
       citty: 0.1.6

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -60,7 +60,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
 
     expect(report).toMatchInlineSnapshot(`
       {
-        "@comark/angular": "54.5k (70 files)",
+        "@comark/angular": "54.6k (70 files)",
         "@comark/ansi": "38.7k (98 files)",
         "@comark/html": "18.6k (58 files)",
         "@comark/nuxt": "11.8k (58 files)",


### PR DESCRIPTION
### What

Fixes docs claims that no longer match the code across ~60 pages: examples calling `parseMarkdown` instead of the created `parse` function, missing `await render(children)`, React `MarkdownLive` vs `MarkdownDocument`, Angular `defineMarkdownComponent` selectors, YAML vs inline attribute precedence, non-default `toc`/`emoji` plugins, plugin option tables, and `Toc`/`TocLink` type names. Also applies a style pass: sentence-case headings, no Latin abbreviations, merged stacked callouts, realistic example names, and one broken link.

### Why

A full docs review verified every page against the package sources; several examples produced wrong output (`[object Promise]`, wrong plugin assumptions) when run as written. The rendering docs describe the unified component resolution order (`Prose{PascalTag}` > `{PascalTag}` > `{tag}`) and omit the removed Angular `name` option, so merge #381 first. The remaining `pnpm-lock.yaml` and `test/bundle.test.ts` changes come from the comark-docs version bump on this branch. All 72 pages parse with Comark, internal links resolve, and `pnpm lint` passes.

---

*This PR was written by an AI agent (OpenCode), reviewed and submitted by @atinux.*