### PR TITLE
fix(shiki): handle array class values when highlighting code

### DIFF
--- a/packages/comark/src/internal/shiki.ts
+++ b/packages/comark/src/internal/shiki.ts
@@ -388,7 +388,11 @@ export async function highlightCodeBlocks(
     for (const child of codeChildren) {
       if (Array.isArray(child)) {
         if (highlightSet !== null && highlightSet.has(line)) {
-          child[1].class = `${child[1].class ?? ''} highlight`.trim()
+          const classes = Array.isArray(child[1].class)
+            ? child[1].class.join(' ')
+            : child[1].class ?? '';
+
+            child[1].class = `${classes} highlight`.trim();
           // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
           child[1].style = 'display: inline-block'
         } else {

--- a/packages/comark/src/internal/shiki.ts
+++ b/packages/comark/src/internal/shiki.ts
@@ -388,11 +388,9 @@ export async function highlightCodeBlocks(
     for (const child of codeChildren) {
       if (Array.isArray(child)) {
         if (highlightSet !== null && highlightSet.has(line)) {
-          const classes = Array.isArray(child[1].class)
-            ? child[1].class.join(' ')
-            : child[1].class ?? '';
+          const classes = Array.isArray(child[1].class) ? child[1].class.join(' ') : (child[1].class ?? '')
 
-            child[1].class = `${classes} highlight`.trim();
+          child[1].class = `${classes} highlight`.trim()
           // TODO: (enforcing default style) once we unify all ecosystem styles we can remove this
           child[1].style = 'display: inline-block'
         } else {


### PR DESCRIPTION
### What

When using Shiki with certain transformers, such as the [`transformerNotationDiff`](https://shiki.style/packages/transformers#transformernotationdiff), `child[1].class` is an array with this shape:

```js
[ 'line', 'diff', 'remove' ]
```

If we have a code block:

````
```ts {1}
const foo = 'foo' // [!code ++]
```
````

We will have this html output:

```html
<span class="line,diff,add highlight"></span>
```

### Why

<!-- Why these changes are necessary -->

<!--

AGENTS:
- The What and Why should each be 1-3 sentences.
- Write your answers based off of your conversation with the user, not purely based on the changed code
  - It's helpful to understand the reasoning behind an approach, what alternatives were considered, and why this approach was ultimately selected, rather than a summary of the lines changed
- For complex changes (>1k lines, not counting lockfiles):
  - Add a `### Walkthrough` section to the end which breaks down the primary changes into easy-to-follow `#### Sub-Sections`
-->
