### PR TITLE
fix: unify component resolution order and drop unused Angular name option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,6 @@ import { defineMarkdownComponent } from '@comark/angular'
 import math, { Math } from '@comark/angular/plugins/math'
 
 export const DocsMarkdown = defineMarkdownComponent({
-  name: 'docs-markdown',
   plugins: [math()],
   components: { Math },
 })

--- a/packages/comark-angular/src/components/markdown-node.component.ts
+++ b/packages/comark-angular/src/components/markdown-node.component.ts
@@ -54,7 +54,7 @@ function getChildren(node: MarkdownAstNode): MarkdownAstNode[] {
 function resolveComponent(tag: string, components: Record<string, Type<any>>): Type<any> | undefined {
   const pascalTag = pascalCase(tag)
   const proseTag = `Prose${pascalTag}`
-  return components[proseTag] || components[tag] || components[pascalTag]
+  return components[proseTag] || components[pascalTag] || components[tag]
 }
 
 /** Void (self-closing) HTML elements that must not have children. */

--- a/packages/comark-angular/src/define.ts
+++ b/packages/comark-angular/src/define.ts
@@ -4,8 +4,6 @@ import { Markdown } from './components/markdown.component.ts'
 import { MarkdownDocument } from './components/markdown-document.component.ts'
 
 export interface DefineMarkdownComponentOptions extends ParserOptions {
-  /** Display name for debugging (used as Angular selector). */
-  name?: string
   /** Pre-configured component mappings. */
   components?: Record<string, Type<any>>
   /** Additional CSS class for the wrapper. */
@@ -13,8 +11,6 @@ export interface DefineMarkdownComponentOptions extends ParserOptions {
 }
 
 export interface DefineMarkdownDocumentOptions {
-  /** Display name for debugging (used as Angular selector). */
-  name?: string
   /** Pre-configured component mappings. */
   components?: Record<string, Type<any>>
   /** Additional CSS class for the wrapper. */
@@ -33,7 +29,6 @@ export interface DefineMarkdownDocumentOptions {
  * import math, { Math } from '@comark/angular/plugins/math'
  *
  * export const DocsMarkdown = defineMarkdownComponent({
- *   name: 'DocsMarkdown',
  *   plugins: [math()],
  *   components: { Math },
  *   class: 'prose dark:prose-invert',
@@ -105,7 +100,6 @@ export function defineMarkdownComponent(config: DefineMarkdownComponentOptions =
  * import { Math } from '@comark/angular/plugins/math'
  *
  * export const DocsRenderer = defineMarkdownDocumentComponent({
- *   name: 'DocsRenderer',
  *   components: { Math },
  * })
  * ```

--- a/packages/comark-angular/test/component-resolution.test.ts
+++ b/packages/comark-angular/test/component-resolution.test.ts
@@ -3,12 +3,12 @@ import { pascalCase } from 'comark/utils'
 
 /**
  * Tests the component resolution logic used by MarkdownNode.
- * The resolution order is: Prose{PascalTag} > tag > PascalTag
+ * The resolution order is: Prose{PascalTag} > PascalTag > tag
  */
 function resolveComponent(tag: string, components: Record<string, any>): any | undefined {
   const pascalTag = pascalCase(tag)
   const proseTag = `Prose${pascalTag}`
-  return components[proseTag] || components[tag] || components[pascalTag]
+  return components[proseTag] || components[pascalTag] || components[tag]
 }
 
 describe('component resolution', () => {
@@ -63,5 +63,13 @@ describe('component resolution', () => {
       ProseAlert: 'ProseAlertComponent',
     }
     expect(resolveComponent('alert', components)).toBe('ProseAlertComponent')
+  })
+
+  it('prefers PascalCase over exact tag', () => {
+    const components = {
+      alert: 'ExactAlert',
+      Alert: 'PascalAlert',
+    }
+    expect(resolveComponent('alert', components)).toBe('PascalAlert')
   })
 })

--- a/packages/comark-angular/test/define-component.test.ts
+++ b/packages/comark-angular/test/define-component.test.ts
@@ -3,7 +3,7 @@ import { defineMarkdownComponent, defineMarkdownDocumentComponent } from '../src
 
 describe('defineMarkdownComponent', () => {
   it('returns a component class', () => {
-    const Defined = defineMarkdownComponent({ name: 'test-comark' })
+    const Defined = defineMarkdownComponent({})
     expect(Defined).toBeDefined()
     expect(typeof Defined).toBe('function')
   })
@@ -17,7 +17,6 @@ describe('defineMarkdownComponent', () => {
   it('accepts plugins in config', () => {
     const fakePlugin = { name: 'test', setup: () => {} }
     const Defined = defineMarkdownComponent({
-      name: 'with-plugins',
       plugins: [fakePlugin as any],
     })
     expect(Defined).toBeDefined()
@@ -26,7 +25,6 @@ describe('defineMarkdownComponent', () => {
   it('accepts components in config', () => {
     class FakeComponent {}
     const Defined = defineMarkdownComponent({
-      name: 'with-components',
       components: { alert: FakeComponent as any },
     })
     expect(Defined).toBeDefined()
@@ -34,7 +32,6 @@ describe('defineMarkdownComponent', () => {
 
   it('accepts class in config', () => {
     const Defined = defineMarkdownComponent({
-      name: 'with-class',
       class: 'prose dark:prose-invert',
     })
     expect(Defined).toBeDefined()
@@ -42,7 +39,6 @@ describe('defineMarkdownComponent', () => {
 
   it('accepts parse options in config', () => {
     const Defined = defineMarkdownComponent({
-      name: 'with-options',
       autoClose: true,
       linkify: true,
     })
@@ -52,7 +48,7 @@ describe('defineMarkdownComponent', () => {
 
 describe('defineMarkdownDocumentComponent', () => {
   it('returns a component class', () => {
-    const Defined = defineMarkdownDocumentComponent({ name: 'test-renderer' })
+    const Defined = defineMarkdownDocumentComponent({})
     expect(Defined).toBeDefined()
     expect(typeof Defined).toBe('function')
   })
@@ -65,7 +61,6 @@ describe('defineMarkdownDocumentComponent', () => {
   it('accepts components in config', () => {
     class FakeComponent {}
     const Defined = defineMarkdownDocumentComponent({
-      name: 'renderer-with-components',
       components: { Math: FakeComponent as any },
     })
     expect(Defined).toBeDefined()
@@ -73,7 +68,6 @@ describe('defineMarkdownDocumentComponent', () => {
 
   it('accepts class in config', () => {
     const Defined = defineMarkdownDocumentComponent({
-      name: 'renderer-with-class',
       class: 'prose',
     })
     expect(Defined).toBeDefined()

--- a/packages/comark-react/src/components/MarkdownDocument.tsx
+++ b/packages/comark-react/src/components/MarkdownDocument.tsx
@@ -76,7 +76,7 @@ function resolveComponent(tag: string, components: Record<string, any>, componen
   const pascalTag = pascalCase(tag)
   const proseTag = `Prose${pascalTag}`
 
-  let resolvedComponent = components[proseTag] || components[tag] || components[pascalTag]
+  let resolvedComponent = components[proseTag] || components[pascalTag] || components[tag]
 
   // If not in components map and manifest is provided, try dynamic resolution
   if (!resolvedComponent && componentsManifest) {

--- a/packages/comark-vue/src/components/MarkdownDocument.ts
+++ b/packages/comark-vue/src/components/MarkdownDocument.ts
@@ -75,8 +75,8 @@ function resolveComponent(
 
   let resolvedComponent =
     components[proseTag] ||
-    components[tag] ||
     components[pascalTag] ||
+    components[tag] ||
     // If the component is not found in the components map, try to find it in the app context
     appComponents?.[proseTag] ||
     appComponents?.[pascalTag]

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -60,7 +60,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
 
     expect(report).toMatchInlineSnapshot(`
       {
-        "@comark/angular": "54.5k (70 files)",
+        "@comark/angular": "54.3k (70 files)",
         "@comark/ansi": "38.7k (98 files)",
         "@comark/html": "18.6k (58 files)",
         "@comark/nuxt": "11.8k (58 files)",


### PR DESCRIPTION
### What

Unifies the component resolution order across all renderers to `Prose{PascalTag}` > `{PascalTag}` > `{tag}`: Vue, React, and Angular previously resolved the exact tag before the PascalCase tag, while Svelte already used this order. Also removes the `name` option from the Angular `defineMarkdownComponent` / `defineMarkdownDocumentComponent` types, since the selectors are hard-coded (`comark-markdown-defined`, `comark-markdown-document-defined`) and `name` was never used.

### Why

A docs review against the sources surfaced the cross-framework inconsistency. The order was chosen deliberately:

1. `Prose{PascalTag}` first: lets you override any component, even when a component with the same name (without the Prose prefix) exists.
2. `{PascalTag}` second: PascalCase is the standard convention for component names.
3. `{tag}` last: the name as the user wrote it in the markdown.

Behavior only changes in Vue, React, and Angular for component maps that define both an exact tag and its PascalCase variant (PascalCase now wins). Split out of #380 so that PR stays docs-only; merge this one first since the docs there describe the unified order.

---

*This PR was written by an AI agent (OpenCode), reviewed and submitted by @atinux.*