### PR TITLE
fix(comark): run default plugin hooks before user plugin hooks

### DIFF
--- a/docs/content/4.plugins/index.md
+++ b/docs/content/4.plugins/index.md
@@ -38,7 +38,9 @@ These plugins are **enabled by default** whenever you call `parseMarkdown()` or 
   ::
 ::
 
+::callout{icon="i-lucide-lightbulb"}
 Default plugins run in the order shown above. Plugins you pass through `plugins` run afterward in the order you provide them. If an explicit plugin has the same `name` as a default plugin, it replaces that default and runs in its explicit position. If you provide the same explicit plugin name more than once, only the first instance runs.
+::
 
 ### Disable default plugins
 

--- a/docs/content/4.plugins/index.md
+++ b/docs/content/4.plugins/index.md
@@ -38,6 +38,8 @@ These plugins are **enabled by default** whenever you call `parseMarkdown()` or 
   ::
 ::
 
+Default plugins run in the order shown above. Plugins you pass through `plugins` run afterward in the order you provide them. If an explicit plugin has the same `name` as a default plugin, it replaces that default and runs in its explicit position. If you provide the same explicit plugin name more than once, only the first instance runs.
+
 ### Disable default plugins
 
 Turn them all off with `registerDefaultPlugins: false`:
@@ -64,7 +66,7 @@ const result = await parseMarkdown(content, {
 })
 ```
 
-See also the [`registerDefaultPlugins` option](/reference/parse#options) on the Parse API.
+See the [`registerDefaultPlugins` and `plugins` options](/reference/parse#options) on the Parse API.
 
 ## Plugins
 

--- a/docs/content/5.reference/1.parse.md
+++ b/docs/content/5.reference/1.parse.md
@@ -365,8 +365,8 @@ Both `parseMarkdown()` and `createMarkdownParser()` accept the same `ParserOptio
 | `html` | `boolean` | `true` | **Deprecated** (warns). Prefer `registerDefaultPlugins: false` and register `html()` explicitly. `html: false` still skips the default html plugin. |
 | `linkify` | `boolean` | `true` | Auto-convert URL-like text into links. Set `false` to disable |
 | `headingIds` | `boolean` | `true` | Auto-generate `id` attributes for `h1`–`h6` headings. Set `false` to disable |
-| `registerDefaultPlugins` | `boolean` | `true` | Register the built-in default plugins (`frontmatter`, `html`, `alert`, `task-list`, `components`, `attributes`). Set `false` to disable. Also can be used to configure default plugins like `components` in conjunction with `plugins` |
-| `plugins` | `ComarkPlugin[]` | `[]` | Array of plugins to apply |
+| `registerDefaultPlugins` | `boolean` | `true` | Register the built-in default plugins (`frontmatter`, `html`, `alert`, `task-list`, `components`, `attributes`). Set `false` to disable them. |
+| `plugins` | `ComarkPlugin[]` | `[]` | Ordered plugins to run after the defaults. A same-name plugin replaces its default; duplicate explicit names keep the first instance. See [Default plugins](/plugins#default-plugins). |
 | `tracer` | `ComarkTracer` | `undefined` | Timing recorder for the parse pipeline — see [Timing the parse](#timing-the-parse) |
 
 ### Timing the parse

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -78,7 +78,6 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
     )
   }
 
-  // User plugins first so same-name entries override defaults via dedupePlugins.
   const defaultPlugins =
     options.registerDefaultPlugins !== false
       ? [
@@ -92,20 +91,8 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
         ]
       : []
 
-  const plugins = dedupePlugins([...userPlugins, ...defaultPlugins])
+  const plugins = dedupePlugins(defaultPlugins, userPlugins)
   const hasPlugin = (name: string) => plugins.some((plugin) => plugin.name === name)
-
-  // Default normalizer hooks run before user hooks in every lifecycle phase, so user plugins
-  // always see normalized input: `frontmatter` has stripped and parsed the frontmatter block
-  // before user `pre` hooks, and `alert` has rewritten `> [!note]` into `['blockquote', { as }]`
-  // before user `post` hooks. A user plugin that overrides a default by name keeps that
-  // default's slot. With `registerDefaultPlugins: false` this is a no-op and explicit
-  // registration order rules. `markdownItPlugins` keep registration order: user plugins first.
-  const defaultPluginNames = new Set(defaultPlugins.map((plugin) => plugin.name))
-  const hookPlugins = [
-    ...plugins.filter((plugin) => defaultPluginNames.has(plugin.name)),
-    ...plugins.filter((plugin) => !defaultPluginNames.has(plugin.name)),
-  ]
 
   const parser = new MarkdownExit({ linkify: options.linkify ?? true }).enable(['table', 'strikethrough'])
 
@@ -161,7 +148,7 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
         )
       }
 
-      for (const plugin of hookPlugins) {
+      for (const plugin of plugins) {
         if (!plugin.pre) continue
         await withSpan(tracer, `comark:pre:${plugin.name}`, () => plugin.pre!(state))
       }
@@ -218,7 +205,7 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
         lastInput = null
       }
 
-      for (const plugin of hookPlugins) {
+      for (const plugin of plugins) {
         if (!plugin.post) continue
         await withSpan(tracer, `comark:post:${plugin.name}`, () => plugin.post!(state as ComarkParsePostState))
       }

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -32,9 +32,6 @@ export { parseFrontmatter } from './internal/frontmatter.ts'
 // Re-export plugin utilities
 export { defineComarkPlugin } from './utils/helpers.ts'
 
-/** Names of the default plugins registered by `registerDefaultPlugins` (see below). */
-const DEFAULT_PLUGIN_NAMES = new Set(['frontmatter', 'html', 'alert', 'task-list', 'components', 'attributes'])
-
 /**
  * Creates a parser function for Comark content.
  *
@@ -100,11 +97,13 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
 
   // Default normalizer `post` hooks run before user `post` hooks so user plugins always see
   // the normalized tree (e.g. `alert` has rewritten `> [!note]` into `['blockquote', { as }]`).
-  // A user plugin that overrides a default by name keeps that default's slot. `pre` hooks and
-  // `markdownItPlugins` keep registration order: user plugins first.
+  // A user plugin that overrides a default by name keeps that default's slot. With
+  // `registerDefaultPlugins: false` this is a no-op and explicit registration order rules.
+  // `pre` hooks and `markdownItPlugins` keep registration order: user plugins first.
+  const defaultPluginNames = new Set(defaultPlugins.map((plugin) => plugin.name))
   const postPlugins = [
-    ...plugins.filter((plugin) => DEFAULT_PLUGIN_NAMES.has(plugin.name)),
-    ...plugins.filter((plugin) => !DEFAULT_PLUGIN_NAMES.has(plugin.name)),
+    ...plugins.filter((plugin) => defaultPluginNames.has(plugin.name)),
+    ...plugins.filter((plugin) => !defaultPluginNames.has(plugin.name)),
   ]
 
   const parser = new MarkdownExit({ linkify: options.linkify ?? true }).enable(['table', 'strikethrough'])

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -32,6 +32,9 @@ export { parseFrontmatter } from './internal/frontmatter.ts'
 // Re-export plugin utilities
 export { defineComarkPlugin } from './utils/helpers.ts'
 
+/** Names of the default plugins registered by `registerDefaultPlugins` (see below). */
+const DEFAULT_PLUGIN_NAMES = new Set(['frontmatter', 'html', 'alert', 'task-list', 'components', 'attributes'])
+
 /**
  * Creates a parser function for Comark content.
  *
@@ -94,6 +97,15 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
 
   const plugins = dedupePlugins([...userPlugins, ...defaultPlugins])
   const hasPlugin = (name: string) => plugins.some((plugin) => plugin.name === name)
+
+  // Default normalizer `post` hooks run before user `post` hooks so user plugins always see
+  // the normalized tree (e.g. `alert` has rewritten `> [!note]` into `['blockquote', { as }]`).
+  // A user plugin that overrides a default by name keeps that default's slot. `pre` hooks and
+  // `markdownItPlugins` keep registration order: user plugins first.
+  const postPlugins = [
+    ...plugins.filter((plugin) => DEFAULT_PLUGIN_NAMES.has(plugin.name)),
+    ...plugins.filter((plugin) => !DEFAULT_PLUGIN_NAMES.has(plugin.name)),
+  ]
 
   const parser = new MarkdownExit({ linkify: options.linkify ?? true }).enable(['table', 'strikethrough'])
 
@@ -206,7 +218,7 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
         lastInput = null
       }
 
-      for (const plugin of plugins) {
+      for (const plugin of postPlugins) {
         if (!plugin.post) continue
         await withSpan(tracer, `comark:post:${plugin.name}`, () => plugin.post!(state as ComarkParsePostState))
       }

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -95,13 +95,14 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
   const plugins = dedupePlugins([...userPlugins, ...defaultPlugins])
   const hasPlugin = (name: string) => plugins.some((plugin) => plugin.name === name)
 
-  // Default normalizer `post` hooks run before user `post` hooks so user plugins always see
-  // the normalized tree (e.g. `alert` has rewritten `> [!note]` into `['blockquote', { as }]`).
-  // A user plugin that overrides a default by name keeps that default's slot. With
-  // `registerDefaultPlugins: false` this is a no-op and explicit registration order rules.
-  // `pre` hooks and `markdownItPlugins` keep registration order: user plugins first.
+  // Default normalizer hooks run before user hooks in every lifecycle phase, so user plugins
+  // always see normalized input: `frontmatter` has stripped and parsed the frontmatter block
+  // before user `pre` hooks, and `alert` has rewritten `> [!note]` into `['blockquote', { as }]`
+  // before user `post` hooks. A user plugin that overrides a default by name keeps that
+  // default's slot. With `registerDefaultPlugins: false` this is a no-op and explicit
+  // registration order rules. `markdownItPlugins` keep registration order: user plugins first.
   const defaultPluginNames = new Set(defaultPlugins.map((plugin) => plugin.name))
-  const postPlugins = [
+  const hookPlugins = [
     ...plugins.filter((plugin) => defaultPluginNames.has(plugin.name)),
     ...plugins.filter((plugin) => !defaultPluginNames.has(plugin.name)),
   ]
@@ -160,7 +161,7 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
         )
       }
 
-      for (const plugin of plugins) {
+      for (const plugin of hookPlugins) {
         if (!plugin.pre) continue
         await withSpan(tracer, `comark:pre:${plugin.name}`, () => plugin.pre!(state))
       }
@@ -217,7 +218,7 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
         lastInput = null
       }
 
-      for (const plugin of postPlugins) {
+      for (const plugin of hookPlugins) {
         if (!plugin.post) continue
         await withSpan(tracer, `comark:post:${plugin.name}`, () => plugin.post!(state as ComarkParsePostState))
       }

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -499,7 +499,9 @@ export interface ParserOptions<TPlugins extends readonly ComarkPlugin<any, any>[
   registerDefaultPlugins?: boolean
 
   /**
-   * Additional plugins to use
+   * Additional plugins to use. A plugin with the same name as a default plugin
+   * replaces that default and runs, in user-defined order, after the remaining defaults.
+   * Duplicate user plugins keep their first occurrence.
    * @default []
    */
   plugins?: TPlugins

--- a/packages/comark/src/utils/helpers.ts
+++ b/packages/comark/src/utils/helpers.ts
@@ -15,21 +15,32 @@ export function createSerializedTask<TArgs extends unknown[], TResult>(
 }
 
 /**
- * Remove duplicate plugins by name, keeping the first occurrence.
+ * Merge default and user plugins, deduplicating by name.
+ *
+ * User plugins replace same-name defaults and run after the remaining defaults.
+ * The default list is expected to contain unique names. The first user plugin
+ * with a given name wins.
  */
-export function dedupePlugins(plugins: ComarkPlugin<any, any>[]): ComarkPlugin<any, any>[] {
-  const seen = new Set<string>()
-  const result: ComarkPlugin<any, any>[] = []
+export function dedupePlugins(
+  defaultPlugins: readonly ComarkPlugin<any, any>[],
+  userPlugins: readonly ComarkPlugin<any, any>[]
+): ComarkPlugin<any, any>[] {
+  const plugins = new Map<string, ComarkPlugin<any, any>>()
 
-  for (const plugin of plugins) {
-    if (seen.has(plugin.name)) {
-      continue
-    }
-    seen.add(plugin.name)
-    result.push(plugin)
+  for (const plugin of defaultPlugins) {
+    plugins.set(plugin.name, plugin)
   }
 
-  return result
+  const seenUserPlugins = new Set<string>()
+  for (const plugin of userPlugins) {
+    if (seenUserPlugins.has(plugin.name)) continue
+    seenUserPlugins.add(plugin.name)
+    // Reinsert overrides so they move from the default order to the user order.
+    plugins.delete(plugin.name)
+    plugins.set(plugin.name, plugin)
+  }
+
+  return [...plugins.values()]
 }
 
 // #region define plugin

--- a/packages/comark/test/plugins/default-plugins.test.ts
+++ b/packages/comark/test/plugins/default-plugins.test.ts
@@ -144,6 +144,24 @@ describe('default plugin options', () => {
       expect(order).toEqual(['alert-override', 'probe'])
     })
 
+    it('extracts frontmatter before user pre hooks run', async () => {
+      let seenMarkdown = ''
+      let seenFrontmatter: unknown
+      const probe: ComarkPlugin = {
+        name: 'probe',
+        pre(state) {
+          seenMarkdown = state.markdown
+          seenFrontmatter = { ...state.frontmatter }
+        },
+      }
+      const tree = await parseMarkdown('---\ntitle: Hello\n---\n\n# Hi', { plugins: [probe] })
+      // User pre hooks see the stripped body and the parsed frontmatter.
+      expect(seenMarkdown).not.toContain('title: Hello')
+      expect(seenMarkdown).toContain('# Hi')
+      expect(seenFrontmatter).toEqual({ title: 'Hello' })
+      expect(tree.frontmatter).toEqual({ title: 'Hello' })
+    })
+
     it('preserves explicit registration order when registerDefaultPlugins is false', async () => {
       const order: string[] = []
       const probe: ComarkPlugin = { name: 'probe', post: () => void order.push('probe') }

--- a/packages/comark/test/plugins/default-plugins.test.ts
+++ b/packages/comark/test/plugins/default-plugins.test.ts
@@ -136,12 +136,12 @@ describe('default plugin options', () => {
       expect(seen).toEqual([['blockquote', { as: 'note' }, 'hi']])
     })
 
-    it('keeps the default slot for a user plugin that overrides a default by name', async () => {
+    it('runs a user override in explicit plugin order after the remaining defaults', async () => {
       const order: string[] = []
       const probe: ComarkPlugin = { name: 'probe', post: () => void order.push('probe') }
       const alertOverride: ComarkPlugin = { name: 'alert', post: () => void order.push('alert-override') }
       await parseMarkdown('> [!NOTE]\n> hi', { plugins: [probe, alertOverride] })
-      expect(order).toEqual(['alert-override', 'probe'])
+      expect(order).toEqual(['probe', 'alert-override'])
     })
 
     it('extracts frontmatter before user pre hooks run', async () => {

--- a/packages/comark/test/plugins/default-plugins.test.ts
+++ b/packages/comark/test/plugins/default-plugins.test.ts
@@ -143,6 +143,18 @@ describe('default plugin options', () => {
       await parseMarkdown('> [!NOTE]\n> hi', { plugins: [probe, alertOverride] })
       expect(order).toEqual(['alert-override', 'probe'])
     })
+
+    it('preserves explicit registration order when registerDefaultPlugins is false', async () => {
+      const order: string[] = []
+      const probe: ComarkPlugin = { name: 'probe', post: () => void order.push('probe') }
+      const userAlert: ComarkPlugin = { name: 'alert', post: () => void order.push('alert') }
+      await parseMarkdown('> [!NOTE]\n> hi', {
+        registerDefaultPlugins: false,
+        plugins: [probe, userAlert],
+      })
+      // No defaults registered, so nothing is hoisted — the user's order rules.
+      expect(order).toEqual(['probe', 'alert'])
+    })
   })
 
   describe('user plugin override', () => {

--- a/packages/comark/test/plugins/default-plugins.test.ts
+++ b/packages/comark/test/plugins/default-plugins.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import type { ComarkPlugin } from '../../src/types'
 import { parseMarkdown } from '../../src/parse'
 import attributes from '../../src/plugins/attributes'
 import components from '../../src/plugins/components'
@@ -118,6 +119,29 @@ describe('default plugin options', () => {
     it('does not add html when registerDefaultPlugins is false even if html is unset', async () => {
       const tree = await parseMarkdown('<em>hi</em>', { registerDefaultPlugins: false })
       expect(tree.nodes).toEqual([['p', {}, '<em>hi</em>']])
+    })
+  })
+
+  describe('post hook ordering', () => {
+    it('runs default normalizer post hooks before user post hooks', async () => {
+      let seen: unknown
+      const probe: ComarkPlugin = {
+        name: 'probe',
+        post(state) {
+          seen = structuredClone(state.tree.nodes)
+        },
+      }
+      await parseMarkdown('> [!NOTE]\n> hi', { plugins: [probe] })
+      // `alert` has already rewritten the blockquote when the user post hook runs.
+      expect(seen).toEqual([['blockquote', { as: 'note' }, 'hi']])
+    })
+
+    it('keeps the default slot for a user plugin that overrides a default by name', async () => {
+      const order: string[] = []
+      const probe: ComarkPlugin = { name: 'probe', post: () => void order.push('probe') }
+      const alertOverride: ComarkPlugin = { name: 'alert', post: () => void order.push('alert-override') }
+      await parseMarkdown('> [!NOTE]\n> hi', { plugins: [probe, alertOverride] })
+      expect(order).toEqual(['alert-override', 'probe'])
     })
   })
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "43.6k (74 files)",
         "@comark/svelte": "43.9k (82 files)",
         "@comark/vue": "60.5k (78 files)",
-        "comark": "422k (156 files)",
+        "comark": "423k (156 files)",
       }
     `)
   })


### PR DESCRIPTION
### What

Comark now resolves plugins into one canonical order for MarkdownExit registration and `pre` and `post` hooks: unchanged defaults first, followed by explicit plugins in user-defined order. An explicit plugin replaces a same-name default at its listed position, and duplicate explicit names keep their first instance; tests and public documentation cover these semantics.

### Why

The previous registration and lifecycle orders differed, so a plugin could run in a different position depending on which part of its interface Comark invoked. Using one resolved order makes overrides predictable while ensuring user plugins receive the transformations from defaults they did not replace.
