### PR TITLE
docs: bump nuxt example code-explorer pin to current HEAD

### DIFF
--- a/docs/content/8.examples/1.frameworks/nuxt.md
+++ b/docs/content/8.examples/1.frameworks/nuxt.md
@@ -8,7 +8,7 @@ navigation:
 ::code-explorer
 ---
 org: comarkdown
-repo: comark@c78885ca7504b38afc7ced59aac1a3c6b3cc5425
+repo: comark@afa4b18a806217d4b6a09696377435e77b582870
 path: examples/1.frameworks/nuxt
 defaultValue: content/posts/comark-syntax.md
 ---


### PR DESCRIPTION
### What

Updates the `::code-explorer` component to point to HEAD so that the Nuxt framework example is accurate. Previously it was pointing to an old commit using deprecated APIs.

### Why

<!-- Why these changes are necessary -->

<!--

AGENTS:
- The What and Why should each be 1-3 sentences.
- Write your answers based off of your conversation with the user, not purely based on the changed code
  - It's helpful to understand the reasoning behind an approach, what alternatives were considered, and why this approach was ultimately selected, rather than a summary of the lines changed
- For complex changes (>1k lines, not counting lockfiles):
  - Add a `### Walkthrough` section to the end which breaks down the primary changes into easy-to-follow `#### Sub-Sections`
-->
