### PR TITLE
feat(comark): support custom auto-close functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,7 +517,7 @@ describe('functionUnderTest', () => {
 ```typescript
 const result = await parseMarkdown(markdownContent, {
   autoUnwrap: true,             // Remove <p> wrappers from single-paragraph containers
-  autoClose: true,              // Auto-close incomplete syntax
+  autoClose: true,              // Auto-close incomplete syntax; also accepts (markdown) => string
   unwrap: 'p',                  // Strip top-level wrapper tags (MDC unwrap); merges paragraphs
   registerDefaultPlugins: true, // frontmatter, html, alert, task-list, components, attributes; false to disable
 })

--- a/docs/content/5.reference/1.parse.md
+++ b/docs/content/5.reference/1.parse.md
@@ -360,7 +360,7 @@ Both `parseMarkdown()` and `createMarkdownParser()` accept the same `ParserOptio
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `autoUnwrap` | `boolean` | `true` | Remove unnecessary `<p>` wrappers from single-element containers |
-| `autoClose` | `boolean` | `true` | Auto-close incomplete markdown syntax |
+| `autoClose` | `boolean \| (markdown: string) => string` | `true` | Auto-close incomplete markdown syntax, or use a custom completion function |
 | `unwrap` | `boolean \| string \| string[]` | `false` | Remove wrapper tags from the tree, hoisting their children (MDC `unwrap` behaviour). `true` unwraps `p`; a comma/whitespace-separated string or array unwraps the listed tags; `'*'` matches any tag. Tags apply sequentially (each descends one level), and adjacent text is merged into a single string. |
 | `html` | `boolean` | `true` | **Deprecated** (warns). Prefer `registerDefaultPlugins: false` and register `html()` explicitly. `html: false` still skips the default html plugin. |
 | `linkify` | `boolean` | `true` | Auto-convert URL-like text into links. Set `false` to disable |

--- a/docs/content/5.reference/2.auto-close.md
+++ b/docs/content/5.reference/2.auto-close.md
@@ -45,7 +45,7 @@ autoCloseMarkdown('**bold text')
 
 ### Parser integration
 
-`autoClose` is enabled by default in `parseMarkdown()` and `createMarkdownParser()`. You can disable it if you want to handle incomplete syntax yourself:
+`autoClose` is enabled by default in `parseMarkdown()` and `createMarkdownParser()`. You can disable it or provide a custom completion function:
 
 ::code-group
 ```typescript [Enabled (default)]
@@ -70,7 +70,17 @@ import { autoCloseMarkdown, parseMarkdown } from 'comark'
 const closed = autoCloseMarkdown(content)
 const result = await parseMarkdown(closed, { autoClose: false })
 ```
+
+```typescript [Custom]
+import { createMarkdownParser } from 'comark'
+
+const parse = createMarkdownParser({
+  autoClose: markdown => completeMarkdown(markdown)
+})
+```
 ::
+
+During incremental parsing with `{ streaming: true }`, the custom function receives only the unstable tail that Comark still needs to parse. On a regular parse, it receives the full input. The function must return the markdown string to tokenize.
 
 ### Supported syntax
 

--- a/docs/content/5.reference/3.reference.md
+++ b/docs/content/5.reference/3.reference.md
@@ -296,7 +296,7 @@ type Node =
 ```typescript
 interface ParserOptions {
   autoUnwrap?: boolean              // default: true
-  autoClose?: boolean               // default: true
+  autoClose?: boolean | AutoCloseFunction // default: true
   unwrap?: boolean | string | string[]  // strip top-level wrapper tags, e.g. 'p' (default: false)
   /** @deprecated Prefer registerDefaultPlugins: false */
   html?: boolean                    // default: true

--- a/packages/comark/src/parse.ts
+++ b/packages/comark/src/parse.ts
@@ -138,7 +138,9 @@ export function createMarkdownParser<const TPlugins extends readonly ComarkPlugi
         state.reusableNodes = reusedNodes
       }
 
-      if (autoClose) {
+      if (typeof autoClose === 'function') {
+        state.markdown = withSpan(tracer, 'comark:autoclose', () => autoClose(state.markdown))
+      } else if (autoClose) {
         state.markdown = withSpan(tracer, 'comark:autoclose', () =>
           autoCloseMarkdown(state.markdown, {
             frontmatter: hasPlugin('frontmatter') && opts.streaming,

--- a/packages/comark/src/types.ts
+++ b/packages/comark/src/types.ts
@@ -411,6 +411,15 @@ export interface ComarkContextProvider {
   componentManifest: ComponentManifest
 }
 
+/**
+ * Rewrites incomplete markdown before Comark tokenizes it.
+ *
+ * In streaming mode, `markdown` is the unstable tail left after Comark reuses
+ * stable nodes from the previous parse. Outside streaming mode, it is the full
+ * input string.
+ */
+export type AutoCloseFunction = (markdown: string) => string
+
 export interface ParserOptions<TPlugins extends readonly ComarkPlugin<any, any>[] = readonly ComarkPlugin<any, any>[]> {
   /**
    * Whether to automatically unwrap single paragraphs in container components.
@@ -453,10 +462,11 @@ export interface ParserOptions<TPlugins extends readonly ComarkPlugin<any, any>[
   unwrap?: boolean | string | string[]
 
   /**
-   * Whether to automatically close unclosed markdown and Comark components.
+   * Whether to automatically close unclosed markdown and Comark components,
+   * or a custom function that rewrites incomplete markdown before tokenization.
    * @default true
    */
-  autoClose?: boolean
+  autoClose?: boolean | AutoCloseFunction
 
   /**
    * @deprecated Use `registerDefaultPlugins: false` and register plugins explicitly

--- a/packages/comark/test/streaming.test.ts
+++ b/packages/comark/test/streaming.test.ts
@@ -258,6 +258,40 @@ describe('streaming mode', () => {
       const result = await parse('# Hello\n\nWorld.\n', { streaming: true })
       expect(result.nodes).toHaveLength(2)
     })
+
+    it('accepts a custom autoClose function', async () => {
+      const inputs: string[] = []
+      const parse = createMarkdownParser({
+        autoClose: (markdown) => {
+          inputs.push(markdown)
+          return markdown.replace('**bold', '**bold**')
+        },
+      })
+
+      const result = await parse('Some **bold', { streaming: true })
+
+      expect(inputs).toEqual(['Some **bold'])
+      const paragraph = result.nodes[0] as ElementNode
+      expect(paragraph.slice(2).some((child) => Array.isArray(child) && child[0] === 'strong')).toBe(true)
+    })
+
+    it('passes only the unstable tail to a custom autoClose function on subsequent parses', async () => {
+      const inputs: string[] = []
+      const parse = createMarkdownParser({
+        autoClose: (markdown) => {
+          inputs.push(markdown)
+          return markdown
+        },
+      })
+
+      await parse('# Title\n\nStable paragraph.\n\nPart', { streaming: true })
+      inputs.length = 0
+      await parse('# Title\n\nStable paragraph.\n\nPartial tail', { streaming: true })
+
+      expect(inputs).toHaveLength(1)
+      expect(inputs[0]).not.toContain('Stable paragraph')
+      expect(inputs[0].trim()).toBe('Partial tail')
+    })
   })
 
   describe('streaming with autoUnwrap interaction', () => {


### PR DESCRIPTION
### What

Allow `ParserOptions.autoClose` to accept a custom function. In streaming mode, it receives only the unstable tail.

### Why

This enables custom completion rules while preserving Comark’s incremental parsing. Closes #391.