### PR TITLE
fix(html): generate html5 style self-closing tags

### DIFF
--- a/packages/comark/SPEC/COMARK/attribute-image.md
+++ b/packages/comark/SPEC/COMARK/attribute-image.md
@@ -58,7 +58,7 @@ Here ![alt](https://example.com/image.jpg){bool} ![alt](https://example.com/imag
 ## HTML
 
 ```html
-<p>Here <img src="https://example.com/image.jpg" alt="alt" bool /> <img src="https://example.com/image.jpg" alt="alt" id="id1" /> <img src="https://example.com/image.jpg" alt="alt" class="class1" /> <img src="https://example.com/image.jpg" alt="alt" attr="value" /></p>
+<p>Here <img src="https://example.com/image.jpg" alt="alt" bool> <img src="https://example.com/image.jpg" alt="alt" id="id1"> <img src="https://example.com/image.jpg" alt="alt" class="class1"> <img src="https://example.com/image.jpg" alt="alt" attr="value"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/attributes/paragraph+span.md
+++ b/packages/comark/SPEC/COMARK/attributes/paragraph+span.md
@@ -19,13 +19,23 @@ A paragraph [span]{attr="value"}
         "attr": "value"
       },
       "A paragraph ",
-      ["span", {}, "span"]
+      [
+        "span",
+        {},
+        "span"
+      ]
     ],
     [
       "p",
       {},
       "A paragraph ",
-      ["span", { "attr": "value" }, "span"]
+      [
+        "span",
+        {
+          "attr": "value"
+        },
+        "span"
+      ]
     ]
   ]
 }

--- a/packages/comark/SPEC/COMARK/attributes/task-list.md
+++ b/packages/comark/SPEC/COMARK/attributes/task-list.md
@@ -60,10 +60,10 @@
 ```html
 <ul class="contains-task-list">
   <li class="task-list-item" attr="value">
-    <input class="task-list-item-checkbox" type="checkbox" disabled /> Task list item
+    <input class="task-list-item-checkbox" type="checkbox" disabled> Task list item
   </li>
   <li class="task-list-item" attr2="value2">
-    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Task list item
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked> Task list item
   </li>
 </ul>
 ```

--- a/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
+++ b/packages/comark/SPEC/COMARK/attributes/wrapped-pre-highlighted.md
@@ -37,55 +37,55 @@ const variable = "value"
         {
           "class": "language-ts"
         },
-         [
-           "span",
-           {
-             "class": "line",
-             "style": "display: inline"
-           },
-           [
-             "span",
-             {
-               "style": "color:#D32F2F;--shiki-dark:#81A1C1"
-             },
-             "const"
-           ],
-           [
-             "span",
-             {
-               "style": "color:#1976D2;--shiki-dark:#D8DEE9"
-             },
-             " variable"
-           ],
-           [
-             "span",
-             {
-               "style": "color:#D32F2F;--shiki-dark:#81A1C1"
-             },
-             " ="
-           ],
-           [
-             "span",
-             {
-               "style": "color:#22863A;--shiki-dark:#ECEFF4"
-             },
-             " \""
-           ],
-           [
-             "span",
-             {
-               "style": "color:#22863A;--shiki-dark:#A3BE8C"
-             },
-             "value"
-           ],
-           [
-             "span",
-             {
-               "style": "color:#22863A;--shiki-dark:#ECEFF4"
-             },
-             "\""
-           ]
-         ]
+        [
+          "span",
+          {
+            "class": "line",
+            "style": "display: inline"
+          },
+          [
+            "span",
+            {
+              "style": "color:#D32F2F;--shiki-dark:#81A1C1"
+            },
+            "const"
+          ],
+          [
+            "span",
+            {
+              "style": "color:#1976D2;--shiki-dark:#D8DEE9"
+            },
+            " variable"
+          ],
+          [
+            "span",
+            {
+              "style": "color:#D32F2F;--shiki-dark:#81A1C1"
+            },
+            " ="
+          ],
+          [
+            "span",
+            {
+              "style": "color:#22863A;--shiki-dark:#ECEFF4"
+            },
+            " \""
+          ],
+          [
+            "span",
+            {
+              "style": "color:#22863A;--shiki-dark:#A3BE8C"
+            },
+            "value"
+          ],
+          [
+            "span",
+            {
+              "style": "color:#22863A;--shiki-dark:#ECEFF4"
+            },
+            "\""
+          ]
+        ]
       ]
     ]
   ]

--- a/packages/comark/SPEC/COMARK/component-with-heading.md
+++ b/packages/comark/SPEC/COMARK/component-with-heading.md
@@ -62,7 +62,7 @@ Text content
 ```html
 <steps>
   <h3 id="step-1">Step 1</h3>
-  <p><img src="https://example.com/image.jpg" alt="Image" /></p>
+  <p><img src="https://example.com/image.jpg" alt="Image"></p>
   <h3 id="step-2">Step 2</h3>
   <p>Text content</p>
 </steps>

--- a/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break-named-slot.md
+++ b/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break-named-slot.md
@@ -27,12 +27,32 @@ Line three
       {},
       [
         "template",
-        { "name": "description" },
-        ["p", {}, "Line one"],
-        ["hr", {}],
-        ["p", {}, "Middle line"],
-        ["hr", {}],
-        ["p", {}, "Line three"]
+        {
+          "name": "description"
+        },
+        [
+          "p",
+          {},
+          "Line one"
+        ],
+        [
+          "hr",
+          {}
+        ],
+        [
+          "p",
+          {},
+          "Middle line"
+        ],
+        [
+          "hr",
+          {}
+        ],
+        [
+          "p",
+          {},
+          "Line three"
+        ]
       ]
     ]
   ]
@@ -45,9 +65,9 @@ Line three
 <card>
   <template name="description">
     <p>Line one</p>
-    <hr />
+    <hr>
     <p>Middle line</p>
-    <hr />
+    <hr>
     <p>Line three</p>
   </template>
 </card>

--- a/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break.md
+++ b/packages/comark/SPEC/COMARK/component-yaml-props-thematic-break.md
@@ -24,11 +24,29 @@ Below
     [
       "card",
       {},
-      ["p", {}, "Above"],
-      ["hr", {}],
-      ["p", {}, "Middle text"],
-      ["hr", {}],
-      ["p", {}, "Below"]
+      [
+        "p",
+        {},
+        "Above"
+      ],
+      [
+        "hr",
+        {}
+      ],
+      [
+        "p",
+        {},
+        "Middle text"
+      ],
+      [
+        "hr",
+        {}
+      ],
+      [
+        "p",
+        {},
+        "Below"
+      ]
     ]
   ]
 }
@@ -39,9 +57,9 @@ Below
 ```html
 <card>
   <p>Above</p>
-  <hr />
+  <hr>
   <p>Middle text</p>
-  <hr />
+  <hr>
   <p>Below</p>
 </card>
 ```

--- a/packages/comark/SPEC/COMARK/emoji-inside-component-autounwrap.md
+++ b/packages/comark/SPEC/COMARK/emoji-inside-component-autounwrap.md
@@ -29,12 +29,16 @@ options:
   "nodes": [
     [
       "alert",
-      { "type": "success" },
+      {
+        "type": "success"
+      },
       "✅ Successfully deployed! 🚀"
     ],
     [
       "alert",
-      { "type": "warning" },
+      {
+        "type": "warning"
+      },
       "⚠️ Please backup your data before proceeding"
     ]
   ]

--- a/packages/comark/SPEC/COMARK/emoji-inside-component.md
+++ b/packages/comark/SPEC/COMARK/emoji-inside-component.md
@@ -29,12 +29,16 @@ options:
   "nodes": [
     [
       "alert",
-      { "type": "success" },
+      {
+        "type": "success"
+      },
       "✅ Successfully deployed! 🚀"
     ],
     [
       "alert",
-      { "type": "warning" },
+      {
+        "type": "warning"
+      },
       "⚠️ Please backup your data before proceeding"
     ]
   ]

--- a/packages/comark/SPEC/COMARK/frontmatter-empty.md
+++ b/packages/comark/SPEC/COMARK/frontmatter-empty.md
@@ -35,8 +35,8 @@
 ## HTML
 
 ```html
-<hr />
-<hr />
+<hr>
+<hr>
 <h1 id="content">Content</h1>
 ```
 

--- a/packages/comark/SPEC/COMARK/frontmatter-unclosed-is-thematic-break.md
+++ b/packages/comark/SPEC/COMARK/frontmatter-unclosed-is-thematic-break.md
@@ -30,7 +30,7 @@
 ## HTML
 
 ```html
-<hr />
+<hr>
 <h1 id="heading">Heading</h1>
 ```
 

--- a/packages/comark/SPEC/COMARK/image-attribute.md
+++ b/packages/comark/SPEC/COMARK/image-attribute.md
@@ -58,7 +58,7 @@ Here ![alt](https://example.com/image.jpg){bool} ![alt](https://example.com/imag
 ## HTML
 
 ```html
-<p>Here <img src="https://example.com/image.jpg" alt="alt" bool /> <img src="https://example.com/image.jpg" alt="alt" id="id1" /> <img src="https://example.com/image.jpg" alt="alt" class="class1" /> <img src="https://example.com/image.jpg" alt="alt" attr="value" /></p>
+<p>Here <img src="https://example.com/image.jpg" alt="alt" bool> <img src="https://example.com/image.jpg" alt="alt" id="id1"> <img src="https://example.com/image.jpg" alt="alt" class="class1"> <img src="https://example.com/image.jpg" alt="alt" attr="value"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/image-no-alt.md
+++ b/packages/comark/SPEC/COMARK/image-no-alt.md
@@ -28,7 +28,7 @@
 ## HTML
 
 ```html
-<p><img src="/my/cool/path" /></p>
+<p><img src="/my/cool/path"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/image-title.md
+++ b/packages/comark/SPEC/COMARK/image-title.md
@@ -36,7 +36,7 @@
           "alt": "alt",
           "title": "A title",
           "class": "rounded-asymmetric",
-          "width":"200"
+          "width": "200"
         }
       ]
     ]
@@ -47,8 +47,8 @@
 ## HTML
 
 ```html
-<p><img src="https://example.com/image.jpg" title="title" alt="alt" attr="value" /></p>
-<p><img src="img.png" title="A title" alt="alt" class="rounded-asymmetric" width="200" /></p>
+<p><img src="https://example.com/image.jpg" title="title" alt="alt" attr="value"></p>
+<p><img src="img.png" title="A title" alt="alt" class="rounded-asymmetric" width="200"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/COMARK/link-with-span.md
+++ b/packages/comark/SPEC/COMARK/link-with-span.md
@@ -9,54 +9,45 @@
 ## AST
 
 ```json
-
 {
-   "frontmatter":{
-      
-   },
-   "meta":{
-      
-   },
-   "nodes":[
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {},
       [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"#"
-            },
-            [
-              "span",
-              {},
-              "1"
-            ],
-            " Document"
-         ]
-      ],
-      [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"https://example.com"
-            },
-            [
-              "span",
-              {
-                "class": "cls"
-              },
-              "link-name"
-            ],
-            " more"
-         ]
+        "a",
+        {
+          "href": "#"
+        },
+        [
+          "span",
+          {},
+          "1"
+        ],
+        " Document"
       ]
-   ]
+    ],
+    [
+      "p",
+      {},
+      [
+        "a",
+        {
+          "href": "https://example.com"
+        },
+        [
+          "span",
+          {
+            "class": "cls"
+          },
+          "link-name"
+        ],
+        " more"
+      ]
+    ]
+  ]
 }
 ```
 

--- a/packages/comark/SPEC/COMARK/wrapped-emoji-inside-component.md
+++ b/packages/comark/SPEC/COMARK/wrapped-emoji-inside-component.md
@@ -30,7 +30,9 @@ options:
   "nodes": [
     [
       "alert",
-      { "type": "success" },
+      {
+        "type": "success"
+      },
       [
         "p",
         {},
@@ -39,7 +41,9 @@ options:
     ],
     [
       "alert",
-      { "type": "warning" },
+      {
+        "type": "warning"
+      },
       [
         "p",
         {},

--- a/packages/comark/SPEC/GFM/task-list-multiple.md
+++ b/packages/comark/SPEC/GFM/task-list-multiple.md
@@ -82,13 +82,13 @@ timeout:
 ```html
 <ul class="contains-task-list">
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Done
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked> Done
   </li>
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Done
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked> Done
   </li>
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled /> todo
+    <input class="task-list-item-checkbox" type="checkbox" disabled> todo
   </li>
 </ul>
 ```

--- a/packages/comark/SPEC/GFM/task-list.md
+++ b/packages/comark/SPEC/GFM/task-list.md
@@ -65,10 +65,10 @@ timeout:
 ```html
 <ul class="contains-task-list">
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled checked /> Done
+    <input class="task-list-item-checkbox" type="checkbox" disabled checked> Done
   </li>
   <li class="task-list-item">
-    <input class="task-list-item-checkbox" type="checkbox" disabled /> todo
+    <input class="task-list-item-checkbox" type="checkbox" disabled> todo
   </li>
 </ul>
 ```

--- a/packages/comark/SPEC/HTML/block+component.md
+++ b/packages/comark/SPEC/HTML/block+component.md
@@ -18,7 +18,10 @@ Default Slot
     [
       "hello",
       {
-        "$": { "html": 1, "block": 1 }
+        "$": {
+          "html": 1,
+          "block": 1
+        }
       },
       "::component\nDefault Slot\n::"
     ]

--- a/packages/comark/SPEC/HTML/block+inline-children.md
+++ b/packages/comark/SPEC/HTML/block+inline-children.md
@@ -14,12 +14,18 @@
     [
       "p",
       {
-        "$": { "html": 1, "block": 1 }
+        "$": {
+          "html": 1,
+          "block": 1
+        }
       },
       [
         "img",
         {
-          "$": { "html": 1, "block": 1 },
+          "$": {
+            "html": 1,
+            "block": 1
+          },
           "src": "/foo.png",
           "alt": "x"
         }
@@ -32,11 +38,11 @@
 ## HTML
 
 ```html
-<p><img src="/foo.png" alt="x" /></p>
+<p><img src="/foo.png" alt="x"></p>
 ```
 
 ## Markdown
 
 ```md
-<p><img src="/foo.png" alt="x" /></p>
+<p><img src="/foo.png" alt="x"></p>
 ```

--- a/packages/comark/SPEC/HTML/block.md
+++ b/packages/comark/SPEC/HTML/block.md
@@ -16,7 +16,10 @@ Hello **World**
     [
       "hello",
       {
-        "$": { "html": 1, "block": 1 }
+        "$": {
+          "html": 1,
+          "block": 1
+        }
       },
       "Hello **World**"
     ]

--- a/packages/comark/SPEC/HTML/inline-2.md
+++ b/packages/comark/SPEC/HTML/inline-2.md
@@ -1,7 +1,7 @@
 ## Input
 
 ```md
-<Hello>Hello **World**</Hello>
+<span>Hello **World**</span>
 ```
 
 ## AST
@@ -15,7 +15,7 @@
       "p",
       {},
       [
-        "hello",
+        "span",
         {
           "$": {
             "html": 1,
@@ -37,13 +37,11 @@
 ## HTML
 
 ```html
-<p>
-  <hello>Hello <strong>World</strong></hello>
-</p>
+<p><span>Hello <strong>World</strong></span></p>
 ```
 
 ## Markdown
 
 ```md
-<hello>Hello **World**</hello>
+<span>Hello **World**</span>
 ```

--- a/packages/comark/SPEC/common-mark/horizontal-rule-3-.md
+++ b/packages/comark/SPEC/common-mark/horizontal-rule-3-.md
@@ -30,7 +30,7 @@ Paragraph
 
 ```html
 <p>Paragraph</p>
-<hr />
+<hr>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/horizontal-rule-3-asterisk.md
+++ b/packages/comark/SPEC/common-mark/horizontal-rule-3-asterisk.md
@@ -22,7 +22,7 @@
 ## HTML
 
 ```html
-<hr />
+<hr>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/horizontal-rule-bare.md
+++ b/packages/comark/SPEC/common-mark/horizontal-rule-bare.md
@@ -22,7 +22,7 @@
 ## HTML
 
 ```html
-<hr />
+<hr>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/horizontal-rule-more-.md
+++ b/packages/comark/SPEC/common-mark/horizontal-rule-more-.md
@@ -30,7 +30,7 @@ Paragraph
 
 ```html
 <p>Paragraph</p>
-<hr />
+<hr>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/html-block-void-br.md
+++ b/packages/comark/SPEC/common-mark/html-block-void-br.md
@@ -36,14 +36,14 @@
 ## HTML
 
 ```html
-<br />
+<br>
 <h1 id="after-br">After br</h1>
 ```
 
 ## Markdown
 
 ```md
-<br />
+<br>
 
 # After br
 ```

--- a/packages/comark/SPEC/common-mark/html-block-void-element.md
+++ b/packages/comark/SPEC/common-mark/html-block-void-element.md
@@ -1,7 +1,7 @@
 ## Input
 
 ```md
-<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner">
 
 # comark
 
@@ -46,7 +46,7 @@ A high-performance markdown parser and renderer.
 ## HTML
 
 ```html
-<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner">
 <h1 id="comark">comark</h1>
 <p>A high-performance markdown parser and renderer.</p>
 ```
@@ -54,7 +54,7 @@ A high-performance markdown parser and renderer.
 ## Markdown
 
 ```md
-<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner" />
+<img src="https://github.com/comarkdown/comark/blob/main/assets/banner.jpg" width="100%" alt="Comark banner">
 
 # comark
 

--- a/packages/comark/SPEC/common-mark/image-title.md
+++ b/packages/comark/SPEC/common-mark/image-title.md
@@ -30,7 +30,7 @@
 ## HTML
 
 ```html
-<p><img src="https://example.com/image.jpg" title="title" alt="alt" /></p>
+<p><img src="https://example.com/image.jpg" title="title" alt="alt"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/line-break.md
+++ b/packages/comark/SPEC/common-mark/line-break.md
@@ -29,7 +29,7 @@ World
 ## HTML
 
 ```html
-<p>Hello<br />World</p>
+<p>Hello<br>World</p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/links.md
+++ b/packages/comark/SPEC/common-mark/links.md
@@ -11,55 +11,44 @@
 ## AST
 
 ```json
-
 {
-   "frontmatter":{
-      
-   },
-   "meta":{
-      
-   },
-   "nodes":[
+  "frontmatter": {},
+  "meta": {},
+  "nodes": [
+    [
+      "p",
+      {},
       [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"#"
-            },
-            "Document"
-         ]
-      ],
-      [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"#"
-            },
-            "[1] Document"
-         ]
-      ],
-      [
-         "p",
-         {
-            
-         },
-         [
-            "a",
-            {
-               "href":"https://example.com"
-            },
-            "[link-name] more"
-         ]
+        "a",
+        {
+          "href": "#"
+        },
+        "Document"
       ]
-   ]
+    ],
+    [
+      "p",
+      {},
+      [
+        "a",
+        {
+          "href": "#"
+        },
+        "[1] Document"
+      ]
+    ],
+    [
+      "p",
+      {},
+      [
+        "a",
+        {
+          "href": "https://example.com"
+        },
+        "[link-name] more"
+      ]
+    ]
+  ]
 }
 ```
 

--- a/packages/comark/SPEC/common-mark/paragraph-image.md
+++ b/packages/comark/SPEC/common-mark/paragraph-image.md
@@ -30,7 +30,7 @@
 ## HTML
 
 ```html
-<p><img src="/assets/images/san-juan-mountains.jpg" title="San Juan Mountains" alt="The San Juan Mountains are beautiful" /></p>
+<p><img src="/assets/images/san-juan-mountains.jpg" title="San Juan Mountains" alt="The San Juan Mountains are beautiful"></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/paragraph-link-image.md
+++ b/packages/comark/SPEC/common-mark/paragraph-link-image.md
@@ -36,7 +36,7 @@
 ## HTML
 
 ```html
-<p><a href="/link"><img src="/assets/images/shiprock.jpg" title="Shiprock, New Mexico by Beau Rogers" alt="An old rock in the desert" /></a></p>
+<p><a href="/link"><img src="/assets/images/shiprock.jpg" title="Shiprock, New Mexico by Beau Rogers" alt="An old rock in the desert"></a></p>
 ```
 
 ## Markdown

--- a/packages/comark/SPEC/common-mark/paragraph-multiple.md
+++ b/packages/comark/SPEC/common-mark/paragraph-multiple.md
@@ -36,7 +36,7 @@ This is another paragraph
 ## HTML
 
 ```html
-<p>This is a simple paragraph<br />And continues in next line</p>
+<p>This is a simple paragraph<br>And continues in next line</p>
 <p>This is another paragraph</p>
 ```
 

--- a/packages/comark/SPEC/common-mark/xyz.md
+++ b/packages/comark/SPEC/common-mark/xyz.md
@@ -313,7 +313,7 @@ And here's a code block:
 </ol>
 <h2 id="section-two">Section Two</h2>
 <p>Here's an image:</p>
-<p><img src="/path/to/image.jpg" title="Image title" alt="Alt text" /></p>
+<p><img src="/path/to/image.jpg" title="Image title" alt="Alt text"></p>
 <p>And here's a code block:</p>
 ```
 

--- a/packages/comark/SPEC/markdown-directive/directive-no-content.md
+++ b/packages/comark/SPEC/markdown-directive/directive-no-content.md
@@ -58,10 +58,10 @@ a :br with no content or attributes
 ```html
 <p>
   a 
-  <hr />
+  <hr>
    directive with no content
 </p>
-<p>a <br /> with no content or attributes</p>
+<p>a <br> with no content or attributes</p>
 <video file="movie.mp4"></video>
 <separator></separator>
 ```

--- a/packages/comark/src/internal/stringify/handlers/html.ts
+++ b/packages/comark/src/internal/stringify/handlers/html.ts
@@ -102,7 +102,7 @@ export async function html(node: ElementNode, state: State, parent?: ElementNode
   const attrs = Object.keys(attributes).length > 0 ? ` ${htmlAttributes(attributes)}` : ''
 
   if (isSelfClose) {
-    return `<${tag}${attrs} />` + (!parent && !isInline ? state.context.blockSeparator : '')
+    return `<${tag}${attrs}>` + (!parent && !isInline ? state.context.blockSeparator : '')
   }
 
   if (!oneLiner && content) {


### PR DESCRIPTION
### What

Emit **HTML5 void tags** instead of XHTML-style self-closing tags when stringifying to HTML.

### Why

Comark’s HTML stringify was still emitting the XHTML form. This aligns output with HTML5 and with how those tags look in real HTML documents / CommonMark-style HTML expectations.

<!--

AGENTS:
- The What and Why should each be 1-3 sentences.
- Write your answers based off of your conversation with the user, not purely based on the changed code
  - It's helpful to understand the reasoning behind an approach, what alternatives were considered, and why this approach was ultimately selected, rather than a summary of the lines changed
- For complex changes (>1k lines, not counting lockfiles):
  - Add a `### Walkthrough` section to the end which breaks down the primary changes into easy-to-follow `#### Sub-Sections`
-->
