### PR TITLE
fix(parse): build heading ids from text content only

### DIFF
--- a/packages/comark/SPEC/COMARK/codeblock-filename-highlight-lines.md
+++ b/packages/comark/SPEC/COMARK/codeblock-filename-highlight-lines.md
@@ -42,7 +42,7 @@ function hello() {
 ## HTML
 
 ```html
-<pre language="javascript" filename="@[...slug].ts" highlights="[1,2,3]" meta="meta=meta-value"><code class="language-javascript">function hello() {
+<pre language="javascript" highlights="[1,2,3]" filename="@[...slug].ts" meta="meta=meta-value"><code class="language-javascript">function hello() {
   console.log("Hello, World!");
 }</code></pre>
 ```

--- a/packages/comark/SPEC/COMARK/inline-component.md
+++ b/packages/comark/SPEC/COMARK/inline-component.md
@@ -48,7 +48,7 @@ Paragraph with :inline-component in middle
     [
       "h2",
       {
-        "id": "a-inline-inside-heading"
+        "id": "a-inside-heading"
       },
       "a ",
       [
@@ -73,7 +73,7 @@ Paragraph with :inline-component in middle
 <p>
   Paragraph with <inline-component></inline-component> in middle
 </p>
-<h2 id="a-inline-inside-heading">
+<h2 id="a-inside-heading">
   a <inline></inline> inside heading
 </h2>
 ```

--- a/packages/comark/SPEC/plugins-binding/binding-heading.md
+++ b/packages/comark/SPEC/plugins-binding/binding-heading.md
@@ -26,7 +26,7 @@ name: Ada
     [
       "h2",
       {
-        "id": "hello-binding"
+        "id": "hello"
       },
       "Hello ",
       [
@@ -43,7 +43,7 @@ name: Ada
 ## HTML
 
 ```html
-<h2 id="hello-binding">
+<h2 id="hello">
   Hello Ada
 </h2>
 ```

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -1,4 +1,5 @@
 import type { ElementNode, Node } from 'comark'
+import { textContent } from 'comark/utils'
 import { htmlToNodes, parseInlineHtmlTag } from './html/index.ts'
 
 // `::tag` components that should fold into a single same-tagged child.
@@ -158,27 +159,23 @@ function processAttributes(
 // Upper bound for expanded highlight ranges in a fence info string.
 const MAX_HIGHLIGHT_LINES = 1_000
 
+interface CodeBlockInfo extends Record<string, unknown> {
+  language?: string
+  filename?: string
+  highlights?: number[]
+  meta?: string
+}
 /**
  * Parse codeblock info string to extract language, highlights, filename, and meta
  * Example: "javascript {1-3} [filename.ts] meta=value"
  * Example: "typescript[filename]{1,3-5}meta"
  */
-function parseCodeblockInfo(info: string): {
-  language: string
-  filename?: string
-  highlights?: number[]
-  meta?: string
-} {
+function parseCodeblockInfo(info: string): CodeBlockInfo {
   if (!info) {
-    return { language: '' }
+    return { }
   }
 
-  const result: {
-    language: string
-    filename?: string
-    highlights?: number[]
-    meta?: string
-  } = { language: '' }
+  const result: CodeBlockInfo = { }
 
   let remaining = info.trim()
 
@@ -384,23 +381,10 @@ function processBlockToken(
     const parsed = parseCodeblockInfo(info)
 
     // Build pre attributes
-    const preAttrs: Record<string, unknown> = {}
-    if (parsed.language && parsed.language.trim()) {
-      preAttrs.language = parsed.language
-    }
-    if (parsed.filename) {
-      preAttrs.filename = parsed.filename
-    }
-    if (parsed.highlights) {
-      preAttrs.highlights = parsed.highlights
-    }
-    if (parsed.meta) {
-      preAttrs.meta = parsed.meta
-    }
-
-    // Build code attributes
+    const preAttrs: Record<string, unknown> = parsed
     const codeAttrs: Record<string, unknown> = {}
     if (parsed.language && parsed.language.trim()) {
+      preAttrs.language = parsed.language
       codeAttrs['class'] = `language-${parsed.language}`
     }
 
@@ -427,8 +411,8 @@ function processBlockToken(
     if (children.nodes.length > 0) {
       let attrs: Record<string, unknown>
       if (state?.headingIds) {
-        const textContent = extractTextContent(children.nodes)
-        const headingId = uniqueSlug(slugify(textContent), level, state)
+        const text = children.nodes.map(n => textContent(n)).join('')
+        const headingId = uniqueSlug(slugify(text), level, state)
         // Merge user-supplied attrs with the auto-generated id; user `id` wins.
         attrs = { id: headingId, ...userAttrs }
       } else {
@@ -634,73 +618,6 @@ function mergeAdjacentTextNodes(nodes: Node[]): Node[] {
   }
 
   return merged
-}
-
-const HTML_INLINE_TAGS = new Set([
-  'a',
-  'abbr',
-  'b',
-  'bdi',
-  'bdo',
-  'cite',
-  'code',
-  'data',
-  'del',
-  'dfn',
-  'em',
-  'i',
-  'img',
-  'ins',
-  'kbd',
-  'mark',
-  'q',
-  'rp',
-  'rt',
-  'ruby',
-  's',
-  'samp',
-  'small',
-  'span',
-  'strong',
-  'sub',
-  'sup',
-  'time',
-  'u',
-  'var',
-  'wbr',
-])
-
-/**
- * Extract text content from nodes for heading ID generation
- */
-function extractTextContent(nodes: Node[]): string {
-  let text = ''
-
-  for (const node of nodes) {
-    if (typeof node === 'string') {
-      text += node
-    } else if (Array.isArray(node)) {
-      // For array nodes (elements), include the tag name (for inline components)
-      const tag = node[0]
-      const children = node.slice(2) as Node[]
-
-      // Skip 'br' and 'html_inline' tags
-      if (tag === 'br' || tag === 'html_inline') {
-        continue
-      }
-
-      // Only inline components contribute their name to the slug; standard
-      // HTML tags (emphasis, code, links, ...) contribute text content only
-      if (typeof tag === 'string' && !HTML_INLINE_TAGS.has(tag)) {
-        text += ' ' + tag + ' '
-      }
-      if (children.length > 0) {
-        text += extractTextContent(children)
-      }
-    }
-  }
-
-  return text
 }
 
 /**

--- a/packages/comark/src/internal/parse/token-processor.ts
+++ b/packages/comark/src/internal/parse/token-processor.ts
@@ -172,10 +172,10 @@ interface CodeBlockInfo extends Record<string, unknown> {
  */
 function parseCodeblockInfo(info: string): CodeBlockInfo {
   if (!info) {
-    return { }
+    return {}
   }
 
-  const result: CodeBlockInfo = { }
+  const result: CodeBlockInfo = {}
 
   let remaining = info.trim()
 
@@ -411,7 +411,7 @@ function processBlockToken(
     if (children.nodes.length > 0) {
       let attrs: Record<string, unknown>
       if (state?.headingIds) {
-        const text = children.nodes.map(n => textContent(n)).join('')
+        const text = children.nodes.map((n) => textContent(n)).join('')
         const headingId = uniqueSlug(slugify(text), level, state)
         // Merge user-supplied attrs with the auto-generated id; user `id` wins.
         attrs = { id: headingId, ...userAttrs }

--- a/packages/comark/test/heading-ids.test.ts
+++ b/packages/comark/test/heading-ids.test.ts
@@ -55,10 +55,10 @@ describe('headingIds option', () => {
       expect((tree.nodes[0] as any)[1].id).toBe('see-nuxt-docs')
     })
 
-    it('includes inline component names in the slug', async () => {
+    it('does not include inline component names in the slug', async () => {
       const tree = await parseMarkdown('## Star :icon-star here')
 
-      expect((tree.nodes[0] as any)[1].id).toBe('star-icon-star-here')
+      expect((tree.nodes[0] as any)[1].id).toBe('star-here')
     })
   })
 })

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -67,7 +67,7 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/react": "36.9k (74 files)",
         "@comark/svelte": "43.9k (82 files)",
         "@comark/vue": "51.7k (78 files)",
-        "comark": "366k (158 files)",
+        "comark": "364k (158 files)",
       }
     `)
   })


### PR DESCRIPTION
### What

Heading slugs now come from visible text only via shared `textContent()`, so empty inline components and bindings no longer leak their tag names into auto-generated ids. Fence info attributes keep the order they appear in the info string instead of a fixed language → filename → highlights → meta order.

### Why

Slugs like `a-inline-inside-heading` or `hello-binding` were unstable for headings that include empty components or data bindings, and they mixed implementation tag names into anchor ids. Using plain text content matches the existing bold/code/link behavior and produces predictable anchors. The fence attr-order tweak is a side effect of assigning parsed info directly as `pre` attrs and is covered by the updated SPEC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Heading IDs now omit inline component names, producing cleaner and more consistent links.
  - Binding plugin headings now generate simplified heading IDs.
  - Empty code block metadata no longer produces an empty language attribute.
  - Code block HTML attributes now follow the documented order.
  - Published package size is now reported as 364k across 158 files.

- **Documentation**
  - Updated code block and heading examples to reflect the current rendered HTML and generated IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->