### PR TITLE
fix(comark): absorb markdown under incomplete HTML openers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,7 +412,7 @@ import alert from 'comark/plugins/alert'
 import frontmatter from 'comark/plugins/frontmatter' // default via registerDefaultPlugins
 import components from 'comark/plugins/components'   // default via registerDefaultPlugins
 import attributes from 'comark/plugins/attributes'   // default via registerDefaultPlugins
-import html from 'comark/plugins/html'               // default via registerDefaultPlugins
+import html from 'comark/plugins/html'               // default via registerDefaultPlugins; html({ markdown: false }) = blank-line-only markdown nesting (CommonMark-style)
 
 // markdown-it / markdown-exit adapters (e.g. VitePress)
 import { markdownItComponents } from 'comark/plugins/components'

--- a/packages/comark/SPEC/COMARK/attribute-image.md
+++ b/packages/comark/SPEC/COMARK/attribute-image.md
@@ -58,7 +58,7 @@ Here ![alt](https://example.com/image.jpg){bool} ![alt](https://example.com/imag
 ## HTML
 
 ```html
-<p>Here <img src="https://example.com/image.jpg" alt="alt" bool /> <img src="https://example.com/image.jpg" alt="alt" id="id1" /> <img src="https://example.com/image.jpg" alt="alt" class="class1" /> <img src="https://example.com/image.jpg" alt="alt" attr="value" /></p>
+<p>Here <img src="https://example.com/image.jpg" alt="alt" bool> <img src="https://example.com/image.jpg" alt="alt" id="id1"> <img src="https://example.com/image.jpg" alt="alt" class="class1"> <img src="https://example.com/image.jpg" alt="alt" attr="value"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/attributes/paragraph+span.md
+++ b/packages/comark/SPEC/COMARK/attributes/paragraph+span.md
@@ -19,13 +19,23 @@ A paragraph [span]{attr="value"}
         "attr": "value"
       },
       "A paragraph ",
-      ["span", {}, "span"]
+      [
+        "span",
+        {},
+        "span"
+      ]
     ],
     [
       "p",
       {},
       "A paragraph ",
-      ["span", { "attr": "value" }, "span"]
+      [
+        "span",
+        {
+          "attr": "value"
+        },
+        "span"
+      ]
     ]
   ]
 }

--- a/packages/comark/SPEC/COMARK/attributes/task-list.md
+++ b/packages/comark/SPEC/COMARK/attributes/task-list.md
@@ -60,10 +60,10 @@
 ```html
 <ul class="contains-task-list">
   <li class="task-list-item" attr="value">
-    <input class="task-list-item-checkbox" type="checkbox" disabled /> Task list item
+    <input class="task-list-item-checkbox" type="checkbox" disabled> Task list item
   </li>
   <li class="task-list-item" attr2="value2">
-    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Task list item
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked> Task list item
   </li>
 </ul>
 ```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
@@ -37,55 +37,55 @@ const variable = "value"
         {
           "class": "language-ts"
         },
-         [
-           "span",
-           {
-             "class": "line",
-             "style": "display: inline"
-           },
-           [
-             "span",
-             {
-               "style": "color:#D32F2F;--shiki-dark:#81A1C1"
-             },
-             "const"
-           ],
-           [
-             "span",
-             {
-               "style": "color:#1976D2;--shiki-dark:#D8DEE9"
-             },
-             " variable"
-           ],
-           [
-             "span",
-             {
-               "style": "color:#D32F2F;--shiki-dark:#81A1C1"
-             },
-             " ="
-           ],
-           [
-             "span",
-             {
-               "style": "color:#22863A;--shiki-dark:#ECEFF4"
-             },
-             " \""
-           ],
-           [
-             "span",
-             {
-               "style": "color:#22863A;--shiki-dark:#A3BE8C"
-             },
-             "value"
-           ],
-           [
-             "span",
-             {
-               "style": "color:#22863A;--shiki-dark:#ECEFF4"
-             },
-             "\""
-           ]
-         ]
+        [
+          "span",
+          {
+            "class": "line",
+            "style": "display: inline"
+          },
+          [
+            "span",
+            {
+              "style": "color:#D32F2F;--shiki-dark:#81A1C1"
+            },
+            "const"
+          ],
+          [
+            "span",
+            {
+              "style": "color:#1976D2;--shiki-dark:#D8DEE9"
+            },
+            " variable"
+          ],
+          [
+            "span",
+            {
+              "style": "color:#D32F2F;--shiki-dark:#81A1C1"
+            },
+            " ="
+          ],
+          [
+            "span",
+            {
+              "style": "color:#22863A;--shiki-dark:#ECEFF4"
+            },
+            " \""
+          ],
+          [
+            "span",
+            {
+              "style": "color:#22863A;--shiki-dark:#A3BE8C"
+            },
+            "value"
+          ],
+          [
+            "span",
+            {
+              "style": "color:#22863A;--shiki-dark:#ECEFF4"
+            },
+            "\""
+          ]
+        ]
       ]
     ]
   ]

--- a/packages/comark/SPEC/COMARK/component-with-heading.md
+++ b/packages/comark/SPEC/COMARK/component-with-heading.md
@@ -62,7 +62,7 @@ Text content
 ```html
 <steps>
   <h3 id="step-1">Step 1</h3>
-  <p><img src="https://example.com/image.jpg" alt="Image" /></p>
+  <p><img src="https://example.com/image.jpg" alt="Image"></p>
   <h3 id="step-2">Step 2</h3>
   <p>Text content</p>
 </steps>

--- a/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break-named-slot.md
+++ b/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break-named-slot.md
@@ -27,12 +27,32 @@ Line three
       {},
       [
         "template",
-        { "name": "description" },
-        ["p", {}, "Line one"],
-        ["hr", {}],
-        ["p", {}, "Middle line"],
-        ["hr", {}],
-        ["p", {}, "Line three"]
+        {
+          "name": "description"
+        },
+        [
+          "p",
+          {},
+          "Line one"
+        ],
+        [
+          "hr",
+          {}
+        ],
+        [
+          "p",
+          {},
+          "Middle line"
+        ],
+        [
+          "hr",
+          {}
+        ],
+        [
+          "p",
+          {},
+          "Line three"
+        ]
       ]
     ]
   ]
@@ -45,9 +65,9 @@ Line three
 <card>
   <template name="description">
     <p>Line one</p>
-    <hr />
+    <hr>
     <p>Middle line</p>
-    <hr />
+    <hr>
     <p>Line three</p>
   </template>
 </card>

--- a/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break.md
+++ b/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break.md
@@ -24,11 +24,29 @@ Below
     [
       "card",
       {},
-      ["p", {}, "Above"],
-      ["hr", {}],
-      ["p", {}, "Middle text"],
-      ["hr", {}],
-      ["p", {}, "Below"]
+      [
+        "p",
+        {},
+        "Above"
+      ],
+      [
+        "hr",
+        {}
+      ],
+      [
+        "p",
+        {},
+        "Middle text"
+      ],
+      [
+        "hr",
+        {}
+      ],
+      [
+        "p",
+        {},
+        "Below"
+      ]
     ]
   ]
 }
@@ -39,9 +57,9 @@ Below
 ```html
 <card>
   <p>Above</p>
-  <hr />
+  <hr>
   <p>Middle text</p>
-  <hr />
+  <hr>
   <p>Below</p>
 </card>
 ```

--- a/packages/comark/SPEC/COMARK/emoji-inside-component-autounwrap.md
+++ b/packages/comark/SPEC/COMARK/emoji-inside-component-autounwrap.md
@@ -29,12 +29,16 @@ options:
   "nodes": [
     [
       "alert",
-      { "type": "success" },
+      {
+        "type": "success"
+      },
       "✅ Successfully deployed! 🚀"
     ],
     [
       "alert",
-      { "type": "warning" },
+      {
+        "type": "warning"
+      },
       "⚠️ Please backup your data before proceeding"
     ]
   ]

--- a/packages/comark/SPEC/COMARK/emoji-inside-component.md
+++ b/packages/comark/SPEC/COMARK/emoji-inside-component.md
@@ -29,12 +29,16 @@ options:
   "nodes": [
     [
       "alert",
-      { "type": "success" },
+      {
+        "type": "success"
+      },
       "✅ Successfully deployed! 🚀"
     ],
     [
       "alert",
-      { "type": "warning" },
+      {
+        "type": "warning"
+      },
       "⚠️ Please backup your data before proceeding"
     ]
   ]

--- a/packages/comark/SPEC/COMARK/frontmatter-empty.md
+++ b/packages/comark/SPEC/COMARK/frontmatter-empty.md
@@ -35,8 +35,8 @@
 ## HTML
 
 ```html
-<hr />
-<hr />
+<hr>
+<hr>
 <h1 id="content">Content</h1>
 ```
 

--- a/packages/comark/SPEC/COMARK/frontmatter-unclosed-is-thematic-break.md
+++ b/packages/comark/SPEC/COMARK/frontmatter-unclosed-is-thematic-break.md
@@ -30,7 +30,7 @@
 ## HTML
 
 ```html
-<hr />
+<hr>
 <h1 id="heading">Heading</h1>
 ```
 

--- a/packages/comark/SPEC/COMARK/image-attribute.md
+++ b/packages/comark/SPEC/COMARK/image-attribute.md
@@ -58,7 +58,7 @@ Here ![alt](https://example.com/image.jpg){bool} ![alt](https://example.com/imag
 ## HTML
 
 ```html
-<p>Here <img src="https://example.com/image.jpg" alt="alt" bool /> <img src="https://example.com/image.jpg" alt="alt" id="id1" /> <img src="https://example.com/image.jpg" alt="alt" class="class1" /> <img src="https://example.com/image.jpg" alt="alt" attr="value" /></p>
+<p>Here <img src="https://example.com/image.jpg" alt="alt" bool> <img src="https://example.com/image.jpg" alt="alt" id="id1"> <img src="https://example.com/image.jpg" alt="alt" class="class1"> <img src="https://example.com/image.jpg" alt="alt" attr="value"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/image-no-alt.md
+++ b/packages/comark/SPEC/COMARK/image-no-alt.md
@@ -28,7 +28,7 @@
 ## HTML
 
 ```html
-<p><img src="/my/cool/path" /></p>
+<p><img src="/my/cool/path"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/image-title.md
+++ b/packages/comark/SPEC/COMARK/image-title.md
@@ -36,7 +36,7 @@
           "alt": "alt",
           "title": "A title",
           "class": "rounded-asymmetric",
-          "width":"200"
+          "width": "200"
         }
       ]
     ]
@@ -47,8 +47,8 @@
 ## HTML
 
 ```html
-<p><img src="https://example.com/image.jpg" title="title" alt="alt" attr="value" /></p>
-<p><img src="img.png" title="A title" alt="alt" class="rounded-asymmetric" width="200" /></p>
+<p><img src="https://example.com/image.jpg" title="title" alt="alt" attr="value"></p>
+<p><img src="img.png" title="A title" alt="alt" class="rounded-asymmetric" width="200"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/link-with-span.md
+++ b/packages/comark/SPEC/COMARK/link-with-span.md
@@ -9,54 +9,45 @@
 ## AST
 
 ```json
-
 {
-   "frontmatter":{
-      
-   },
-   "meta":{
-      
-   },
-   "nodes":[
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {},
       [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"#"
-            },
-            [
-              "span",
-              {},
-              "1"
-            ],
-            " Document"
-         ]
-      ],
-      [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"https://example.com"
-            },
-            [
-              "span",
-              {
-                "class": "cls"
-              },
-              "link-name"
-            ],
-            " more"
-         ]
+        "a",
+        {
+          "href": "#"
+        },
+        [
+          "span",
+          {},
+          "1"
+        ],
+        " Document"
       ]
-   ]
+    ],
+    [
+      "p",
+      {},
+      [
+        "a",
+        {
+          "href": "https://example.com"
+        },
+        [
+          "span",
+          {
+            "class": "cls"
+          },
+          "link-name"
+        ],
+        " more"
+      ]
+    ]
+  ]
 }
 ```
 

--- a/packages/comark/SPEC/COMARK/wrapped-emoji-inside-component.md
+++ b/packages/comark/SPEC/COMARK/wrapped-emoji-inside-component.md
@@ -30,7 +30,9 @@ options:
   "nodes": [
     [
       "alert",
-      { "type": "success" },
+      {
+        "type": "success"
+      },
       [
         "p",
         {},
@@ -39,7 +41,9 @@ options:
     ],
     [
       "alert",
-      { "type": "warning" },
+      {
+        "type": "warning"
+      },
       [
         "p",
         {},

--- a/packages/comark/SPEC/GFM/task-list-multiple.md
+++ b/packages/comark/SPEC/GFM/task-list-multiple.md
@@ -82,13 +82,13 @@ timeout:
 ```html
 <ul class="contains-task-list">
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Done
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked> Done
   </li>
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Done
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked> Done
   </li>
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled /> todo
+    <input class="task-list-item-checkbox" type="checkbox" disabled> todo
   </li>
 </ul>
 ```

--- a/packages/comark/SPEC/GFM/task-list.md
+++ b/packages/comark/SPEC/GFM/task-list.md
@@ -65,10 +65,10 @@ timeout:
 ```html
 <ul class="contains-task-list">
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Done
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked> Done
   </li>
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled /> todo
+    <input class="task-list-item-checkbox" type="checkbox" disabled> todo
   </li>
 </ul>
 ```

--- a/packages/comark/SPEC/HTML/block+component.md
+++ b/packages/comark/SPEC/HTML/block+component.md
@@ -18,7 +18,10 @@ Default Slot
     [
       "hello",
       {
-        "$": { "html": 1, "block": 1 }
+        "$": {
+          "html": 1,
+          "block": 1
+        }
       },
       "::component\nDefault Slot\n::"
     ]

--- a/packages/comark/SPEC/HTML/block+inline-children.md
+++ b/packages/comark/SPEC/HTML/block+inline-children.md
@@ -14,12 +14,18 @@
     [
       "p",
       {
-        "$": { "html": 1, "block": 1 }
+        "$": {
+          "html": 1,
+          "block": 1
+        }
       },
       [
         "img",
         {
-          "$": { "html": 1, "block": 1 },
+          "$": {
+            "html": 1,
+            "block": 0
+          },
           "src": "/foo.png",
           "alt": "x"
         }
@@ -32,11 +38,11 @@
 ## HTML
 
 ```html
-<p><img src="/foo.png" alt="x" /></p>
+<p><img src="/foo.png" alt="x"></p>
 ```
 
 ## Markdown
 
 ```md
-<p><img src="/foo.png" alt="x" /></p>
+<p><img src="/foo.png" alt="x"></p>
 ```

--- a/packages/comark/SPEC/HTML/block.md
+++ b/packages/comark/SPEC/HTML/block.md
@@ -16,7 +16,10 @@ Hello **World**
     [
       "hello",
       {
-        "$": { "html": 1, "block": 1 }
+        "$": {
+          "html": 1,
+          "block": 1
+        }
       },
       "Hello **World**"
     ]

--- a/packages/comark/SPEC/HTML/details-inside-details-no-unwrap.md
+++ b/packages/comark/SPEC/HTML/details-inside-details-no-unwrap.md
@@ -1,3 +1,8 @@
+---
+options:
+  autoUnwrap: false
+---
+
 ## Input
 
 ```md
@@ -45,7 +50,11 @@ Nested content
           },
           "Nested"
         ],
-        "Nested content"
+        [
+          "p",
+          {},
+          "Nested content"
+        ]
       ]
     ]
   ]
@@ -62,7 +71,8 @@ Nested content
   <details>
     <summary>
       Nested
-    </summary>Nested content
+    </summary>
+    <p>Nested content</p>
   </details>
 </details>
 ```

--- a/packages/comark/SPEC/HTML/details-inside-details-no-unwrap.md
+++ b/packages/comark/SPEC/HTML/details-inside-details-no-unwrap.md
@@ -29,24 +29,36 @@ Nested content
     [
       "details",
       {
-        "$": { "html": 1, "block": 1 }
+        "$": {
+          "html": 1,
+          "block": 1
+        }
       },
       [
         "summary",
         {
-          "$": { "html": 1, "block": 1 }
+          "$": {
+            "html": 1,
+            "block": 0
+          }
         },
         "Top"
       ],
       [
         "details",
         {
-          "$": { "html": 1, "block": 1 }
+          "$": {
+            "html": 1,
+            "block": 1
+          }
         },
         [
           "summary",
           {
-            "$": { "html": 1, "block": 1 }
+            "$": {
+              "html": 1,
+              "block": 0
+            }
           },
           "Nested"
         ],
@@ -65,13 +77,9 @@ Nested content
 
 ```html
 <details>
-  <summary>
-    Top
-  </summary>
+  <summary>Top</summary>
   <details>
-    <summary>
-      Nested
-    </summary>
+    <summary>Nested</summary>
     <p>Nested content</p>
   </details>
 </details>
@@ -81,12 +89,8 @@ Nested content
 
 ```md
 <details>
-<summary>
-Top
-</summary><details>
-<summary>
-Nested
-</summary>
+<summary>Top</summary><details>
+<summary>Nested</summary>
 
 Nested content
 </details>

--- a/packages/comark/SPEC/HTML/details-inside-details.md
+++ b/packages/comark/SPEC/HTML/details-inside-details.md
@@ -24,24 +24,36 @@ Nested content
     [
       "details",
       {
-        "$": { "html": 1, "block": 1 }
+        "$": {
+          "html": 1,
+          "block": 1
+        }
       },
       [
         "summary",
         {
-          "$": { "html": 1, "block": 1 }
+          "$": {
+            "html": 1,
+            "block": 0
+          }
         },
         "Top"
       ],
       [
         "details",
         {
-          "$": { "html": 1, "block": 1 }
+          "$": {
+            "html": 1,
+            "block": 1
+          }
         },
         [
           "summary",
           {
-            "$": { "html": 1, "block": 1 }
+            "$": {
+              "html": 1,
+              "block": 0
+            }
           },
           "Nested"
         ],
@@ -56,13 +68,9 @@ Nested content
 
 ```html
 <details>
-  <summary>
-    Top
-  </summary>
+  <summary>Top</summary>
   <details>
-    <summary>
-      Nested
-    </summary>Nested content
+    <summary>Nested</summary>Nested content
   </details>
 </details>
 ```
@@ -71,12 +79,8 @@ Nested content
 
 ```md
 <details>
-<summary>
-Top
-</summary><details>
-<summary>
-Nested
-</summary>
+<summary>Top</summary><details>
+<summary>Nested</summary>
 
 Nested content
 </details>

--- a/packages/comark/SPEC/HTML/details-inside-details.md
+++ b/packages/comark/SPEC/HTML/details-inside-details.md
@@ -1,0 +1,82 @@
+## Input
+
+```md
+<details>
+<summary>Top</summary>
+
+<details>
+<summary>Nested</summary>
+
+Nested content
+
+</details>
+
+</details>
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "details",
+      {
+        "$": { "html": 1, "block": 1 }
+      },
+      [
+        "summary",
+        {
+          "$": { "html": 1, "block": 1 }
+        },
+        "Top"
+      ],
+      [
+        "details",
+        {
+          "$": { "html": 1, "block": 1 }
+        },
+        [
+          "summary",
+          {
+            "$": { "html": 1, "block": 1 }
+          },
+          "Nested"
+        ],
+        "Nested content"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<details>
+  <summary>
+    Top
+  </summary>
+  <details>
+    <summary>
+      Nested
+    </summary>Nested content
+  </details>
+</details>
+```
+
+## Markdown
+
+```md
+<details>
+<summary>
+Top
+</summary><details>
+<summary>
+Nested
+</summary>Nested content
+</details>
+</details>
+```

--- a/packages/comark/SPEC/HTML/incomplete-block-two-new-line.md
+++ b/packages/comark/SPEC/HTML/incomplete-block-two-new-line.md
@@ -18,7 +18,12 @@
   "nodes": [
     [
       "ai-thinking",
-      {"$": { "html": 1, "block": 1 }},
+      {
+        "$": {
+          "html": 1,
+          "block": 1
+        }
+      },
       [
         "p",
         {},

--- a/packages/comark/SPEC/HTML/incomplete-block-two-new-line.md
+++ b/packages/comark/SPEC/HTML/incomplete-block-two-new-line.md
@@ -1,0 +1,77 @@
+## Input
+
+```md
+<ai-thinking>
+
+**bold** and more
+
+- list
+- **item**
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ai-thinking",
+      {"$": { "html": 1, "block": 0 }},
+      [
+        "p",
+        {},
+        [
+          "strong",
+          {},
+          "bold"
+        ],
+        " and more"
+      ],
+      [
+        "ul",
+        {},
+        [
+          "li",
+          {},
+          "list"
+        ],
+        [
+          "li",
+          {},
+          [
+            "strong",
+            {},
+            "item"
+          ]
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ai-thinking>
+  <p><strong>bold</strong> and more</p>
+  <ul>
+    <li>list</li>
+    <li><strong>item</strong></li>
+  </ul>
+</ai-thinking>
+```
+
+## Markdown
+
+```md
+<ai-thinking>
+
+**bold** and more
+
+- list
+- **item**
+</ai-thinking>
+```

--- a/packages/comark/SPEC/HTML/incomplete-block-two-new-line.md
+++ b/packages/comark/SPEC/HTML/incomplete-block-two-new-line.md
@@ -18,7 +18,7 @@
   "nodes": [
     [
       "ai-thinking",
-      {"$": { "html": 1, "block": 0 }},
+      {"$": { "html": 1, "block": 1 }},
       [
         "p",
         {},
@@ -73,5 +73,6 @@
 
 - list
 - **item**
+
 </ai-thinking>
 ```

--- a/packages/comark/SPEC/HTML/incomplete-one-new-line-no-unwrap.md
+++ b/packages/comark/SPEC/HTML/incomplete-one-new-line-no-unwrap.md
@@ -1,0 +1,52 @@
+---
+options:
+  autoUnwrap: false
+---
+
+## Input
+
+```md
+<ai-thinking>
+**bold**
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ai-thinking",
+      {"$": { "html": 1, "block": 0 }},
+      [
+        "p",
+        {},
+        [
+          "strong",
+          {},
+          "bold"
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ai-thinking>
+  <p><strong>bold</strong></p>
+</ai-thinking>
+```
+
+## Markdown
+
+```md
+<ai-thinking>
+
+**bold**
+</ai-thinking>
+```

--- a/packages/comark/SPEC/HTML/incomplete-one-new-line-no-unwrap.md
+++ b/packages/comark/SPEC/HTML/incomplete-one-new-line-no-unwrap.md
@@ -19,7 +19,12 @@ options:
   "nodes": [
     [
       "ai-thinking",
-      {"$": { "html": 1, "block": 0 }},
+      {
+        "$": {
+          "html": 1,
+          "block": 0
+        }
+      },
       [
         "p",
         {},

--- a/packages/comark/SPEC/HTML/incomplete-one-new-line-no-unwrap.md
+++ b/packages/comark/SPEC/HTML/incomplete-one-new-line-no-unwrap.md
@@ -48,5 +48,6 @@ options:
 <ai-thinking>
 
 **bold**
+
 </ai-thinking>
 ```

--- a/packages/comark/SPEC/HTML/incomplete-one-new-line.md
+++ b/packages/comark/SPEC/HTML/incomplete-one-new-line.md
@@ -14,7 +14,12 @@
   "nodes": [
     [
       "ai-thinking",
-      {"$": { "html": 1, "block": 0 }},
+      {
+        "$": {
+          "html": 1,
+          "block": 0
+        }
+      },
       [
         "strong",
         {},

--- a/packages/comark/SPEC/HTML/incomplete-one-new-line.md
+++ b/packages/comark/SPEC/HTML/incomplete-one-new-line.md
@@ -1,0 +1,38 @@
+## Input
+
+```md
+<ai-thinking>
+**bold**
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "ai-thinking",
+      {"$": { "html": 1, "block": 0 }},
+      [
+        "strong",
+        {},
+        "bold"
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<ai-thinking><strong>bold</strong></ai-thinking>
+```
+
+## Markdown
+
+```md
+<ai-thinking>**bold**</ai-thinking>
+```

--- a/packages/comark/SPEC/HTML/inline.md
+++ b/packages/comark/SPEC/HTML/inline.md
@@ -17,7 +17,10 @@
       [
         "hello",
         {
-          "$": { "html": 1, "block": 0 }
+          "$": {
+            "html": 1,
+            "block": 0
+          }
         },
         "Hello ",
         [

--- a/packages/comark/SPEC/HTML/p-details-inside-details.md
+++ b/packages/comark/SPEC/HTML/p-details-inside-details.md
@@ -26,24 +26,36 @@ Nested content2
     [
       "details",
       {
-        "$": { "html": 1, "block": 1 }
+        "$": {
+          "html": 1,
+          "block": 1
+        }
       },
       [
         "summary",
         {
-          "$": { "html": 1, "block": 1 }
+          "$": {
+            "html": 1,
+            "block": 0
+          }
         },
         "Top"
       ],
       [
         "details",
         {
-          "$": { "html": 1, "block": 1 }
+          "$": {
+            "html": 1,
+            "block": 1
+          }
         },
         [
           "summary",
           {
-            "$": { "html": 1, "block": 1 }
+            "$": {
+              "html": 1,
+              "block": 0
+            }
           },
           "Nested"
         ],
@@ -67,13 +79,9 @@ Nested content2
 
 ```html
 <details>
-  <summary>
-    Top
-  </summary>
+  <summary>Top</summary>
   <details>
-    <summary>
-      Nested
-    </summary>
+    <summary>Nested</summary>
     <p>Nested content</p>
     <p>Nested content2</p>
   </details>
@@ -84,12 +92,8 @@ Nested content2
 
 ```md
 <details>
-<summary>
-Top
-</summary><details>
-<summary>
-Nested
-</summary>
+<summary>Top</summary><details>
+<summary>Nested</summary>
 
 Nested content
 

--- a/packages/comark/SPEC/HTML/p-details-inside-details.md
+++ b/packages/comark/SPEC/HTML/p-details-inside-details.md
@@ -9,6 +9,8 @@
 
 Nested content
 
+Nested content2
+
 </details>
 
 </details>
@@ -45,7 +47,16 @@ Nested content
           },
           "Nested"
         ],
-        "Nested content"
+        [
+          "p",
+          {},
+          "Nested content"
+        ],
+        [
+          "p",
+          {},
+          "Nested content2"
+        ]
       ]
     ]
   ]
@@ -62,7 +73,9 @@ Nested content
   <details>
     <summary>
       Nested
-    </summary>Nested content
+    </summary>
+    <p>Nested content</p>
+    <p>Nested content2</p>
   </details>
 </details>
 ```
@@ -79,6 +92,8 @@ Nested
 </summary>
 
 Nested content
+
+Nested content2
 </details>
 </details>
 ```

--- a/packages/comark/SPEC/HTML/real-life-sample-1.md
+++ b/packages/comark/SPEC/HTML/real-life-sample-1.md
@@ -1,0 +1,128 @@
+## Input
+
+```md
+<p valign="center">
+  <a href="https://go.nuxt.com/discord"><img width="20" src="./.github/assets/discord.svg" alt="Discord"></a>&nbsp;&nbsp;<a href="https://go.nuxt.com/x"><img width="20" src="./.github/assets/twitter.svg" alt="Twitter"></a>&nbsp;&nbsp;<a href="https://go.nuxt.com/github"><img width="20" src="./.github/assets/github.svg" alt="GitHub"></a>&nbsp;&nbsp;<a href="https://go.nuxt.com/bluesky"><img width="20" src="./.github/assets/bluesky.svg" alt="Bluesky"></a>
+</p>
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {
+        "$": {
+          "html": 1,
+          "block": 1
+        },
+        "valign": "center"
+      },
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://go.nuxt.com/discord"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "width": "20",
+            "src": "./.github/assets/discord.svg",
+            "alt": "Discord"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://go.nuxt.com/x"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "width": "20",
+            "src": "./.github/assets/twitter.svg",
+            "alt": "Twitter"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://go.nuxt.com/github"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "width": "20",
+            "src": "./.github/assets/github.svg",
+            "alt": "GitHub"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://go.nuxt.com/bluesky"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "width": "20",
+            "src": "./.github/assets/bluesky.svg",
+            "alt": "Bluesky"
+          }
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<p valign="center"><a href="https://go.nuxt.com/discord"><img width="20" src="./.github/assets/discord.svg" alt="Discord"></a><a href="https://go.nuxt.com/x"><img width="20" src="./.github/assets/twitter.svg" alt="Twitter"></a><a href="https://go.nuxt.com/github"><img width="20" src="./.github/assets/github.svg" alt="GitHub"></a><a href="https://go.nuxt.com/bluesky"><img width="20" src="./.github/assets/bluesky.svg" alt="Bluesky"></a></p>
+```
+
+## Markdown
+
+```md
+<p valign="center"><a href="https://go.nuxt.com/discord"><img width="20" src="./.github/assets/discord.svg" alt="Discord"></a><a href="https://go.nuxt.com/x"><img width="20" src="./.github/assets/twitter.svg" alt="Twitter"></a><a href="https://go.nuxt.com/github"><img width="20" src="./.github/assets/github.svg" alt="GitHub"></a><a href="https://go.nuxt.com/bluesky"><img width="20" src="./.github/assets/bluesky.svg" alt="Bluesky"></a></p>
+```

--- a/packages/comark/SPEC/HTML/real-life-sample-2.md
+++ b/packages/comark/SPEC/HTML/real-life-sample-2.md
@@ -1,0 +1,205 @@
+## Input
+
+```md
+<p><a href="https://npmx.dev/package/nuxt"><img src="https://npmx.dev/api/registry/badge/version/nuxt" alt="Version"></a><a href="https://npmx.dev/package/nuxt"><img src="https://npmx.dev/api/registry/badge/downloads/nuxt" alt="Downloads"></a><a href="https://github.com/nuxt/nuxt/blob/main/LICENSE"><img src="https://img.shields.io/github/license/nuxt/nuxt.svg?style=flat&amp;colorA=18181B&amp;colorB=28CF8D" alt="License"></a><a href="https://nuxt.com/modules"><img src="https://img.shields.io/badge/dynamic/json?url=https://nuxt.com/api/v1/modules&amp;query=$.stats.modules&amp;label=Modules&amp;style=flat&amp;colorA=18181B&amp;colorB=28CF8D" alt="Modules"></a><a href="https://nuxt.com"><img src="https://img.shields.io/badge/Nuxt%20Docs-18181B?logo=nuxt" alt="Website"></a><a href="https://chat.nuxt.dev"><img src="https://img.shields.io/badge/Nuxt%20Discord-18181B?logo=discord" alt="Discord"></a><a href="https://securityscorecards.dev/viewer/?uri=github.com/nuxt/nuxt"><img src="https://api.securityscorecards.dev/projects/github.com/nuxt/nuxt/badge" alt="Nuxt openssf scorecard score"></a><a href="https://deepwiki.com/nuxt/nuxt"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a></p>
+```
+
+## AST
+
+```json
+{
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {
+        "$": {
+          "html": 1,
+          "block": 1
+        }
+      },
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://npmx.dev/package/nuxt"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "src": "https://npmx.dev/api/registry/badge/version/nuxt",
+            "alt": "Version"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://npmx.dev/package/nuxt"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "src": "https://npmx.dev/api/registry/badge/downloads/nuxt",
+            "alt": "Downloads"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://github.com/nuxt/nuxt/blob/main/LICENSE"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "src": "https://img.shields.io/github/license/nuxt/nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D",
+            "alt": "License"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://nuxt.com/modules"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "src": "https://img.shields.io/badge/dynamic/json?url=https://nuxt.com/api/v1/modules&query=$.stats.modules&label=Modules&style=flat&colorA=18181B&colorB=28CF8D",
+            "alt": "Modules"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://nuxt.com"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "src": "https://img.shields.io/badge/Nuxt%20Docs-18181B?logo=nuxt",
+            "alt": "Website"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://chat.nuxt.dev"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "src": "https://img.shields.io/badge/Nuxt%20Discord-18181B?logo=discord",
+            "alt": "Discord"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://securityscorecards.dev/viewer/?uri=github.com/nuxt/nuxt"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "src": "https://api.securityscorecards.dev/projects/github.com/nuxt/nuxt/badge",
+            "alt": "Nuxt openssf scorecard score"
+          }
+        ]
+      ],
+      [
+        "a",
+        {
+          "$": {
+            "html": 1,
+            "block": 0
+          },
+          "href": "https://deepwiki.com/nuxt/nuxt"
+        },
+        [
+          "img",
+          {
+            "$": {
+              "html": 1,
+              "block": 0
+            },
+            "src": "https://deepwiki.com/badge.svg",
+            "alt": "Ask DeepWiki"
+          }
+        ]
+      ]
+    ]
+  ]
+}
+```
+
+## HTML
+
+```html
+<p><a href="https://npmx.dev/package/nuxt"><img src="https://npmx.dev/api/registry/badge/version/nuxt" alt="Version"></a><a href="https://npmx.dev/package/nuxt"><img src="https://npmx.dev/api/registry/badge/downloads/nuxt" alt="Downloads"></a><a href="https://github.com/nuxt/nuxt/blob/main/LICENSE"><img src="https://img.shields.io/github/license/nuxt/nuxt.svg?style=flat&amp;colorA=18181B&amp;colorB=28CF8D" alt="License"></a><a href="https://nuxt.com/modules"><img src="https://img.shields.io/badge/dynamic/json?url=https://nuxt.com/api/v1/modules&amp;query=$.stats.modules&amp;label=Modules&amp;style=flat&amp;colorA=18181B&amp;colorB=28CF8D" alt="Modules"></a><a href="https://nuxt.com"><img src="https://img.shields.io/badge/Nuxt%20Docs-18181B?logo=nuxt" alt="Website"></a><a href="https://chat.nuxt.dev"><img src="https://img.shields.io/badge/Nuxt%20Discord-18181B?logo=discord" alt="Discord"></a><a href="https://securityscorecards.dev/viewer/?uri=github.com/nuxt/nuxt"><img src="https://api.securityscorecards.dev/projects/github.com/nuxt/nuxt/badge" alt="Nuxt openssf scorecard score"></a><a href="https://deepwiki.com/nuxt/nuxt"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a></p>
+```
+
+## Markdown
+
+```md
+<p><a href="https://npmx.dev/package/nuxt"><img src="https://npmx.dev/api/registry/badge/version/nuxt" alt="Version"></a><a href="https://npmx.dev/package/nuxt"><img src="https://npmx.dev/api/registry/badge/downloads/nuxt" alt="Downloads"></a><a href="https://github.com/nuxt/nuxt/blob/main/LICENSE"><img src="https://img.shields.io/github/license/nuxt/nuxt.svg?style=flat&amp;colorA=18181B&amp;colorB=28CF8D" alt="License"></a><a href="https://nuxt.com/modules"><img src="https://img.shields.io/badge/dynamic/json?url=https://nuxt.com/api/v1/modules&amp;query=$.stats.modules&amp;label=Modules&amp;style=flat&amp;colorA=18181B&amp;colorB=28CF8D" alt="Modules"></a><a href="https://nuxt.com"><img src="https://img.shields.io/badge/Nuxt%20Docs-18181B?logo=nuxt" alt="Website"></a><a href="https://chat.nuxt.dev"><img src="https://img.shields.io/badge/Nuxt%20Discord-18181B?logo=discord" alt="Discord"></a><a href="https://securityscorecards.dev/viewer/?uri=github.com/nuxt/nuxt"><img src="https://api.securityscorecards.dev/projects/github.com/nuxt/nuxt/badge" alt="Nuxt openssf scorecard score"></a><a href="https://deepwiki.com/nuxt/nuxt"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a></p>
+```

--- a/packages/comark/SPEC/common-mark/horizontal-rule-3-.md
+++ b/packages/comark/SPEC/common-mark/horizontal-rule-3-.md
@@ -30,7 +30,7 @@ Paragraph
 
 ```html
 <p>Paragraph</p>
-<hr />
+<hr>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/horizontal-rule-3-asterisk.md
+++ b/packages/comark/SPEC/common-mark/horizontal-rule-3-asterisk.md
@@ -22,7 +22,7 @@
 ## HTML
 
 ```html
-<hr />
+<hr>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/horizontal-rule-bare.md
+++ b/packages/comark/SPEC/common-mark/horizontal-rule-bare.md
@@ -22,7 +22,7 @@
 ## HTML
 
 ```html
-<hr />
+<hr>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/horizontal-rule-more-.md
+++ b/packages/comark/SPEC/common-mark/horizontal-rule-more-.md
@@ -30,7 +30,7 @@ Paragraph
 
 ```html
 <p>Paragraph</p>
-<hr />
+<hr>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/html-block-void-br.md
+++ b/packages/comark/SPEC/common-mark/html-block-void-br.md
@@ -36,14 +36,14 @@
 ## HTML
 
 ```html
-<br />
+<br>
 <h1 id="after-br">After br</h1>
 ```
 
 ## Markdown
 
 ```md
-<br />
+<br>
 
 # After br
 ```

--- a/packages/comark/SPEC/common-mark/html-block-void-element.md
+++ b/packages/comark/SPEC/common-mark/html-block-void-element.md
@@ -1,7 +1,7 @@
 ## Input
 
 ```md
-<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner">
 
 # comark
 
@@ -46,7 +46,7 @@ A high-performance markdown parser and renderer.
 ## HTML
 
 ```html
-<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner">
 <h1 id="comark">comark</h1>
 <p>A high-performance markdown parser and renderer.</p>
 ```
@@ -54,7 +54,7 @@ A high-performance markdown parser and renderer.
 ## Markdown
 
 ```md
-<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner">
 
 # comark
 

--- a/packages/comark/SPEC/common-mark/image-title.md
+++ b/packages/comark/SPEC/common-mark/image-title.md
@@ -30,7 +30,7 @@
 ## HTML
 
 ```html
-<p><img src="https://example.com/image.jpg" title="title" alt="alt" /></p>
+<p><img src="https://example.com/image.jpg" title="title" alt="alt"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/line-break.md
+++ b/packages/comark/SPEC/common-mark/line-break.md
@@ -29,7 +29,7 @@ World
 ## HTML
 
 ```html
-<p>Hello<br />World</p>
+<p>Hello<br>World</p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/links.md
+++ b/packages/comark/SPEC/common-mark/links.md
@@ -11,55 +11,44 @@
 ## AST
 
 ```json
-
 {
-   "frontmatter":{
-      
-   },
-   "meta":{
-      
-   },
-   "nodes":[
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {},
       [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"#"
-            },
-            "Document"
-         ]
-      ],
-      [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"#"
-            },
-            "[1] Document"
-         ]
-      ],
-      [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"https://example.com"
-            },
-            "[link-name] more"
-         ]
+        "a",
+        {
+          "href": "#"
+        },
+        "Document"
       ]
-   ]
+    ],
+    [
+      "p",
+      {},
+      [
+        "a",
+        {
+          "href": "#"
+        },
+        "[1] Document"
+      ]
+    ],
+    [
+      "p",
+      {},
+      [
+        "a",
+        {
+          "href": "https://example.com"
+        },
+        "[link-name] more"
+      ]
+    ]
+  ]
 }
 ```
 

--- a/packages/comark/SPEC/common-mark/paragraph-image.md
+++ b/packages/comark/SPEC/common-mark/paragraph-image.md
@@ -30,7 +30,7 @@
 ## HTML
 
 ```html
-<p><img src="/assets/images/san-juan-mountains.jpg" title="San Juan Mountains" alt="The San Juan Mountains are beautiful" /></p>
+<p><img src="/assets/images/san-juan-mountains.jpg" title="San Juan Mountains" alt="The San Juan Mountains are beautiful"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/paragraph-link-image.md
+++ b/packages/comark/SPEC/common-mark/paragraph-link-image.md
@@ -36,7 +36,7 @@
 ## HTML
 
 ```html
-<p><a href="/link"><img src="/assets/images/shiprock.jpg" title="Shiprock, New Mexico by Beau Rogers" alt="An old rock in the desert" /></a></p>
+<p><a href="/link"><img src="/assets/images/shiprock.jpg" title="Shiprock, New Mexico by Beau Rogers" alt="An old rock in the desert"></a></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/paragraph-multiple.md
+++ b/packages/comark/SPEC/common-mark/paragraph-multiple.md
@@ -36,7 +36,7 @@ This is another paragraph
 ## HTML
 
 ```html
-<p>This is a simple paragraph<br />And continues in next line</p>
+<p>This is a simple paragraph<br>And continues in next line</p>
 <p>This is another paragraph</p>
 ```
 

--- a/packages/comark/SPEC/common-mark/xyz.md
+++ b/packages/comark/SPEC/common-mark/xyz.md
@@ -313,7 +313,7 @@ And here's a code block:
 </ol>
 <h2 id="section-two">Section Two</h2>
 <p>Here's an image:</p>
-<p><img src="/path/to/image.jpg" title="Image title" alt="Alt text" /></p>
+<p><img src="/path/to/image.jpg" title="Image title" alt="Alt text"></p>
 <p>And here's a code block:</p>
 ```
 

--- a/packages/comark/SPEC/markdown-directive/directive-no-content.md
+++ b/packages/comark/SPEC/markdown-directive/directive-no-content.md
@@ -58,10 +58,10 @@ a :br with no content or attributes
 ```html
 <p>
   a 
-  <hr />
+  <hr>
    directive with no content
 </p>
-<p>a <br /> with no content or attributes</p>
+<p>a <br> with no content or attributes</p>
 <video file="movie.mp4"></video>
 <separator></separator>
 ```

--- a/packages/comark/src/internal/parse/auto-close/index.ts
+++ b/packages/comark/src/internal/parse/auto-close/index.ts
@@ -378,8 +378,14 @@ function closeInlineMarkersLinear(line: string, attributesEnabled: boolean): str
         dollarCount += 2
         i++
       } else {
-        dollarCount++
-        inMath = true
+        // A lone `$` with only trailing whitespace after it is currency/literal
+        // (e.g. `The cost is $`), not an open math span to complete.
+        let j = i + 1
+        while (j < len && (line[j] === ' ' || line[j] === '\t')) j++
+        if (j < len) {
+          dollarCount++
+          inMath = true
+        }
       }
       continue
     }

--- a/packages/comark/src/internal/parse/auto-unwrap.ts
+++ b/packages/comark/src/internal/parse/auto-unwrap.ts
@@ -18,6 +18,14 @@ import type { Node } from 'comark'
  * // After:
  * { tag: 'alert', children: [{ type: 'text', value: 'Text' }] }
  */
+function isMarkdownParagraph(child: Node): child is [string, Record<string, unknown>, ...Node[]] {
+  return (
+    Array.isArray(child) &&
+    child[0] === 'p' &&
+    !(child[1] as Record<string, unknown> | undefined)?.$
+  )
+}
+
 export function applyAutoUnwrap(node: Node): Node {
   if (typeof node === 'string' || node.length < 2) {
     return node
@@ -25,22 +33,58 @@ export function applyAutoUnwrap(node: Node): Node {
 
   const [tag, props, ...children] = node
 
+  // Recurse first so nested HTML wrappers (details → details → p) unwrap bottom-up.
+  const unwrappedChildren = children.map((child: Node) => applyAutoUnwrap(child as Node))
+
   // Filter out empty text nodes for checking
-  const nonEmptyChildren = children.filter((child: Node) => typeof child !== 'string' || (child && child.trim()))
+  const nonEmptyChildren = unwrappedChildren.filter(
+    (child: Node) => typeof child !== 'string' || (child && child.trim())
+  )
 
   if (nonEmptyChildren.length === 0) {
-    return node
+    return [tag, props, ...unwrappedChildren] as Node
   }
 
-  // Check if we have exactly one paragraph child (and possibly empty text nodes)
-  if (nonEmptyChildren.length > 1 || typeof nonEmptyChildren[0] === 'string' || nonEmptyChildren[0][0] !== 'p') {
-    return [tag, props, ...children.map((child: Node) => applyAutoUnwrap(child as Node))] as Node
+  // Classic case: container has only a single markdown paragraph child.
+  if (nonEmptyChildren.length === 1 && isMarkdownParagraph(nonEmptyChildren[0])) {
+    // Lift the paragraph's attrs onto the parent so trailing `{attr}` survives the unwrap.
+    // Parent attrs take precedence so explicit component props aren't overridden.
+    const paragraphAttrs = nonEmptyChildren[0][1] as Record<string, unknown>
+    const mergedProps =
+      paragraphAttrs && Object.keys(paragraphAttrs).length > 0 ? { ...paragraphAttrs, ...props } : props
+    return [tag, mergedProps, ...(nonEmptyChildren[0].slice(2) as Node[])] as Node
   }
 
-  // Lift the paragraph's attrs onto the parent so trailing `{attr}` survives the unwrap.
-  // Parent attrs take precedence so explicit component props aren't overridden.
-  const paragraphAttrs = nonEmptyChildren[0][1] as Record<string, unknown>
-  const mergedProps = paragraphAttrs && Object.keys(paragraphAttrs).length > 0 ? { ...paragraphAttrs, ...props } : props
+  // HTML wrapper (e.g. nested <details>) may mix raw-HTML siblings (`summary`
+  // with `$.html`) with a single markdown paragraph body. Unwrap that lone
+  // markdown p only when every other non-empty sibling is itself HTML-originated
+  // — so `p + ul` under an incomplete `<ai-thinking>` stays as-is.
+  const isHtmlParent =
+    (props as Record<string, unknown> | undefined)?.$ &&
+    typeof (props as Record<string, any>).$ === 'object' &&
+    (props as Record<string, any>).$.html === 1
+  if (isHtmlParent) {
+    const markdownParagraphs = nonEmptyChildren.filter(isMarkdownParagraph)
+    const otherChildren = nonEmptyChildren.filter((c) => !isMarkdownParagraph(c))
+    const othersAreHtml = otherChildren.every(
+      (c) =>
+        Array.isArray(c) &&
+        typeof c[1] === 'object' &&
+        c[1] !== null &&
+        (c[1] as Record<string, any>).$?.html === 1
+    )
+    if (markdownParagraphs.length === 1 && othersAreHtml) {
+      const out: Node[] = []
+      for (const child of unwrappedChildren) {
+        if (isMarkdownParagraph(child)) {
+          out.push(...(child.slice(2) as Node[]))
+        } else {
+          out.push(child)
+        }
+      }
+      return [tag, props, ...out] as Node
+    }
+  }
 
-  return [tag, mergedProps, ...(nonEmptyChildren[0].slice(2) as Node[])] as Node
+  return [tag, props, ...unwrappedChildren] as Node
 }

--- a/packages/comark/src/internal/parse/auto-unwrap.ts
+++ b/packages/comark/src/internal/parse/auto-unwrap.ts
@@ -19,11 +19,7 @@ import type { Node } from 'comark'
  * { tag: 'alert', children: [{ type: 'text', value: 'Text' }] }
  */
 function isMarkdownParagraph(child: Node): child is [string, Record<string, unknown>, ...Node[]] {
-  return (
-    Array.isArray(child) &&
-    child[0] === 'p' &&
-    !(child[1] as Record<string, unknown> | undefined)?.$
-  )
+  return Array.isArray(child) && child[0] === 'p' && !(child[1] as Record<string, unknown> | undefined)?.$
 }
 
 export function applyAutoUnwrap(node: Node): Node {
@@ -68,10 +64,7 @@ export function applyAutoUnwrap(node: Node): Node {
     const otherChildren = nonEmptyChildren.filter((c) => !isMarkdownParagraph(c))
     const othersAreHtml = otherChildren.every(
       (c) =>
-        Array.isArray(c) &&
-        typeof c[1] === 'object' &&
-        c[1] !== null &&
-        (c[1] as Record<string, any>).$?.html === 1
+        Array.isArray(c) && typeof c[1] === 'object' && c[1] !== null && (c[1] as Record<string, any>).$?.html === 1
     )
     if (markdownParagraphs.length === 1 && othersAreHtml) {
       const out: Node[] = []

--- a/packages/comark/src/internal/parse/auto-unwrap.ts
+++ b/packages/comark/src/internal/parse/auto-unwrap.ts
@@ -31,15 +31,9 @@ export function applyAutoUnwrap(node: Node): Node {
 
   // Recurse first so nested HTML wrappers (details → details → p) unwrap bottom-up.
   const unwrappedChildren = children.map((child: Node) => applyAutoUnwrap(child as Node))
-
-  // Filter out empty text nodes for checking
   const nonEmptyChildren = unwrappedChildren.filter(
     (child: Node) => typeof child !== 'string' || (child && child.trim())
   )
-
-  if (nonEmptyChildren.length === 0) {
-    return [tag, props, ...unwrappedChildren] as Node
-  }
 
   // Classic case: container has only a single markdown paragraph child.
   if (nonEmptyChildren.length === 1 && isMarkdownParagraph(nonEmptyChildren[0])) {
@@ -55,27 +49,18 @@ export function applyAutoUnwrap(node: Node): Node {
   // with `$.html`) with a single markdown paragraph body. Unwrap that lone
   // markdown p only when every other non-empty sibling is itself HTML-originated
   // — so `p + ul` under an incomplete `<ai-thinking>` stays as-is.
-  const isHtmlParent =
-    (props as Record<string, unknown> | undefined)?.$ &&
-    typeof (props as Record<string, any>).$ === 'object' &&
-    (props as Record<string, any>).$.html === 1
-  if (isHtmlParent) {
+  const htmlMeta = (props as Record<string, any>)?.$
+  if (htmlMeta && typeof htmlMeta === 'object' && htmlMeta.html === 1) {
     const markdownParagraphs = nonEmptyChildren.filter(isMarkdownParagraph)
-    const otherChildren = nonEmptyChildren.filter((c) => !isMarkdownParagraph(c))
-    const othersAreHtml = otherChildren.every(
-      (c) =>
-        Array.isArray(c) && typeof c[1] === 'object' && c[1] !== null && (c[1] as Record<string, any>).$?.html === 1
+    const othersAreHtml = nonEmptyChildren.every(
+      (c) => isMarkdownParagraph(c) || (Array.isArray(c) && (c[1] as Record<string, any>)?.$?.html === 1)
     )
     if (markdownParagraphs.length === 1 && othersAreHtml) {
-      const out: Node[] = []
-      for (const child of unwrappedChildren) {
-        if (isMarkdownParagraph(child)) {
-          out.push(...(child.slice(2) as Node[]))
-        } else {
-          out.push(child)
-        }
-      }
-      return [tag, props, ...out] as Node
+      return [
+        tag,
+        props,
+        ...unwrappedChildren.flatMap((child) => (isMarkdownParagraph(child) ? (child.slice(2) as Node[]) : [child])),
+      ] as Node
     }
   }
 

--- a/packages/comark/src/internal/parse/html/html_block_rule.ts
+++ b/packages/comark/src/internal/parse/html/html_block_rule.ts
@@ -2,6 +2,11 @@
 // https://spec.commonmark.org/0.30/#html-blocks
 //
 // 7 sequences in priority order, each: [opener regex, closer regex, can-terminate-paragraph]
+//
+// Blank-line terminated HTML (CommonMark types 6/7) already allows markdown in
+// the body after `\n\n`. The `markdown` option only changes tight incomplete
+// openers (no closer before EOF, no blank line): with `markdown: true` (default)
+// the body is left for markdown; with `markdown: false` the block stays raw.
 
 import type { StateBlock } from 'markdown-exit'
 import block_names from './html_blocks.ts'
@@ -31,62 +36,78 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-export default function html_block(state: StateBlock, startLine: number, endLine: number, silent: boolean) {
-  let pos = state.bMarks[startLine] + state.tShift[startLine]
-  let max = state.eMarks[startLine]
+export interface HtmlBlockRuleOptions {
+  /**
+   * When true, incomplete lone open tags (no closer before EOF) leave the body
+   * for markdown tokenization. When false, they stay CommonMark-raw until a
+   * blank line (markdown only after `\n\n`).
+   * @default true
+   */
+  markdown?: boolean
+}
 
-  if (state.sCount[startLine] - state.blkIndent >= 4) return false
-  if (state.src.charCodeAt(pos) !== 0x3c /* < */) return false
+export default function createHtmlBlockRule(options: HtmlBlockRuleOptions = {}) {
+  const allowIncompleteMarkdown = options.markdown !== false
 
-  let lineText = state.src.slice(pos, max)
+  return function html_block(state: StateBlock, startLine: number, endLine: number, silent: boolean) {
+    let pos = state.bMarks[startLine] + state.tShift[startLine]
+    let max = state.eMarks[startLine]
 
-  let i = 0
-  for (; i < HTML_SEQUENCES.length; i++) {
-    if (HTML_SEQUENCES[i][0].test(lineText)) break
-  }
-  if (i === HTML_SEQUENCES.length) return false
+    if (state.sCount[startLine] - state.blkIndent >= 4) return false
+    if (state.src.charCodeAt(pos) !== 0x3c /* < */) return false
 
-  if (silent) return HTML_SEQUENCES[i][2]
+    let lineText = state.src.slice(pos, max)
 
-  let nextLine = startLine + 1
+    let i = 0
+    for (; i < HTML_SEQUENCES.length; i++) {
+      if (HTML_SEQUENCES[i][0].test(lineText)) break
+    }
+    if (i === HTML_SEQUENCES.length) return false
 
-  // Sequences whose end condition is a blank line (type 6 block tags, type 7
-  // generic tags). A lone open tag with no matching closer before EOF is an
-  // incomplete streaming opener — only consume the opener line so following
-  // markdown can be tokenized and absorbed by the token processor.
-  const blankLineTerminated = HTML_SEQUENCES[i][1].source === '^$'
-  const openerTag = blankLineTerminated ? loneOpenTagName(lineText) : null
+    if (silent) return HTML_SEQUENCES[i][2]
 
-  // Walk forward until the closer regex matches or we hit a blank line.
-  if (!HTML_SEQUENCES[i][1].test(lineText)) {
-    let sawMatchingClose = false
-    for (; nextLine < endLine; nextLine++) {
-      if (state.sCount[nextLine] < state.blkIndent) break
+    let nextLine = startLine + 1
 
-      pos = state.bMarks[nextLine] + state.tShift[nextLine]
-      max = state.eMarks[nextLine]
-      lineText = state.src.slice(pos, max)
+    // Sequences whose end condition is a blank line (type 6 block tags, type 7
+    // generic tags). A lone open tag with no matching closer before EOF is an
+    // incomplete streaming opener — only consume the opener line so following
+    // markdown can be tokenized and absorbed by the token processor (when
+    // `markdown` is enabled).
+    const blankLineTerminated = HTML_SEQUENCES[i][1].source === '^$'
+    const openerTag = blankLineTerminated ? loneOpenTagName(lineText) : null
 
-      if (openerTag && new RegExp(`^</\\s*${escapeRegExp(openerTag)}\\s*>\\s*$`, 'i').test(lineText.trim())) {
-        sawMatchingClose = true
+    // Walk forward until the closer regex matches or we hit a blank line.
+    if (!HTML_SEQUENCES[i][1].test(lineText)) {
+      let sawMatchingClose = false
+      for (; nextLine < endLine; nextLine++) {
+        if (state.sCount[nextLine] < state.blkIndent) break
+
+        pos = state.bMarks[nextLine] + state.tShift[nextLine]
+        max = state.eMarks[nextLine]
+        lineText = state.src.slice(pos, max)
+
+        if (openerTag && new RegExp(`^</\\s*${escapeRegExp(openerTag)}\\s*>\\s*$`, 'i').test(lineText.trim())) {
+          sawMatchingClose = true
+        }
+
+        if (HTML_SEQUENCES[i][1].test(lineText)) {
+          if (lineText.length !== 0) nextLine++
+          break
+        }
       }
 
-      if (HTML_SEQUENCES[i][1].test(lineText)) {
-        if (lineText.length !== 0) nextLine++
-        break
+      // Incomplete open tag running to EOF with no closer: leave body for markdown
+      // (opt-in; `markdown: false` keeps CommonMark raw until blank line / EOF).
+      if (allowIncompleteMarkdown && openerTag && !sawMatchingClose && nextLine >= endLine) {
+        nextLine = startLine + 1
       }
     }
 
-    // Incomplete open tag running to EOF with no closer: leave body for markdown.
-    if (openerTag && !sawMatchingClose && nextLine >= endLine) {
-      nextLine = startLine + 1
-    }
+    state.line = nextLine
+    const token = state.push('html_block', '', 1)
+    token.map = [startLine, nextLine]
+    token.content = state.getLines(startLine, nextLine, state.blkIndent, true)
+
+    return true
   }
-
-  state.line = nextLine
-  const token = state.push('html_block', '', 1)
-  token.map = [startLine, nextLine]
-  token.content = state.getLines(startLine, nextLine, state.blkIndent, true)
-
-  return true
 }

--- a/packages/comark/src/internal/parse/html/html_block_rule.ts
+++ b/packages/comark/src/internal/parse/html/html_block_rule.ts
@@ -17,6 +17,20 @@ const HTML_SEQUENCES: [RegExp, RegExp, boolean][] = [
   [new RegExp(`${HTML_OPEN_CLOSE_TAG_RE.source}\\s*$`), /^$/, false],
 ]
 
+/** Open tag name when `line` is a lone start tag (`<foo>` / `<foo attr>`), else null. */
+function loneOpenTagName(line: string): string | null {
+  const trimmed = line.trim()
+  // Closing tags, void self-closers, comments, declarations — not incomplete openers.
+  if (!trimmed.startsWith('<') || trimmed.startsWith('</') || trimmed.startsWith('<!')) return null
+  if (/\/\s*>\s*$/.test(trimmed)) return null
+  const match = trimmed.match(/^<([a-zA-Z][\w:-]*)(?:\s[^>]*)?>\s*$/)
+  return match ? match[1] : null
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 export default function html_block(state: StateBlock, startLine: number, endLine: number, silent: boolean) {
   let pos = state.bMarks[startLine] + state.tShift[startLine]
   let max = state.eMarks[startLine]
@@ -36,8 +50,16 @@ export default function html_block(state: StateBlock, startLine: number, endLine
 
   let nextLine = startLine + 1
 
+  // Sequences whose end condition is a blank line (type 6 block tags, type 7
+  // generic tags). A lone open tag with no matching closer before EOF is an
+  // incomplete streaming opener — only consume the opener line so following
+  // markdown can be tokenized and absorbed by the token processor.
+  const blankLineTerminated = HTML_SEQUENCES[i][1].source === '^$'
+  const openerTag = blankLineTerminated ? loneOpenTagName(lineText) : null
+
   // Walk forward until the closer regex matches or we hit a blank line.
   if (!HTML_SEQUENCES[i][1].test(lineText)) {
+    let sawMatchingClose = false
     for (; nextLine < endLine; nextLine++) {
       if (state.sCount[nextLine] < state.blkIndent) break
 
@@ -45,10 +67,19 @@ export default function html_block(state: StateBlock, startLine: number, endLine
       max = state.eMarks[nextLine]
       lineText = state.src.slice(pos, max)
 
+      if (openerTag && new RegExp(`^</\\s*${escapeRegExp(openerTag)}\\s*>\\s*$`, 'i').test(lineText.trim())) {
+        sawMatchingClose = true
+      }
+
       if (HTML_SEQUENCES[i][1].test(lineText)) {
         if (lineText.length !== 0) nextLine++
         break
       }
+    }
+
+    // Incomplete open tag running to EOF with no closer: leave body for markdown.
+    if (openerTag && !sawMatchingClose && nextLine >= endLine) {
+      nextLine = startLine + 1
     }
   }
 

--- a/packages/comark/src/internal/parse/html/html_block_rule.ts
+++ b/packages/comark/src/internal/parse/html/html_block_rule.ts
@@ -12,14 +12,16 @@ import type { StateBlock } from 'markdown-exit'
 import block_names from './html_blocks.ts'
 import { HTML_OPEN_CLOSE_TAG_RE } from './html_re.ts'
 
+const BLANK_LINE = /^$/
+
 const HTML_SEQUENCES: [RegExp, RegExp, boolean][] = [
   [/^<(script|pre|style|textarea)(?=(\s|>|$))/i, /<\/(script|pre|style|textarea)>/i, true],
   [/^<!--/, /-->/, true],
   [/^<\?/, /\?>/, true],
   [/^<![A-Z]/, />/, true],
   [/^<!\[CDATA\[/, /\]\]>/, true],
-  [new RegExp(`^</?(${block_names.join('|')})(?=(\\s|/?>|$))`, 'i'), /^$/, true],
-  [new RegExp(`${HTML_OPEN_CLOSE_TAG_RE.source}\\s*$`), /^$/, false],
+  [new RegExp(`^</?(${block_names.join('|')})(?=(\\s|/?>|$))`, 'i'), BLANK_LINE, true],
+  [new RegExp(`${HTML_OPEN_CLOSE_TAG_RE.source}\\s*$`), BLANK_LINE, false],
 ]
 
 /** Open tag name when `line` is a lone start tag (`<foo>` / `<foo attr>`), else null. */
@@ -72,7 +74,7 @@ export default function createHtmlBlockRule(options: HtmlBlockRuleOptions = {}) 
     // markdown can be tokenized and absorbed by the token processor (when
     // `markdown` is enabled).
     const closer = HTML_SEQUENCES[i][1]
-    const openerTag = allowIncompleteMarkdown && closer.source === '^$' ? loneOpenTagName(lineText) : null
+    const openerTag = allowIncompleteMarkdown && closer === BLANK_LINE ? loneOpenTagName(lineText) : null
     const matchingClose = openerTag ? new RegExp(`^</\\s*${escapeRegExp(openerTag)}\\s*>\\s*$`, 'i') : null
 
     // Walk forward until the closer regex matches or we hit a blank line.
@@ -95,7 +97,7 @@ export default function createHtmlBlockRule(options: HtmlBlockRuleOptions = {}) 
 
       // Incomplete open tag running to EOF with no closer: leave body for markdown
       // (opt-in; `markdown: false` keeps CommonMark raw until blank line / EOF).
-      if (allowIncompleteMarkdown && openerTag && !sawMatchingClose && nextLine >= endLine) {
+      if (openerTag && !sawMatchingClose && nextLine >= endLine) {
         nextLine = startLine + 1
       }
     }

--- a/packages/comark/src/internal/parse/html/html_block_rule.ts
+++ b/packages/comark/src/internal/parse/html/html_block_rule.ts
@@ -25,8 +25,6 @@ const HTML_SEQUENCES: [RegExp, RegExp, boolean][] = [
 /** Open tag name when `line` is a lone start tag (`<foo>` / `<foo attr>`), else null. */
 function loneOpenTagName(line: string): string | null {
   const trimmed = line.trim()
-  // Closing tags, void self-closers, comments, declarations — not incomplete openers.
-  if (!trimmed.startsWith('<') || trimmed.startsWith('</') || trimmed.startsWith('<!')) return null
   if (/\/\s*>\s*$/.test(trimmed)) return null
   const match = trimmed.match(/^<([a-zA-Z][\w:-]*)(?:\s[^>]*)?>\s*$/)
   return match ? match[1] : null
@@ -73,11 +71,12 @@ export default function createHtmlBlockRule(options: HtmlBlockRuleOptions = {}) 
     // incomplete streaming opener — only consume the opener line so following
     // markdown can be tokenized and absorbed by the token processor (when
     // `markdown` is enabled).
-    const blankLineTerminated = HTML_SEQUENCES[i][1].source === '^$'
-    const openerTag = blankLineTerminated ? loneOpenTagName(lineText) : null
+    const closer = HTML_SEQUENCES[i][1]
+    const openerTag = allowIncompleteMarkdown && closer.source === '^$' ? loneOpenTagName(lineText) : null
+    const matchingClose = openerTag ? new RegExp(`^</\\s*${escapeRegExp(openerTag)}\\s*>\\s*$`, 'i') : null
 
     // Walk forward until the closer regex matches or we hit a blank line.
-    if (!HTML_SEQUENCES[i][1].test(lineText)) {
+    if (!closer.test(lineText)) {
       let sawMatchingClose = false
       for (; nextLine < endLine; nextLine++) {
         if (state.sCount[nextLine] < state.blkIndent) break
@@ -86,11 +85,9 @@ export default function createHtmlBlockRule(options: HtmlBlockRuleOptions = {}) 
         max = state.eMarks[nextLine]
         lineText = state.src.slice(pos, max)
 
-        if (openerTag && new RegExp(`^</\\s*${escapeRegExp(openerTag)}\\s*>\\s*$`, 'i').test(lineText.trim())) {
-          sawMatchingClose = true
-        }
+        if (matchingClose?.test(lineText.trim())) sawMatchingClose = true
 
-        if (HTML_SEQUENCES[i][1].test(lineText)) {
+        if (closer.test(lineText)) {
           if (lineText.length !== 0) nextLine++
           break
         }

--- a/packages/comark/src/internal/parse/html/index.ts
+++ b/packages/comark/src/internal/parse/html/index.ts
@@ -1,5 +1,5 @@
 import { Parser } from 'htmlparser2'
-import type { Node } from 'comark'
+import type { ElementNode, Node } from 'comark'
 
 export const VOID_ELEMENTS = new Set([
   'area',
@@ -78,8 +78,52 @@ export function parseInlineHtmlTag(html: string): HtmlTagInfo | null {
 }
 
 /**
+ * Whether a node is a block-level HTML element (`$.block === 1`).
+ * Text and comments are not block elements.
+ */
+function isBlockHtmlElement(node: Node): boolean {
+  if (typeof node === 'string' || !Array.isArray(node) || node[0] === null) return false
+  const meta = (node[1] as Record<string, unknown> | undefined)?.$ as Record<string, unknown> | undefined
+  return meta?.html === 1 && meta?.block === 1
+}
+
+/**
+ * Infer `$.block` from structure (no tag-name allowlists):
+ *
+ * - Root of an `html_block` fragment stays `block: 1` (it was a block unit).
+ * - Nested element is `block: 0` when every child is text / comment / inline HTML
+ *   (no nested `block: 1` descendants that make it a block container).
+ * - Nested element is `block: 1` when it contains at least one block child.
+ *
+ * Walks bottom-up so children's flags are settled before the parent is classified.
+ */
+function inferBlockFromChildren(nodes: Node[], isRootLevel: boolean): void {
+  for (const node of nodes) {
+    if (typeof node === 'string' || !Array.isArray(node) || node[0] === null) continue
+
+    const element = node as ElementNode
+    const children = element.slice(2) as Node[]
+    inferBlockFromChildren(children, false)
+
+    const attrs = element[1] as Record<string, unknown>
+    const meta = (attrs.$ ||= {}) as Record<string, unknown>
+    if (meta.html !== 1) continue
+
+    if (isRootLevel) {
+      // Top-level of an html_block token is always a block unit.
+      meta.block = 1
+      continue
+    }
+
+    const hasBlockChild = children.some(isBlockHtmlElement)
+    meta.block = hasBlockChild ? 1 : 0
+  }
+}
+
+/**
  * Parse a full HTML string into Nodes using htmlparser2.
  * Handles nested elements, text, void elements, and comments.
+ * `$.block` is inferred from children after the tree is built.
  */
 export function htmlToNodes(html: string): Node[] {
   const root: Node[] = []
@@ -88,7 +132,8 @@ export function htmlToNodes(html: string): Node[] {
   const parser = new Parser(
     {
       onopentag(name, attribs) {
-        const attrs = attribsToComarkAttrs(attribs)
+        // Provisional block:1; refined by inferBlockFromChildren after close.
+        const attrs = attribsToComarkAttrs(attribs, false)
         if (VOID_ELEMENTS.has(name)) {
           const node = [name, attrs] as Node
           if (stack.length > 0) {
@@ -151,5 +196,6 @@ export function htmlToNodes(html: string): Node[] {
   parser.write(html.trim())
   parser.end()
 
+  inferBlockFromChildren(root, true)
   return root
 }

--- a/packages/comark/src/internal/parse/html/index.ts
+++ b/packages/comark/src/internal/parse/html/index.ts
@@ -109,14 +109,7 @@ function inferBlockFromChildren(nodes: Node[], isRootLevel: boolean): void {
     const meta = (attrs.$ ||= {}) as Record<string, unknown>
     if (meta.html !== 1) continue
 
-    if (isRootLevel) {
-      // Top-level of an html_block token is always a block unit.
-      meta.block = 1
-      continue
-    }
-
-    const hasBlockChild = children.some(isBlockHtmlElement)
-    meta.block = hasBlockChild ? 1 : 0
+    meta.block = isRootLevel || children.some(isBlockHtmlElement) ? 1 : 0
   }
 }
 

--- a/packages/comark/src/internal/parse/html/index.ts
+++ b/packages/comark/src/internal/parse/html/index.ts
@@ -121,6 +121,10 @@ function inferBlockFromChildren(nodes: Node[], isRootLevel: boolean): void {
 export function htmlToNodes(html: string): Node[] {
   const root: Node[] = []
   const stack: { tag: string; attrs: Record<string, unknown>; children: Node[] }[] = []
+  const append = (node: Node) => {
+    if (stack.length > 0) stack[stack.length - 1].children.push(node)
+    else root.push(node)
+  }
 
   const parser = new Parser(
     {
@@ -128,12 +132,7 @@ export function htmlToNodes(html: string): Node[] {
         // Provisional block:1; refined by inferBlockFromChildren after close.
         const attrs = attribsToComarkAttrs(attribs, false)
         if (VOID_ELEMENTS.has(name)) {
-          const node = [name, attrs] as Node
-          if (stack.length > 0) {
-            stack[stack.length - 1].children.push(node)
-          } else {
-            root.push(node)
-          }
+          append([name, attrs] as Node)
           return
         }
         stack.push({ tag: name, attrs, children: [] })
@@ -141,18 +140,11 @@ export function htmlToNodes(html: string): Node[] {
 
       ontext(text) {
         const trimmed = text.trim()
-        if (!trimmed) return
-        if (stack.length > 0) {
-          stack[stack.length - 1].children.push(trimmed)
-        } else {
-          root.push(trimmed)
-        }
+        if (trimmed) append(trimmed)
       },
 
       onclosetag(name) {
-        if (VOID_ELEMENTS.has(name)) {
-          return
-        }
+        if (VOID_ELEMENTS.has(name)) return
         // Find matching frame (handles mismatched tags gracefully)
         let idx = stack.length - 1
         while (idx >= 0 && stack[idx].tag !== name) {
@@ -161,26 +153,17 @@ export function htmlToNodes(html: string): Node[] {
         if (idx >= 0) {
           while (stack.length > idx) {
             const frame = stack.pop()!
-            const node =
-              frame.children.length > 0
-                ? ([frame.tag, frame.attrs, ...frame.children] as Node)
-                : ([frame.tag, frame.attrs] as Node)
-            if (stack.length > 0) {
-              stack[stack.length - 1].children.push(node)
-            } else {
-              root.push(node)
-            }
+            append(
+              (frame.children.length > 0
+                ? [frame.tag, frame.attrs, ...frame.children]
+                : [frame.tag, frame.attrs]) as Node
+            )
           }
         }
       },
 
       oncomment(data) {
-        const node = [null, {}, data] as unknown as Node
-        if (stack.length > 0) {
-          stack[stack.length - 1].children.push(node)
-        } else {
-          root.push(node)
-        }
+        append([null, {}, data] as unknown as Node)
       },
     },
     { decodeEntities: true }

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -128,25 +128,6 @@ function htmlOuterTagDepth(content: string, tag: string): number {
   return depth
 }
 
-/** Normalize children of an incomplete HTML wrapper before emitting the node. */
-function finalizeIncompleteHtmlChildren(nodes: Node[]): Node[] {
-  // Markdown paragraphs that only wrap plain text under a raw HTML parent
-  // (blank-line body of `<details>`) collapse to that text so the AST matches
-  // a single content string rather than an extra `<p>`.
-  return nodes.map((child) => {
-    if (
-      Array.isArray(child) &&
-      child[0] === 'p' &&
-      !(child[1] as Record<string, unknown> | undefined)?.$ &&
-      child.length === 3 &&
-      typeof child[2] === 'string'
-    ) {
-      return child[2] as string
-    }
-    return child
-  })
-}
-
 /**
  * Convert an html_block token into Comark nodes.
  *
@@ -230,13 +211,15 @@ function processHtmlBlockTokens(
       $: { ...prevMeta, html: 1, block: 0 },
     }
     return {
-      nodes: [[element[0], attrs, ...openerChildren, ...finalizeIncompleteHtmlChildren(children.nodes)] as Node],
+      nodes: [[element[0], attrs, ...openerChildren, ...children.nodes] as Node],
       nextIndex: children.nextIndex,
     }
   }
 
   // Matching closer → nest body under the opener (block: 1). Slice so
   // processBlockChildren stops before the closer; recurse for nested HTML.
+  // Single-paragraph bodies are left as `<p>` here; `applyAutoUnwrap` lifts
+  // them when `autoUnwrap` is on (default).
   const bodyTokens = tokens.slice(startIndex + 1, closeIndex)
   const body = processBlockChildren(bodyTokens, 0, '\0', false, false, false, state)
 
@@ -246,7 +229,7 @@ function processHtmlBlockTokens(
   }
 
   return {
-    nodes: [[element[0], attrs, ...openerChildren, ...finalizeIncompleteHtmlChildren(body.nodes)] as Node],
+    nodes: [[element[0], attrs, ...openerChildren, ...body.nodes] as Node],
     // Consume the closer as well.
     nextIndex: closeIndex + 1,
   }

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -230,14 +230,7 @@ function processHtmlBlockTokens(
       $: { ...prevMeta, html: 1, block: 0 },
     }
     return {
-      nodes: [
-        [
-          element[0],
-          attrs,
-          ...openerChildren,
-          ...finalizeIncompleteHtmlChildren(children.nodes),
-        ] as Node,
-      ],
+      nodes: [[element[0], attrs, ...openerChildren, ...finalizeIncompleteHtmlChildren(children.nodes)] as Node],
       nextIndex: children.nextIndex,
     }
   }
@@ -253,9 +246,7 @@ function processHtmlBlockTokens(
   }
 
   return {
-    nodes: [
-      [element[0], attrs, ...openerChildren, ...finalizeIncompleteHtmlChildren(body.nodes)] as Node,
-    ],
+    nodes: [[element[0], attrs, ...openerChildren, ...finalizeIncompleteHtmlChildren(body.nodes)] as Node],
     // Consume the closer as well.
     nextIndex: closeIndex + 1,
   }

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -1,5 +1,5 @@
 import type { ElementNode, Node } from 'comark'
-import { htmlToNodes, parseInlineHtmlTag } from './html/index.ts'
+import { htmlToNodes, parseInlineHtmlTag, VOID_ELEMENTS } from './html/index.ts'
 
 // `::tag` components that should fold into a single same-tagged child.
 const WRAPPER_TAGS = new Set(['ul', 'ol', 'table', 'blockquote', 'pre'])
@@ -61,7 +61,7 @@ export function marmdownItTokensToMarkdownDocument(tokens: any[], opts?: TokenPr
     const token = tokens[i]
 
     if (token.type === 'html_block') {
-      const result = processHtmlBlockTokens(tokens, i)
+      const result = processHtmlBlockTokens(tokens, i, state)
       nodes.push(...result.nodes)
       i = result.nextIndex
       continue
@@ -89,13 +89,95 @@ export function marmdownItTokensToMarkdownDocument(tokens: any[], opts?: TokenPr
 }
 
 /**
- * Convert an html_block token into Comark nodes. The whole HTML payload is
- * parsed once by htmlparser2; text inside is preserved verbatim (no markdown
- * re-parsing — CommonMark default).
+ * Whether an `html_block` token's content already closes its own outer element
+ * (self-contained on one run: `<p><img></p>`, void tags, comments, etc.).
  */
-function processHtmlBlockTokens(tokens: any[], startIndex: number): { nodes: Node[]; nextIndex: number } {
+function htmlBlockHasOwnClose(content: string): boolean {
+  const trimmed = content.trim()
+  if (!trimmed) return false
+  // Comments, declarations, CDATA, processing instructions: self-terminating.
+  if (trimmed.startsWith('<!') || trimmed.startsWith('<?')) return true
+  const match = trimmed.match(/^<\s*([a-zA-Z][\w:-]*)/)
+  if (!match) return false
+  const tag = match[1]
+  if (VOID_ELEMENTS.has(tag.toLowerCase())) return true
+  // Self-closing start tag (`<br/>`, `<div />`)
+  if (/\/\s*>\s*$/.test(trimmed) && !trimmed.slice(1).includes('<')) return true
+  return new RegExp(`</\\s*${tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`, 'i').test(trimmed)
+}
+
+/** Tag name of a bare closing HTML block (`</div>`), or null. */
+function htmlBlockCloseTag(content: string): string | null {
+  const match = content.trim().match(/^<\/\s*([a-zA-Z][\w:-]*)\s*>$/)
+  return match ? match[1].toLowerCase() : null
+}
+
+/**
+ * Convert an html_block token into Comark nodes.
+ *
+ * Self-contained blocks are parsed once by htmlparser2 (text preserved
+ * verbatim — CommonMark default). Incomplete openers with no matching closer
+ * later in the token stream absorb subsequent markdown as children
+ * (`$.block = 0`) so streaming unfinished tags (e.g. `<ai-thinking>…`) wrap
+ * their body instead of leaving siblings outside the unclosed element.
+ */
+function processHtmlBlockTokens(
+  tokens: any[],
+  startIndex: number,
+  state?: ProcessState
+): { nodes: Node[]; nextIndex: number } {
   const content = typeof tokens[startIndex]?.content === 'string' ? tokens[startIndex].content : ''
-  return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
+
+  // Self-contained / void / comment / already-closed payload, or a bare closer
+  // token (`</p>`) — CommonMark keeps these as independent html_block siblings.
+  // Bare closers still go through htmlToNodes (htmlparser2 may emit an empty
+  // element for some tags; that matches existing SPEC/tests).
+  if (htmlBlockHasOwnClose(content) || htmlBlockCloseTag(content)) {
+    return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
+  }
+
+  const openMatch = content.trim().match(/^<\s*([a-zA-Z][\w:-]*)/)
+  if (!openMatch) {
+    return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
+  }
+  const tag = openMatch[1].toLowerCase()
+
+  // Matching closer later in the stream → standard blank-line-terminated HTML
+  // block behaviour (open and close are siblings; body is markdown between them).
+  for (let i = startIndex + 1; i < tokens.length; i++) {
+    const t = tokens[i]
+    if (t.type === 'html_block' && htmlBlockCloseTag(typeof t.content === 'string' ? t.content : '') === tag) {
+      return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
+    }
+  }
+
+  // Incomplete open tag with no closer: absorb the rest of the stream as children.
+  const parsed = htmlToNodes(content)
+  const node = parsed[0]
+  if (!node || typeof node === 'string' || node[0] === null) {
+    return { nodes: parsed, nextIndex: startIndex + 1 }
+  }
+
+  // `\0` never matches a real token type — process through end of stream.
+  const children = processBlockChildren(tokens, startIndex + 1, '\0', false, false, false, state)
+  const element = node as ElementNode
+  const openerAttrs = (element[1] || {}) as Record<string, unknown>
+  const prevMeta = (openerAttrs.$ || {}) as Record<string, unknown>
+  // `block: 0` marks markdown-parsed children (vs raw HTML body at block:1).
+  const attrs: Record<string, unknown> = {
+    ...openerAttrs,
+    $: { ...prevMeta, html: 1, block: 0 },
+  }
+  const openerChildren = element.slice(2) as Node[]
+
+  // Multiple block children keep their structure (p + ul, etc.). A single
+  // markdown paragraph is left intact so incomplete multi-line bodies match
+  // the streaming SPEC; autoUnwrap does not apply at the document root to
+  // these html wrappers (the wrapper is the root node).
+  return {
+    nodes: [[element[0], attrs, ...openerChildren, ...children.nodes] as Node],
+    nextIndex: children.nextIndex,
+  }
 }
 
 /**
@@ -307,7 +389,7 @@ function processBlockToken(
   // processBlockChildren / processBlockChildrenWithSlots) before reaching here.
   // Safety fallback when it slips through.
   if (token.type === 'html_block') {
-    const result = processHtmlBlockTokens(tokens, startIndex)
+    const result = processHtmlBlockTokens(tokens, startIndex, state)
     return { node: result.nodes[0] ?? null, nextIndex: result.nextIndex }
   }
 
@@ -486,7 +568,7 @@ function processBlockChildrenWithSlots(
 
     // html_block can produce multiple nodes — handle before processBlockToken
     if (token.type === 'html_block') {
-      const result = processHtmlBlockTokens(tokens, i)
+      const result = processHtmlBlockTokens(tokens, i, state)
       if (currentSlotName !== null) {
         currentSlotChildren.push(...result.nodes)
       } else {
@@ -581,7 +663,7 @@ function processBlockChildren(
     const token = tokens[i]
 
     if (token.type === 'html_block') {
-      const result = processHtmlBlockTokens(tokens, i)
+      const result = processHtmlBlockTokens(tokens, i, state)
       nodes.push(...result.nodes)
       i = result.nextIndex
       continue

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -133,8 +133,9 @@ function htmlOuterTagDepth(content: string, tag: string): number {
  *
  * Self-contained blocks are parsed once by htmlparser2 (text preserved
  * verbatim — CommonMark default). Incomplete openers absorb subsequent tokens
- * as children until a matching closer (`block: 1` with a closer, or `block: 0`
- * for streaming tags with no closer) so nested blank-line HTML like
+ * as children until a matching closer (`block: 1`). Streaming openers with no
+ * closer are `block: 1` when the body is multi-block markdown, otherwise
+ * `block: 0` (lone paragraph / inline-like). Nested blank-line HTML like
  * `<details>…<details>…</details></details>` builds a real tree.
  */
 function processHtmlBlockTokens(
@@ -203,12 +204,19 @@ function processHtmlBlockTokens(
   const prevMeta = (openerAttrs.$ || {}) as Record<string, unknown>
   const openerChildren = element.slice(2) as Node[]
 
-  // No matching closer → streaming incomplete tag (block: 0), absorb to EOF.
+  // No matching closer → streaming incomplete tag, absorb to EOF.
+  // Multi-block markdown bodies are real block containers (`block: 1`).
+  // A lone paragraph (often auto-unwrapped later) stays `block: 0` so it can
+  // serialize as a one-liner: `<tag>**bold**</tag>`.
   if (closeIndex < 0) {
     const children = processBlockChildren(tokens, startIndex + 1, '\0', false, false, false, state)
+    const nonEmpty = children.nodes.filter((child) => typeof child !== 'string' || (child && child.trim()))
+    const isMultiBlock =
+      nonEmpty.length > 1 ||
+      (nonEmpty.length === 1 && Array.isArray(nonEmpty[0]) && nonEmpty[0][0] !== null && nonEmpty[0][0] !== 'p')
     const attrs: Record<string, unknown> = {
       ...openerAttrs,
-      $: { ...prevMeta, html: 1, block: 0 },
+      $: { ...prevMeta, html: 1, block: isMultiBlock ? 1 : 0 },
     }
     return {
       nodes: [[element[0], attrs, ...openerChildren, ...children.nodes] as Node],

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -113,13 +113,48 @@ function htmlBlockCloseTag(content: string): string | null {
 }
 
 /**
+ * Depth of `tag` openers still unclosed inside `content` (can be nested).
+ * Positive → more openers than closers; 0 → balanced; negative is treated as 0.
+ */
+function htmlOuterTagDepth(content: string, tag: string): number {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`</?\\s*${escaped}\\b[^>]*>`, 'gi')
+  let depth = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(content)) !== null) {
+    if (m[0].charAt(1) === '/') depth = Math.max(0, depth - 1)
+    else if (!/\/\s*>$/.test(m[0])) depth++
+  }
+  return depth
+}
+
+/** Normalize children of an incomplete HTML wrapper before emitting the node. */
+function finalizeIncompleteHtmlChildren(nodes: Node[]): Node[] {
+  // Markdown paragraphs that only wrap plain text under a raw HTML parent
+  // (blank-line body of `<details>`) collapse to that text so the AST matches
+  // a single content string rather than an extra `<p>`.
+  return nodes.map((child) => {
+    if (
+      Array.isArray(child) &&
+      child[0] === 'p' &&
+      !(child[1] as Record<string, unknown> | undefined)?.$ &&
+      child.length === 3 &&
+      typeof child[2] === 'string'
+    ) {
+      return child[2] as string
+    }
+    return child
+  })
+}
+
+/**
  * Convert an html_block token into Comark nodes.
  *
  * Self-contained blocks are parsed once by htmlparser2 (text preserved
- * verbatim — CommonMark default). Incomplete openers with no matching closer
- * later in the token stream absorb subsequent markdown as children
- * (`$.block = 0`) so streaming unfinished tags (e.g. `<ai-thinking>…`) wrap
- * their body instead of leaving siblings outside the unclosed element.
+ * verbatim — CommonMark default). Incomplete openers absorb subsequent tokens
+ * as children until a matching closer (`block: 1` with a closer, or `block: 0`
+ * for streaming tags with no closer) so nested blank-line HTML like
+ * `<details>…<details>…</details></details>` builds a real tree.
  */
 function processHtmlBlockTokens(
   tokens: any[],
@@ -128,11 +163,14 @@ function processHtmlBlockTokens(
 ): { nodes: Node[]; nextIndex: number } {
   const content = typeof tokens[startIndex]?.content === 'string' ? tokens[startIndex].content : ''
 
-  // Self-contained / void / comment / already-closed payload, or a bare closer
-  // token (`</p>`) — CommonMark keeps these as independent html_block siblings.
-  // Bare closers still go through htmlToNodes (htmlparser2 may emit an empty
-  // element for some tags; that matches existing SPEC/tests).
-  if (htmlBlockHasOwnClose(content) || htmlBlockCloseTag(content)) {
+  // Bare closer with no surrounding open — drop (parent consumes matching ones).
+  if (htmlBlockCloseTag(content)) {
+    return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
+  }
+
+  // Fully closed in this token alone (including multi-line runs with matching
+  // open/close) — parse as a self-contained HTML fragment.
+  if (htmlBlockHasOwnClose(content)) {
     return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
   }
 
@@ -142,41 +180,84 @@ function processHtmlBlockTokens(
   }
   const tag = openMatch[1].toLowerCase()
 
-  // Matching closer later in the stream → standard blank-line-terminated HTML
-  // block behaviour (open and close are siblings; body is markdown between them).
+  // How many outer `tag` frames this token opens that still need a closer.
+  // Opener-only content like `<details>\n<summary>…</summary>` starts depth 1.
+  let depth = htmlOuterTagDepth(content, tag)
+  if (depth <= 0) {
+    return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
+  }
+
+  // Scan ahead for a matching closer (nested same-tag openers bump depth).
+  let closeIndex = -1
   for (let i = startIndex + 1; i < tokens.length; i++) {
     const t = tokens[i]
-    if (t.type === 'html_block' && htmlBlockCloseTag(typeof t.content === 'string' ? t.content : '') === tag) {
-      return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
+    if (t.type !== 'html_block') continue
+    const c = typeof t.content === 'string' ? t.content : ''
+    const closeTag = htmlBlockCloseTag(c)
+    if (closeTag === tag) {
+      depth--
+      if (depth === 0) {
+        closeIndex = i
+        break
+      }
+      continue
+    }
+    // Nested opener of the same tag (may include its own closer in the same token).
+    if (!htmlBlockCloseTag(c)) {
+      const nestedOpen = c.trim().match(/^<\s*([a-zA-Z][\w:-]*)/)
+      if (nestedOpen && nestedOpen[1].toLowerCase() === tag) {
+        depth += htmlOuterTagDepth(c, tag)
+      }
     }
   }
 
-  // Incomplete open tag with no closer: absorb the rest of the stream as children.
   const parsed = htmlToNodes(content)
   const node = parsed[0]
   if (!node || typeof node === 'string' || node[0] === null) {
     return { nodes: parsed, nextIndex: startIndex + 1 }
   }
 
-  // `\0` never matches a real token type — process through end of stream.
-  const children = processBlockChildren(tokens, startIndex + 1, '\0', false, false, false, state)
   const element = node as ElementNode
   const openerAttrs = (element[1] || {}) as Record<string, unknown>
   const prevMeta = (openerAttrs.$ || {}) as Record<string, unknown>
-  // `block: 0` marks markdown-parsed children (vs raw HTML body at block:1).
-  const attrs: Record<string, unknown> = {
-    ...openerAttrs,
-    $: { ...prevMeta, html: 1, block: 0 },
-  }
   const openerChildren = element.slice(2) as Node[]
 
-  // Multiple block children keep their structure (p + ul, etc.). A single
-  // markdown paragraph is left intact so incomplete multi-line bodies match
-  // the streaming SPEC; autoUnwrap does not apply at the document root to
-  // these html wrappers (the wrapper is the root node).
+  // No matching closer → streaming incomplete tag (block: 0), absorb to EOF.
+  if (closeIndex < 0) {
+    const children = processBlockChildren(tokens, startIndex + 1, '\0', false, false, false, state)
+    const attrs: Record<string, unknown> = {
+      ...openerAttrs,
+      $: { ...prevMeta, html: 1, block: 0 },
+    }
+    return {
+      nodes: [
+        [
+          element[0],
+          attrs,
+          ...openerChildren,
+          ...finalizeIncompleteHtmlChildren(children.nodes),
+        ] as Node,
+      ],
+      nextIndex: children.nextIndex,
+    }
+  }
+
+  // Matching closer → nest body under the opener (block: 1). Slice so
+  // processBlockChildren stops before the closer; recurse for nested HTML.
+  const bodyTokens = tokens.slice(startIndex + 1, closeIndex)
+  const body = processBlockChildren(bodyTokens, 0, '\0', false, false, false, state)
+
+  const attrs: Record<string, unknown> = {
+    ...openerAttrs,
+    $: { ...prevMeta, html: 1, block: 1 },
+  }
+
   return {
-    nodes: [[element[0], attrs, ...openerChildren, ...children.nodes] as Node],
-    nextIndex: children.nextIndex,
+    nodes: [
+      [element[0], attrs, ...openerChildren, ...finalizeIncompleteHtmlChildren(body.nodes)] as Node,
+    ],
+    // Consume the closer as well.
+    nextIndex: closeIndex + 1,
   }
 }
 

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -161,13 +161,9 @@ function processHtmlBlockTokens(
 ): { nodes: Node[]; nextIndex: number } {
   const content = typeof tokens[startIndex]?.content === 'string' ? tokens[startIndex].content : ''
   const tag = htmlOpenTagName(content)
+  const depth = tag && !VOID_ELEMENTS.has(tag) ? htmlOuterTagDepth(content, tag) : 0
   // Comments, closers, void tags, and already-balanced fragments stay as-is.
-  if (!tag || VOID_ELEMENTS.has(tag)) {
-    return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
-  }
-
-  const depth = htmlOuterTagDepth(content, tag)
-  if (depth <= 0) {
+  if (!tag || depth <= 0) {
     return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
   }
 

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -88,37 +88,27 @@ export function marmdownItTokensToMarkdownDocument(tokens: any[], opts?: TokenPr
   return nodes
 }
 
-/**
- * Whether an `html_block` token's content already closes its own outer element
- * (self-contained on one run: `<p><img></p>`, void tags, comments, etc.).
- */
-function htmlBlockHasOwnClose(content: string): boolean {
-  const trimmed = content.trim()
-  if (!trimmed) return false
-  // Comments, declarations, CDATA, processing instructions: self-terminating.
-  if (trimmed.startsWith('<!') || trimmed.startsWith('<?')) return true
-  const match = trimmed.match(/^<\s*([a-zA-Z][\w:-]*)/)
-  if (!match) return false
-  const tag = match[1]
-  if (VOID_ELEMENTS.has(tag.toLowerCase())) return true
-  // Self-closing start tag (`<br/>`, `<div />`)
-  if (/\/\s*>\s*$/.test(trimmed) && !trimmed.slice(1).includes('<')) return true
-  return new RegExp(`</\\s*${tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*>`, 'i').test(trimmed)
+const HTML_OPEN_TAG_RE = /^<\s*([a-zA-Z][\w:-]*)/
+const HTML_CLOSE_TAG_RE = /^<\/\s*([a-zA-Z][\w:-]*)\s*>$/
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function htmlOpenTagName(content: string): string | null {
+  const match = content.trim().match(HTML_OPEN_TAG_RE)
+  return match ? match[1].toLowerCase() : null
 }
 
 /** Tag name of a bare closing HTML block (`</div>`), or null. */
 function htmlBlockCloseTag(content: string): string | null {
-  const match = content.trim().match(/^<\/\s*([a-zA-Z][\w:-]*)\s*>$/)
+  const match = content.trim().match(HTML_CLOSE_TAG_RE)
   return match ? match[1].toLowerCase() : null
 }
 
-/**
- * Depth of `tag` openers still unclosed inside `content` (can be nested).
- * Positive → more openers than closers; 0 → balanced; negative is treated as 0.
- */
+/** Unclosed `tag` openers in `content`. Nested same-tag pairs cancel out. */
 function htmlOuterTagDepth(content: string, tag: string): number {
-  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const re = new RegExp(`</?\\s*${escaped}\\b[^>]*>`, 'gi')
+  const re = new RegExp(`</?\\s*${escapeRegExp(tag)}(?![\\w:-])[^>]*>`, 'gi')
   let depth = 0
   let m: RegExpExecArray | null
   while ((m = re.exec(content)) !== null) {
@@ -126,6 +116,32 @@ function htmlOuterTagDepth(content: string, tag: string): number {
     else if (!/\/\s*>$/.test(m[0])) depth++
   }
   return depth
+}
+
+/** Index of the matching closer, or -1 if this opener runs to EOF. */
+function findHtmlBlockCloseIndex(tokens: any[], startIndex: number, tag: string, depth: number): number {
+  for (let i = startIndex + 1; i < tokens.length; i++) {
+    const t = tokens[i]
+    if (t.type !== 'html_block') continue
+    const c = typeof t.content === 'string' ? t.content : ''
+    const closeTag = htmlBlockCloseTag(c)
+    if (closeTag === tag) {
+      depth--
+      if (depth === 0) return i
+      continue
+    }
+    // Nested opener of the same tag (may include its own closer in the same token).
+    if (!closeTag && htmlOpenTagName(c) === tag) depth += htmlOuterTagDepth(c, tag)
+  }
+  return -1
+}
+
+function isMultiBlockBody(nodes: Node[]): boolean {
+  const nonEmpty = nodes.filter((child) => typeof child !== 'string' || (child && child.trim()))
+  return (
+    nonEmpty.length > 1 ||
+    (nonEmpty.length === 1 && Array.isArray(nonEmpty[0]) && nonEmpty[0][0] !== null && nonEmpty[0][0] !== 'p')
+  )
 }
 
 /**
@@ -144,55 +160,18 @@ function processHtmlBlockTokens(
   state?: ProcessState
 ): { nodes: Node[]; nextIndex: number } {
   const content = typeof tokens[startIndex]?.content === 'string' ? tokens[startIndex].content : ''
-
-  // Bare closer with no surrounding open — drop (parent consumes matching ones).
-  if (htmlBlockCloseTag(content)) {
+  const tag = htmlOpenTagName(content)
+  // Comments, closers, void tags, and already-balanced fragments stay as-is.
+  if (!tag || VOID_ELEMENTS.has(tag)) {
     return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
   }
 
-  // Fully closed in this token alone (including multi-line runs with matching
-  // open/close) — parse as a self-contained HTML fragment.
-  if (htmlBlockHasOwnClose(content)) {
-    return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
-  }
-
-  const openMatch = content.trim().match(/^<\s*([a-zA-Z][\w:-]*)/)
-  if (!openMatch) {
-    return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
-  }
-  const tag = openMatch[1].toLowerCase()
-
-  // How many outer `tag` frames this token opens that still need a closer.
-  // Opener-only content like `<details>\n<summary>…</summary>` starts depth 1.
-  let depth = htmlOuterTagDepth(content, tag)
+  const depth = htmlOuterTagDepth(content, tag)
   if (depth <= 0) {
     return { nodes: htmlToNodes(content), nextIndex: startIndex + 1 }
   }
 
-  // Scan ahead for a matching closer (nested same-tag openers bump depth).
-  let closeIndex = -1
-  for (let i = startIndex + 1; i < tokens.length; i++) {
-    const t = tokens[i]
-    if (t.type !== 'html_block') continue
-    const c = typeof t.content === 'string' ? t.content : ''
-    const closeTag = htmlBlockCloseTag(c)
-    if (closeTag === tag) {
-      depth--
-      if (depth === 0) {
-        closeIndex = i
-        break
-      }
-      continue
-    }
-    // Nested opener of the same tag (may include its own closer in the same token).
-    if (!htmlBlockCloseTag(c)) {
-      const nestedOpen = c.trim().match(/^<\s*([a-zA-Z][\w:-]*)/)
-      if (nestedOpen && nestedOpen[1].toLowerCase() === tag) {
-        depth += htmlOuterTagDepth(c, tag)
-      }
-    }
-  }
-
+  const closeIndex = findHtmlBlockCloseIndex(tokens, startIndex, tag, depth)
   const parsed = htmlToNodes(content)
   const node = parsed[0]
   if (!node || typeof node === 'string' || node[0] === null) {
@@ -202,44 +181,20 @@ function processHtmlBlockTokens(
   const element = node as ElementNode
   const openerAttrs = (element[1] || {}) as Record<string, unknown>
   const prevMeta = (openerAttrs.$ || {}) as Record<string, unknown>
-  const openerChildren = element.slice(2) as Node[]
-
-  // No matching closer → streaming incomplete tag, absorb to EOF.
-  // Multi-block markdown bodies are real block containers (`block: 1`).
-  // A lone paragraph (often auto-unwrapped later) stays `block: 0` so it can
-  // serialize as a one-liner: `<tag>**bold**</tag>`.
-  if (closeIndex < 0) {
-    const children = processBlockChildren(tokens, startIndex + 1, '\0', false, false, false, state)
-    const nonEmpty = children.nodes.filter((child) => typeof child !== 'string' || (child && child.trim()))
-    const isMultiBlock =
-      nonEmpty.length > 1 ||
-      (nonEmpty.length === 1 && Array.isArray(nonEmpty[0]) && nonEmpty[0][0] !== null && nonEmpty[0][0] !== 'p')
-    const attrs: Record<string, unknown> = {
-      ...openerAttrs,
-      $: { ...prevMeta, html: 1, block: isMultiBlock ? 1 : 0 },
-    }
-    return {
-      nodes: [[element[0], attrs, ...openerChildren, ...children.nodes] as Node],
-      nextIndex: children.nextIndex,
-    }
-  }
-
-  // Matching closer → nest body under the opener (block: 1). Slice so
-  // processBlockChildren stops before the closer; recurse for nested HTML.
-  // Single-paragraph bodies are left as `<p>` here; `applyAutoUnwrap` lifts
-  // them when `autoUnwrap` is on (default).
-  const bodyTokens = tokens.slice(startIndex + 1, closeIndex)
-  const body = processBlockChildren(bodyTokens, 0, '\0', false, false, false, state)
-
-  const attrs: Record<string, unknown> = {
-    ...openerAttrs,
-    $: { ...prevMeta, html: 1, block: 1 },
-  }
+  const end = closeIndex < 0 ? tokens.length : closeIndex
+  const body = processBlockChildren(tokens.slice(startIndex + 1, end), 0, '\0', false, false, false, state)
+  const block = closeIndex < 0 && !isMultiBlockBody(body.nodes) ? 0 : 1
 
   return {
-    nodes: [[element[0], attrs, ...openerChildren, ...body.nodes] as Node],
-    // Consume the closer as well.
-    nextIndex: closeIndex + 1,
+    nodes: [
+      [
+        element[0],
+        { ...openerAttrs, $: { ...prevMeta, html: 1, block } },
+        ...(element.slice(2) as Node[]),
+        ...body.nodes,
+      ] as Node,
+    ],
+    nextIndex: closeIndex < 0 ? tokens.length : closeIndex + 1,
   }
 }
 

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -79,10 +79,11 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   }
 
   // In markdown mode, block children already append their own blockSeparator, so
-  // we must not inject extra newlines between them. In HTML mode the separator
-  // is the pretty-print block gap. A blank line inside a *raw* HTML body would
-  // terminate the block on reparse — markdown children of incomplete openers
-  // (`$.block === 0`) intentionally use blank lines like normal markdown.
+  // we must not inject extra newlines between *markdown* siblings. HTML element
+  // closers (`</summary>`) do not carry a trailing separator, so a following
+  // markdown body would otherwise glue on (`</summary>Nested content`). Insert
+  // a blank line when the previous render ends with an HTML closer and the next
+  // is not itself an HTML open tag. In HTML mode use the pretty-print gap.
   const childSeparator = state.context.html ? state.context.blockSeparator : ''
 
   let content = ''
@@ -90,17 +91,27 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   for (let i = 0; i < children.length; i++) {
     const childContent = childrenContent[i]
     const child = children[i]
-    const isBlock =
+    const childIsBlock =
       typeof child !== 'string' &&
       (blockTags.has(String(child?.[0])) || (!inlineTags.has(String(child?.[0])) && !hasTextSibling))
 
-    if (i > 0 && !isPrevBlock && isBlock) {
+    if (i > 0 && !isPrevBlock && childIsBlock) {
       content += childSeparator
     }
-    content += childContent
-    isPrevBlock = isBlock
 
-    if (isBlock && i < children.length - 1) {
+    if (i > 0 && !state.context.html) {
+      const prevContent = childrenContent[i - 1]
+      // `…</summary>` + `Nested content` → blank line so the body re-parses as
+      // a separate markdown block. Keep HTML→HTML tight (`</summary><details>`).
+      if (prevContent.endsWith('>') && childContent && !childContent.startsWith('<') && !childContent.startsWith('\n')) {
+        content += state.context.blockSeparator
+      }
+    }
+
+    content += childContent
+    isPrevBlock = childIsBlock
+
+    if (childIsBlock && i < children.length - 1) {
       content += childSeparator
     }
   }

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -42,11 +42,20 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   const hasTextSibling = children.some((child) => typeof child === 'string')
   const isBlock = textBlocks.has(String(tag))
   const isInline = inlineTags.has(String(tag)) && $.block === 0
-  // Incomplete HTML openers (streaming) store markdown/HTML block children under
-  // `$.block === 0`; those still need multi-line wrapping, not one-liner inline.
+  // Any non-inline child (markdown p/ul or nested HTML) needs multi-line wrapping.
   const hasBlockChildren = children.some(
     (child) => Array.isArray(child) && child[0] !== null && !inlineTags.has(String(child[0]))
   )
+  // Blank line after the open tag only when the body *starts* with markdown
+  // (`<tag>\n\n**bold**…`), so it re-parses as markdown. HTML-first bodies
+  // (`<details>\n<summary>…`) stay flush; the sibling join path adds the gap
+  // before a later markdown block.
+  const firstMeaningfulChild = children.find((child) => typeof child !== 'string' || (child && child.trim()))
+  const bodyStartsWithMarkdown =
+    Array.isArray(firstMeaningfulChild) &&
+    firstMeaningfulChild[0] !== null &&
+    !inlineTags.has(String(firstMeaningfulChild[0])) &&
+    !(firstMeaningfulChild[1] as Record<string, any> | undefined)?.$?.html
 
   let oneLiner = isBlock && hasOnlyTextChildren
 
@@ -63,7 +72,7 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   }
 
   // Inline HTML (`block: 0` with only text/inline children) collapses to one line.
-  // Incomplete block wrappers with real markdown block children stay multi-line.
+  // Block wrappers with real block children stay multi-line.
   if ($.block === 0 && !hasBlockChildren) {
     oneLiner = true
   }
@@ -135,14 +144,14 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   if (!oneLiner && content) {
     if (state.context.html) {
       content = '\n' + paddNoneHtmlContent(content, state, String(tag)).trimEnd() + '\n'
-    } else if ($.block === 0 && hasBlockChildren) {
-      // Incomplete HTML openers with markdown body: blank line after open tag so
-      // the body re-parses as markdown, children's own blockSeparators between
-      // blocks, single newline before close.
-      content = '\n\n' + content.trimEnd() + '\n'
+    } else if (bodyStartsWithMarkdown) {
+      // Markdown-first body: blank line after open so the body re-parses as
+      // markdown; blank line before close so a trailing closer is its own
+      // html_block (not absorbed into a list item / paragraph).
+      content = '\n\n' + content.trimEnd() + '\n\n'
     } else {
-      // Raw HTML block body (block:1) — keep content flush after the open tag
-      // so reparse matches CommonMark html_block runs.
+      // Raw HTML / HTML-first body — keep content flush after the open tag so
+      // reparse matches CommonMark html_block runs.
       content = '\n' + paddNoneHtmlContent(content, state, String(tag)).trimEnd() + '\n'
     }
   }

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -103,7 +103,12 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
       const prevContent = childrenContent[i - 1]
       // `…</summary>` + `Nested content` → blank line so the body re-parses as
       // a separate markdown block. Keep HTML→HTML tight (`</summary><details>`).
-      if (prevContent.endsWith('>') && childContent && !childContent.startsWith('<') && !childContent.startsWith('\n')) {
+      if (
+        prevContent.endsWith('>') &&
+        childContent &&
+        !childContent.startsWith('<') &&
+        !childContent.startsWith('\n')
+      ) {
         content += state.context.blockSeparator
       }
     }

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -138,7 +138,7 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   const attrs = Object.keys(attributes).length > 0 ? ` ${htmlAttributes(attributes)}` : ''
 
   if (isSelfClose) {
-    return `<${tag}${attrs} />` + (!parent && !isInline ? state.context.blockSeparator : '')
+    return `<${tag}${attrs}>` + (!parent && !isInline ? state.context.blockSeparator : '')
   }
 
   if (!oneLiner && content) {

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -142,16 +142,10 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   }
 
   if (!oneLiner && content) {
-    if (state.context.html) {
-      content = '\n' + paddNoneHtmlContent(content, state, String(tag)).trimEnd() + '\n'
-    } else if (bodyStartsWithMarkdown) {
-      // Markdown-first body: blank line after open so the body re-parses as
-      // markdown; blank line before close so a trailing closer is its own
-      // html_block (not absorbed into a list item / paragraph).
+    if (!state.context.html && bodyStartsWithMarkdown) {
+      // blank line after open so the body re-parses as markdown;
       content = '\n\n' + content.trimEnd() + '\n\n'
     } else {
-      // Raw HTML / HTML-first body — keep content flush after the open tag so
-      // reparse matches CommonMark html_block runs.
       content = '\n' + paddNoneHtmlContent(content, state, String(tag)).trimEnd() + '\n'
     }
   }

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -42,6 +42,11 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   const hasTextSibling = children.some((child) => typeof child === 'string')
   const isBlock = textBlocks.has(String(tag))
   const isInline = inlineTags.has(String(tag)) && $.block === 0
+  // Incomplete HTML openers (streaming) store markdown/HTML block children under
+  // `$.block === 0`; those still need multi-line wrapping, not one-liner inline.
+  const hasBlockChildren = children.some(
+    (child) => Array.isArray(child) && child[0] !== null && !inlineTags.has(String(child[0]))
+  )
 
   let oneLiner = isBlock && hasOnlyTextChildren
 
@@ -57,7 +62,9 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
     oneLiner = true
   }
 
-  if ($.block === 0) {
+  // Inline HTML (`block: 0` with only text/inline children) collapses to one line.
+  // Incomplete block wrappers with real markdown block children stay multi-line.
+  if ($.block === 0 && !hasBlockChildren) {
     oneLiner = true
   }
 
@@ -71,8 +78,12 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
     childrenContent.push(await state.one(child, state, node))
   }
 
-  // A blank line inside a raw-HTML element would terminate it on reparse
-  const childSeparator = state.context.html ? state.context.blockSeparator : oneLiner ? '' : '\n'
+  // In markdown mode, block children already append their own blockSeparator, so
+  // we must not inject extra newlines between them. In HTML mode the separator
+  // is the pretty-print block gap. A blank line inside a *raw* HTML body would
+  // terminate the block on reparse — markdown children of incomplete openers
+  // (`$.block === 0`) intentionally use blank lines like normal markdown.
+  const childSeparator = state.context.html ? state.context.blockSeparator : ''
 
   let content = ''
   let isPrevBlock = true
@@ -106,7 +117,18 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   }
 
   if (!oneLiner && content) {
-    content = '\n' + paddNoneHtmlContent(content, state, String(tag)).trimEnd() + '\n'
+    if (state.context.html) {
+      content = '\n' + paddNoneHtmlContent(content, state, String(tag)).trimEnd() + '\n'
+    } else if ($.block === 0 && hasBlockChildren) {
+      // Incomplete HTML openers with markdown body: blank line after open tag so
+      // the body re-parses as markdown, children's own blockSeparators between
+      // blocks, single newline before close.
+      content = '\n\n' + content.trimEnd() + '\n'
+    } else {
+      // Raw HTML block body (block:1) — keep content flush after the open tag
+      // so reparse matches CommonMark html_block runs.
+      content = '\n' + paddNoneHtmlContent(content, state, String(tag)).trimEnd() + '\n'
+    }
   }
 
   return `<${tag}${attrs}>${content}</${tag}>` + (!parent && !isInline ? state.context.blockSeparator : '')

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -57,25 +57,14 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
     !inlineTags.has(String(firstMeaningfulChild[0])) &&
     !(firstMeaningfulChild[1] as Record<string, any> | undefined)?.$?.html
 
-  let oneLiner = isBlock && hasOnlyTextChildren
-
-  if (!oneLiner && inlineTags.has(String(tag)) && hasOnlyTextChildren) {
-    oneLiner = true
-  }
-  if (tag === 'pre') {
-    oneLiner = true
-  }
-
-  // If parent is a paragraph, it is inline
-  if (parent?.[0] === 'p' || state.context.inline) {
-    oneLiner = true
-  }
-
-  // Inline HTML (`block: 0` with only text/inline children) collapses to one line.
-  // Block wrappers with real block children stay multi-line.
-  if ($.block === 0 && !hasBlockChildren) {
-    oneLiner = true
-  }
+  const oneLiner =
+    tag === 'pre' ||
+    parent?.[0] === 'p' ||
+    state.context.inline ||
+    (hasOnlyTextChildren && (isBlock || inlineTags.has(String(tag)))) ||
+    // Inline HTML (`block: 0` with only text/inline children) collapses to one line.
+    // Block wrappers with real block children stay multi-line.
+    ($.block === 0 && !hasBlockChildren)
 
   const isSelfClose = selfCloseTags.has(String(tag))
 

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -137,8 +137,9 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
 
   const attrs = Object.keys(attributes).length > 0 ? ` ${htmlAttributes(attributes)}` : ''
 
+  const trail = !parent && !isInline ? state.context.blockSeparator : ''
   if (isSelfClose) {
-    return `<${tag}${attrs}>` + (!parent && !isInline ? state.context.blockSeparator : '')
+    return `<${tag}${attrs}>` + trail
   }
 
   if (!oneLiner && content) {
@@ -150,19 +151,12 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
     }
   }
 
-  return `<${tag}${attrs}>${content}</${tag}>` + (!parent && !isInline ? state.context.blockSeparator : '')
+  return `<${tag}${attrs}>${content}</${tag}>` + trail
 }
 
-// Literal-content tags whose body must be rendered verbatim (no indentation
-// re-flow). Matches the parser-side set so `<style>` / `<script>` etc. stay
-// flush-left in the output, the way they were authored.
 const LITERAL_CONTENT_TAGS = new Set(['code', 'kbd', 'pre', 'samp', 'script', 'style', 'textarea', 'var'])
 
 function paddNoneHtmlContent(content: string, state: State, tag: string) {
-  if (state.context.html) {
-    if (LITERAL_CONTENT_TAGS.has(tag.toLowerCase())) return content
-    return indent(content)
-  }
-
-  return (content.trim().startsWith('<') ? '' : '') + content + (content.trim().endsWith('>') ? '' : '')
+  if (!state.context.html || LITERAL_CONTENT_TAGS.has(tag.toLowerCase())) return content
+  return indent(content)
 }

--- a/packages/comark/src/plugins/html.ts
+++ b/packages/comark/src/plugins/html.ts
@@ -18,24 +18,76 @@
  *   plugins: [html()],
  * })
  * // → [ ['strong', { class: 'bold', $: { html: 1, block: 0 } }, 'Hello'] ]
+ *
+ * // Blank-line-only markdown nesting (CommonMark-style HTML blocks)
+ * const raw = await parseMarkdown('<div>\n**bold**\n</div>', {
+ *   plugins: [html({ markdown: false })],
+ * })
+ * // → body stays literal `**bold**` (no strong node)
+ *
+ * // Blank line still enables markdown either way:
+ * // <div>\n\n**bold**\n\n</div> → strong
  * ```
  */
 
 import type { MarkdownExit } from 'markdown-exit'
 import type { MarkdownItPlugin } from '../types.ts'
 import { defineComarkPlugin } from '../utils/helpers.ts'
-import html_block from '../internal/parse/html/html_block_rule.ts'
+import createHtmlBlockRule from '../internal/parse/html/html_block_rule.ts'
 import html_inline from '../internal/parse/html/html_inline_rule.ts'
 
-function markdownItHtml(md: MarkdownExit) {
-  md.set({ html: true })
-  md.inline.ruler.before('text', 'comark_html_inline', html_inline)
-  md.block.ruler.before('html_block', 'comark_html_block', html_block, {
-    alt: ['paragraph', 'reference', 'blockquote'],
-  })
+export interface HtmlPluginOptions {
+  /**
+   * When markdown is allowed inside / after HTML **without** a blank line.
+   *
+   * HTML nesting has two shapes:
+   *
+   * 1. **Blank-line body** (always markdown, either mode):
+   *    ```md
+   *    <div>
+   *
+   *    **bold**
+   *
+   *    </div>
+   *    ```
+   *    CommonMark ends the HTML block on the blank line, so the body is normal
+   *    markdown and is later nested under the open tag.
+   *
+   * 2. **Tight body** (no blank line after the open tag):
+   *    ```md
+   *    <div>
+   *    **bold**
+   *    </div>
+   *    ```
+   *    or incomplete / streaming:
+   *    ```md
+   *    <ai-thinking>
+   *    **bold**
+   *    ```
+   *
+   * - `true` (default): tight incomplete openers (no closer yet) still tokenize
+   *   the body as markdown. Closed tight bodies stay CommonMark-raw.
+   * - `false`: tight bodies stay raw HTML (CommonMark). Markdown only when a
+   *   blank line separates the open tag from the body.
+   *
+   * @default true
+   */
+  markdown?: boolean
 }
 
-export default defineComarkPlugin(() => ({
+function markdownItHtml(options: HtmlPluginOptions = {}) {
+  const html_block = createHtmlBlockRule({ markdown: options.markdown })
+
+  return function install(md: MarkdownExit) {
+    md.set({ html: true })
+    md.inline.ruler.before('text', 'comark_html_inline', html_inline)
+    md.block.ruler.before('html_block', 'comark_html_block', html_block, {
+      alt: ['paragraph', 'reference', 'blockquote'],
+    })
+  }
+}
+
+export default defineComarkPlugin<HtmlPluginOptions>((options = {}) => ({
   name: 'html',
-  markdownItPlugins: [markdownItHtml as unknown as MarkdownItPlugin],
+  markdownItPlugins: [markdownItHtml(options) as unknown as MarkdownItPlugin],
 }))

--- a/packages/comark/src/plugins/html.ts
+++ b/packages/comark/src/plugins/html.ts
@@ -40,31 +40,6 @@ export interface HtmlPluginOptions {
   /**
    * When markdown is allowed inside / after HTML **without** a blank line.
    *
-   * HTML nesting has two shapes:
-   *
-   * 1. **Blank-line body** (always markdown, either mode):
-   *    ```md
-   *    <div>
-   *
-   *    **bold**
-   *
-   *    </div>
-   *    ```
-   *    CommonMark ends the HTML block on the blank line, so the body is normal
-   *    markdown and is later nested under the open tag.
-   *
-   * 2. **Tight body** (no blank line after the open tag):
-   *    ```md
-   *    <div>
-   *    **bold**
-   *    </div>
-   *    ```
-   *    or incomplete / streaming:
-   *    ```md
-   *    <ai-thinking>
-   *    **bold**
-   *    ```
-   *
    * - `true` (default): tight incomplete openers (no closer yet) still tokenize
    *   the body as markdown. Closed tight bodies stay CommonMark-raw.
    * - `false`: tight bodies stay raw HTML (CommonMark). Markdown only when a

--- a/packages/comark/src/plugins/html.ts
+++ b/packages/comark/src/plugins/html.ts
@@ -50,19 +50,17 @@ export interface HtmlPluginOptions {
   markdown?: boolean
 }
 
-function markdownItHtml(options: HtmlPluginOptions = {}) {
+export default defineComarkPlugin<HtmlPluginOptions>((options = {}) => {
   const html_block = createHtmlBlockRule({ markdown: options.markdown })
-
-  return function install(md: MarkdownExit) {
+  function install(md: MarkdownExit) {
     md.set({ html: true })
     md.inline.ruler.before('text', 'comark_html_inline', html_inline)
     md.block.ruler.before('html_block', 'comark_html_block', html_block, {
       alt: ['paragraph', 'reference', 'blockquote'],
     })
   }
-}
-
-export default defineComarkPlugin<HtmlPluginOptions>((options = {}) => ({
-  name: 'html',
-  markdownItPlugins: [markdownItHtml(options) as unknown as MarkdownItPlugin],
-}))
+  return {
+    name: 'html',
+    markdownItPlugins: [install as unknown as MarkdownItPlugin],
+  }
+})

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -1,7 +1,6 @@
 import type { DumpOptions } from 'js-yaml'
 import type MarkdownExit from 'markdown-exit'
 import type MarkdownIt from 'markdown-it'
-import { HtmlPluginOptions } from './plugins/html'
 
 // #region Utility Types
 /**

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -1,6 +1,7 @@
 import type { DumpOptions } from 'js-yaml'
 import type MarkdownExit from 'markdown-exit'
 import type MarkdownIt from 'markdown-it'
+import { HtmlPluginOptions } from './plugins/html'
 
 // #region Utility Types
 /**

--- a/packages/comark/test/auto-close.test.ts
+++ b/packages/comark/test/auto-close.test.ts
@@ -22,6 +22,7 @@ Some text with **bold → Some text with **bold**
 **bold** and *italic* and \`code\` → **bold** and *italic* and \`code\`
 [text](url → [text](url)
 $$formula → $$formula$$
+The cost is $ → The cost is $
 ~Hello → ~Hello~
 ~~Hello → ~~Hello~~
 ~Hello~ → ~Hello~

--- a/packages/comark/test/auto-close.test.ts
+++ b/packages/comark/test/auto-close.test.ts
@@ -32,7 +32,11 @@ $$formula → $$formula
 _ not valid → _ not valid
 __ not valid → __ not valid
 ~ not valid → ~ not valid
-~~ not valid → ~~ not valid`
+~~ not valid → ~~ not valid
+The cost is $ → The cost is $
+~Hello → ~Hello
+~~Hello~~ → ~~Hello~~
+~~ Hello → ~~ Hello`
 
 const multilines = `
 | Month    | Savings

--- a/packages/comark/test/html-block.test.ts
+++ b/packages/comark/test/html-block.test.ts
@@ -63,9 +63,7 @@ this is **markdown**
 
 </p>`)
 
-    expect(result.nodes).toEqual([
-      ['p', { $: { html: 1, block: 1 } }, 'this is ', ['strong', {}, 'markdown']],
-    ])
+    expect(result.nodes).toEqual([['p', { $: { html: 1, block: 1 } }, 'this is ', ['strong', {}, 'markdown']]])
   })
 
   it('preserves mixed text and raw HTML children verbatim inside a multiline raw HTML block', async () => {

--- a/packages/comark/test/html-block.test.ts
+++ b/packages/comark/test/html-block.test.ts
@@ -1,7 +1,56 @@
 import { describe, expect, it } from 'vitest'
 import { parseMarkdown } from '../src/index'
+import html from '../src/plugins/html'
 
 const sponsorsUrl = 'https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg'
+
+describe('html({ markdown })', () => {
+  it('parses markdown inside incomplete HTML by default', async () => {
+    const result = await parseMarkdown('<ai-thinking>\n**bold**')
+
+    expect(result.nodes).toEqual([
+      ['ai-thinking', { $: { html: 1, block: 0 } }, ['strong', {}, 'bold']],
+    ])
+  })
+
+  it('keeps markdown literal inside incomplete HTML when markdown: false', async () => {
+    const result = await parseMarkdown('<ai-thinking>\n**bold**', {
+      // Replace the default html plugin so only this config is active.
+      plugins: [html({ markdown: false })],
+    })
+
+    // Body is a single text leaf → block: 0 (inline-like incomplete opener).
+    expect(result.nodes).toEqual([['ai-thinking', { $: { html: 1, block: 0 } }, '**bold**']])
+  })
+
+  it('still parses markdown after a blank line when markdown: false', async () => {
+    const result = await parseMarkdown('<ai-thinking>\n\n**bold**\n\n', {
+      plugins: [html({ markdown: false })],
+    })
+
+    expect(result.nodes).toEqual([
+      ['ai-thinking', { $: { html: 1, block: 0 } }, ['strong', {}, 'bold']],
+    ])
+  })
+
+  it('still keeps closed HTML body literal without a blank line when markdown: false', async () => {
+    const result = await parseMarkdown('<div>\nHello **World**\n</div>', {
+      plugins: [html({ markdown: false })],
+    })
+
+    expect(result.nodes).toEqual([['div', { $: { html: 1, block: 1 } }, 'Hello **World**']])
+  })
+
+  it('parses markdown inside closed HTML after a blank line when markdown: false', async () => {
+    const result = await parseMarkdown('<div>\n\nHello **World**\n\n</div>', {
+      plugins: [html({ markdown: false })],
+    })
+
+    expect(result.nodes).toEqual([
+      ['div', { $: { html: 1, block: 1 } }, 'Hello ', ['strong', {}, 'World']],
+    ])
+  })
+})
 
 describe('block-level raw HTML', () => {
   it('preserves inline children inside a self-contained block-level <p>', async () => {

--- a/packages/comark/test/html-block.test.ts
+++ b/packages/comark/test/html-block.test.ts
@@ -8,7 +8,7 @@ describe('block-level raw HTML', () => {
     const result = await parseMarkdown('<p><img src="/foo.png" alt="x"></p>')
 
     expect(result.nodes).toEqual([
-      ['p', { $: { html: 1, block: 1 } }, ['img', { $: { html: 1, block: 1 }, src: '/foo.png', alt: 'x' }]],
+      ['p', { $: { html: 1, block: 1 } }, ['img', { $: { html: 1, block: 0 }, src: '/foo.png', alt: 'x' }]],
     ])
   })
 
@@ -20,7 +20,7 @@ describe('block-level raw HTML', () => {
         'p',
         { $: { html: 1, block: 1 } },
         'hello',
-        ['img', { $: { html: 1, block: 1 }, src: '/foo.png', alt: 'x' }],
+        ['img', { $: { html: 1, block: 0 }, src: '/foo.png', alt: 'x' }],
         'world',
       ],
     ])
@@ -37,7 +37,7 @@ That is some text here.`
 
     expect(result.nodes).toEqual([
       ['h1', { id: 'hello' }, 'Hello'],
-      ['p', { $: { html: 1, block: 1 } }, ['img', { $: { html: 1, block: 1 }, src: '/foo.png', alt: 'x' }]],
+      ['p', { $: { html: 1, block: 1 } }, ['img', { $: { html: 1, block: 0 }, src: '/foo.png', alt: 'x' }]],
       ['p', {}, 'That is some text here.'],
     ])
   })
@@ -78,7 +78,7 @@ this is **markdown**
         'div',
         { $: { html: 1, block: 1 } },
         'before **strong**',
-        ['img', { $: { html: 1, block: 1 }, src: '/x.png', alt: 'x' }],
+        ['img', { $: { html: 1, block: 0 }, src: '/x.png', alt: 'x' }],
         'after `code`',
       ],
     ])
@@ -121,7 +121,7 @@ after \`code\`
 </div>`)
 
     expect(result.nodes).toEqual([
-      ['div', { $: { html: 1, block: 1 } }, [null, {}, ' note '], ['img', { $: { html: 1, block: 1 }, src: '/x.png' }]],
+      ['div', { $: { html: 1, block: 1 } }, [null, {}, ' note '], ['img', { $: { html: 1, block: 0 }, src: '/x.png' }]],
     ])
   })
 
@@ -134,7 +134,7 @@ after \`code\`
       [
         'a',
         { $: { html: 1, block: 1 }, href: sponsorsUrl },
-        ['img', { $: { html: 1, block: 1 }, src: sponsorsUrl, alt: 'Sponsors' }],
+        ['img', { $: { html: 1, block: 0 }, src: sponsorsUrl, alt: 'Sponsors' }],
       ],
     ])
   })
@@ -152,8 +152,8 @@ after \`code\`
         { $: { html: 1, block: 1 }, align: 'center' },
         [
           'a',
-          { $: { html: 1, block: 1 }, href: sponsorsUrl },
-          ['img', { $: { html: 1, block: 1 }, src: sponsorsUrl, alt: 'Sponsors' }],
+          { $: { html: 1, block: 0 }, href: sponsorsUrl },
+          ['img', { $: { html: 1, block: 0 }, src: sponsorsUrl, alt: 'Sponsors' }],
         ],
       ],
     ])

--- a/packages/comark/test/html-block.test.ts
+++ b/packages/comark/test/html-block.test.ts
@@ -56,7 +56,7 @@ That is some text here.`
     expect(result.nodes).toEqual([['p', { $: { html: 1, block: 1 } }, 'this is **markdown**']])
   })
 
-  it('parses markdown as a sibling when a blank line separates it from the HTML tags', async () => {
+  it('nests blank-line markdown body under a matching HTML open/close pair', async () => {
     const result = await parseMarkdown(`<p>
 
 this is **markdown**
@@ -64,9 +64,7 @@ this is **markdown**
 </p>`)
 
     expect(result.nodes).toEqual([
-      ['p', { $: { html: 1, block: 1 } }],
-      ['p', {}, 'this is ', ['strong', {}, 'markdown']],
-      ['p', { $: { html: 1, block: 1 } }],
+      ['p', { $: { html: 1, block: 1 } }, 'this is ', ['strong', {}, 'markdown']],
     ])
   })
 
@@ -88,7 +86,7 @@ this is **markdown**
     ])
   })
 
-  it('parses markdown and raw HTML as siblings when blank lines separate them', async () => {
+  it('nests blank-line markdown and HTML under a matching open/close pair', async () => {
     const result = await parseMarkdown(`<div>
 
 before **strong**
@@ -100,10 +98,13 @@ after \`code\`
 </div>`)
 
     expect(result.nodes).toEqual([
-      ['div', { $: { html: 1, block: 1 } }],
-      ['p', {}, 'before ', ['strong', {}, 'strong']],
-      ['img', { $: { html: 1, block: 1 }, src: '/x.png', alt: 'x' }],
-      ['p', {}, 'after ', ['code', {}, 'code']],
+      [
+        'div',
+        { $: { html: 1, block: 1 } },
+        ['p', {}, 'before ', ['strong', {}, 'strong']],
+        ['img', { $: { html: 1, block: 1 }, src: '/x.png', alt: 'x' }],
+        ['p', {}, 'after ', ['code', {}, 'code']],
+      ],
     ])
   })
 

--- a/packages/comark/test/html-block.test.ts
+++ b/packages/comark/test/html-block.test.ts
@@ -8,9 +8,7 @@ describe('html({ markdown })', () => {
   it('parses markdown inside incomplete HTML by default', async () => {
     const result = await parseMarkdown('<ai-thinking>\n**bold**')
 
-    expect(result.nodes).toEqual([
-      ['ai-thinking', { $: { html: 1, block: 0 } }, ['strong', {}, 'bold']],
-    ])
+    expect(result.nodes).toEqual([['ai-thinking', { $: { html: 1, block: 0 } }, ['strong', {}, 'bold']]])
   })
 
   it('keeps markdown literal inside incomplete HTML when markdown: false', async () => {
@@ -28,9 +26,7 @@ describe('html({ markdown })', () => {
       plugins: [html({ markdown: false })],
     })
 
-    expect(result.nodes).toEqual([
-      ['ai-thinking', { $: { html: 1, block: 0 } }, ['strong', {}, 'bold']],
-    ])
+    expect(result.nodes).toEqual([['ai-thinking', { $: { html: 1, block: 0 } }, ['strong', {}, 'bold']]])
   })
 
   it('still keeps closed HTML body literal without a blank line when markdown: false', async () => {
@@ -46,9 +42,7 @@ describe('html({ markdown })', () => {
       plugins: [html({ markdown: false })],
     })
 
-    expect(result.nodes).toEqual([
-      ['div', { $: { html: 1, block: 1 } }, 'Hello ', ['strong', {}, 'World']],
-    ])
+    expect(result.nodes).toEqual([['div', { $: { html: 1, block: 1 } }, 'Hello ', ['strong', {}, 'World']]])
   })
 })
 

--- a/packages/comark/test/html-escape.test.ts
+++ b/packages/comark/test/html-escape.test.ts
@@ -49,6 +49,16 @@ describe('HTML attribute escaping', () => {
     expect(html).toContain('title="a&amp;b&lt;c&gt;d"')
   })
 
+  it('escapes bare ampersands in URL attribute values', async () => {
+    // Query-string `&` must become `&amp;` in HTML attrs (HTML5).
+    // Re-parse still yields bare `&` because htmlparser2 decodes entities.
+    const html = await renderHtml(`<img src="https://x.com/?a=1&b=2" alt="x">`)
+    expect(html).toContain('src="https://x.com/?a=1&amp;b=2"')
+    const tree = await parseMarkdown(html)
+    const img = tree.nodes[0] as [string, Record<string, unknown>]
+    expect(img[1].src).toBe('https://x.com/?a=1&b=2')
+  })
+
   it('escapes object attribute values as JSON with entities', async () => {
     const html = await renderNodes([['div', { ':data': { x: '"><img src=x onerror=alert(1)>' } }, 'hi']])
     expect(html).not.toContain('<img src=x onerror=alert(1)>')

--- a/packages/comark/test/index.test.ts
+++ b/packages/comark/test/index.test.ts
@@ -269,6 +269,7 @@ describe('Comark Tests', () => {
           },
         })
         const expectedHTML = testCase.html.trim()
+        console.log(result)
         expect(result).toBe(expectedHTML)
       })
 


### PR DESCRIPTION
### What

Incomplete block HTML open tags (e.g. streaming `<ai-thinking>…` with no closer) now wrap following markdown as children with `$: { html: 1, block: 0 }`, including the single-newline case where CommonMark would otherwise swallow the body into one raw `html_block`.

### Why

During AI/streaming output, custom tags often arrive without a closing tag yet. The previous CommonMark-faithful path left the opener empty and the body as siblings, so renderers could not keep the unfinished element around its content. Blank-line-terminated incomplete openers were fixed first; the blank-line-less case still needed the block rule to stop at the opener line so the token processor can absorb the rest.