### PR TITLE
chore: enable removeComments in package tsconfigs

### DIFF
--- a/packages/comark-angular/package.json
+++ b/packages/comark-angular/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "stub": "node ../../scripts/stub.mjs",
-    "build": "ngc -p tsconfig.json && node scripts/verify-build.mjs",
+    "build": "ngc -p tsconfig.json && ngc -p tsconfig.json --removeComments true --declaration false && node scripts/verify-build.mjs",
     "dev": "ngc -p tsconfig.json --watch",
     "test": "vitest run",
     "prepack": "pnpm run build",

--- a/packages/comark-ansi/package.json
+++ b/packages/comark-ansi/package.json
@@ -41,10 +41,10 @@
   },
   "scripts": {
     "stub": "node ../../scripts/stub.mjs",
-    "build": "tsc",
+    "build": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "prepack": "tsc",
+    "prepack": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "release": "release-it"
   },
   "dependencies": {

--- a/packages/comark-html/package.json
+++ b/packages/comark-html/package.json
@@ -40,10 +40,10 @@
   },
   "scripts": {
     "stub": "node ../../scripts/stub.mjs",
-    "build": "tsc",
+    "build": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "prepack": "tsc",
+    "prepack": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "release": "release-it"
   },
   "dependencies": {

--- a/packages/comark-nuxt/package.json
+++ b/packages/comark-nuxt/package.json
@@ -42,10 +42,10 @@
   },
   "scripts": {
     "stub": "node ../../scripts/stub.mjs",
-    "build": "tsc",
+    "build": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "dev": "tsc --watch",
     "test": "vitest run --passWithNoTests",
-    "prepack": "tsc",
+    "prepack": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "release": "release-it"
   },
   "dependencies": {

--- a/packages/comark-react/package.json
+++ b/packages/comark-react/package.json
@@ -43,10 +43,10 @@
   },
   "scripts": {
     "stub": "node ../../scripts/stub.mjs",
-    "build": "tsc",
+    "build": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "prepack": "tsc",
+    "prepack": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "release": "release-it"
   },
   "dependencies": {

--- a/packages/comark-svelte/package.json
+++ b/packages/comark-svelte/package.json
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "stub": "node ../../scripts/stub.mjs",
-    "build": "svelte-package --input src && node ../../scripts/sync-plugins.mjs",
+    "build": "svelte-package --input src && svelte-package --input src --types false --preserve-output --tsconfig ./tsconfig.build.json && node ../../scripts/sync-plugins.mjs",
     "build:watch": "svelte-package --input src --watch",
     "test": "vitest run",
     "check": "svelte-check --tsconfig ./tsconfig.json",

--- a/packages/comark-svelte/tsconfig.build.json
+++ b/packages/comark-svelte/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2024",
+    "lib": ["esnext", "DOM", "DOM.Iterable"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "skipDefaultLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "removeComments": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/comark-vue/package.json
+++ b/packages/comark-vue/package.json
@@ -42,10 +42,10 @@
   },
   "scripts": {
     "stub": "node ../../scripts/stub.mjs",
-    "build": "tsc",
+    "build": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "prepack": "tsc",
+    "prepack": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "release": "release-it"
   },
   "dependencies": {

--- a/packages/comark/package.json
+++ b/packages/comark/package.json
@@ -51,10 +51,10 @@
   },
   "scripts": {
     "stub": "node ../../scripts/stub.mjs",
-    "build": "tsc",
+    "build": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "prepack": "tsc",
+    "prepack": "tsc --removeComments --declaration false && tsc --emitDeclarationOnly",
     "release": "release-it",
     "release:dry": "release-it --dry-run"
   },

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -60,14 +60,14 @@ describe('package bundle size', { timeout: 60_000 }, () => {
 
     expect(report).toMatchInlineSnapshot(`
       {
-        "@comark/angular": "60.6k (70 files)",
-        "@comark/ansi": "42.0k (98 files)",
-        "@comark/html": "18.9k (58 files)",
+        "@comark/angular": "54.0k (70 files)",
+        "@comark/ansi": "36.6k (98 files)",
+        "@comark/html": "15.7k (58 files)",
         "@comark/nuxt": "11.8k (58 files)",
-        "@comark/react": "43.6k (74 files)",
+        "@comark/react": "36.9k (74 files)",
         "@comark/svelte": "43.9k (82 files)",
-        "@comark/vue": "60.5k (78 files)",
-        "comark": "440k (156 files)",
+        "@comark/vue": "51.7k (78 files)",
+        "comark": "363k (156 files)",
       }
     `)
   })


### PR DESCRIPTION
### What

Enable `"removeComments": true` in every publishable package `tsconfig.json` so TypeScript strips comments from emitted JS during builds.

### Why

Published package output should not carry source comments. Scoping this to `packages/*` keeps examples/docs/root configs unchanged.