### PR TITLE
fix(comark): preserve nested markup when stringifying del

### DIFF
--- a/packages/comark/SPEC/COMARK/attribute-del.md
+++ b/packages/comark/SPEC/COMARK/attribute-del.md
@@ -1,0 +1,88 @@
+## Input
+
+```md
+Here ~~del~~{bool} ~~del~~{#id1} ~~del~~{.class1} ~~del~~{attr="value"} ~~`x`~~{.gone} ~~*x*~~{.gone}
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {},
+      "Here ",
+      [
+        "del",
+        {
+          ":bool": "true"
+        },
+        "del"
+      ],
+      " ",
+      [
+        "del",
+        {
+          "id": "id1"
+        },
+        "del"
+      ],
+      " ",
+      [
+        "del",
+        {
+          "class": "class1"
+        },
+        "del"
+      ],
+      " ",
+      [
+        "del",
+        {
+          "attr": "value"
+        },
+        "del"
+      ],
+      " ",
+      [
+        "del",
+        {
+          "class": "gone"
+        },
+        [
+          "code",
+          {},
+          "x"
+        ]
+      ],
+      " ",
+      [
+        "del",
+        {
+          "class": "gone"
+        },
+        [
+          "em",
+          {},
+          "x"
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<p>Here <del bool>del</del> <del id="id1">del</del> <del class="class1">del</del> <del attr="value">del</del> <del class="gone"><code>x</code></del> <del class="gone"><em>x</em></del></p>
+```
+
+## Markdown
+
+```md
+Here ~~del~~{bool} ~~del~~{#id1} ~~del~~{.class1} ~~del~~{attr="value"} ~~`x`~~{.gone} ~~*x*~~{.gone}
+```

--- a/packages/comark/SPEC/common-mark/paragraph-del-code.md
+++ b/packages/comark/SPEC/common-mark/paragraph-del-code.md
@@ -1,0 +1,58 @@
+## Input
+
+```md
+~~`x`~~ ~~a **b** `c`~~
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {},
+      [
+        "del",
+        {},
+        [
+          "code",
+          {},
+          "x"
+        ]
+      ],
+      " ",
+      [
+        "del",
+        {},
+        "a ",
+        [
+          "strong",
+          {},
+          "b"
+        ],
+        " ",
+        [
+          "code",
+          {},
+          "c"
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<p><del><code>x</code></del> <del>a <strong>b</strong> <code>c</code></del></p>
+```
+
+## Markdown
+
+```md
+~~`x`~~ ~~a **b** `c`~~
+```

--- a/packages/comark/src/internal/stringify/handlers/del.ts
+++ b/packages/comark/src/internal/stringify/handlers/del.ts
@@ -1,7 +1,17 @@
 import type { State } from 'comark/render'
 import type { ElementNode } from 'comark'
-import { textContent } from '../../../utils/index.ts'
+import { comarkAttributes } from '../attributes.ts'
 
-export function del(node: ElementNode, _: State) {
-  return `~~${textContent(node)}~~`
+export async function del(node: ElementNode, state: State) {
+  const [_, attrs, ...children] = node
+
+  let content = ''
+  for (const child of children) {
+    content += await state.one(child, state, node)
+  }
+  content = content.trim()
+
+  const attrsString = Object.keys(attrs).length > 0 ? comarkAttributes(attrs) : ''
+
+  return `~~${content}~~${attrsString}`
 }

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -5,7 +5,7 @@ import { indent } from '../../../utils/index.ts'
 
 const textBlocks = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'td', 'th'])
 const selfCloseTags = new Set(['br', 'hr', 'img', 'input', 'link', 'meta', 'source', 'track', 'wbr'])
-const inlineTags = new Set(['strong', 'em', 'code', 'a', 'br', 'span', 'img'])
+const inlineTags = new Set(['strong', 'em', 'del', 'code', 'a', 'br', 'span', 'img'])
 const blockTags = new Set([
   'p',
   'h1',

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "43.6k (74 files)",
         "@comark/svelte": "43.9k (82 files)",
         "@comark/vue": "60.5k (78 files)",
-        "comark": "422k (156 files)",
+        "comark": "423k (156 files)",
       }
     `)
   })


### PR DESCRIPTION
## Summary
- Recurse into `del` children in `renderMarkdown` (like `strong`/`em`) instead of flattening with `textContent`, so nested inlines such as `~~\`x\`~~` round-trip correctly
- Emit `del` attributes after the closing `~~` delimiter
- Treat `del` as an inline tag in HTML stringify so output stays on one line
- Add SPEC coverage for nested code in `del` and for `del` attributes

Fixes #266

## Test plan
- [x] `pnpm vitest run test/index.test.ts` in `packages/comark` (656 passed)
- [ ] Confirm `~~\`x\`~~` parses and stringifies back to `~~\`x\`~~`
- [ ] Confirm `~~*x*~~{.gone}` round-trips attributes and nested emphasis