### PR TITLE
fix(vue): accept a parsed document in a defined component

### DIFF
--- a/packages/comark-angular/src/components/markdown.component.ts
+++ b/packages/comark-angular/src/components/markdown.component.ts
@@ -44,7 +44,7 @@ export class Markdown implements OnChanges {
   @Input() value?: string | MarkdownDocumentType
 
   /** Parser options (excluding plugins) */
-  @Input() options: Exclude<ParserOptions, 'plugins'> = {}
+  @Input() options: Omit<ParserOptions, 'plugins'> = {}
 
   /** Additional plugins to use */
   @Input() plugins: ParserOptions['plugins'] = []

--- a/packages/comark-react/src/components/Markdown.tsx
+++ b/packages/comark-react/src/components/Markdown.tsx
@@ -19,7 +19,7 @@ export interface MarkdownProps {
   /**
    * Parser options (excluding plugins)
    */
-  options?: Exclude<ParserOptions, 'plugins'>
+  options?: Omit<ParserOptions, 'plugins'>
 
   /**
    * Additional plugins to use

--- a/packages/comark-react/src/index.ts
+++ b/packages/comark-react/src/index.ts
@@ -60,7 +60,7 @@ export function defineMarkdownComponent(config: DefineMarkdownComponentOptions =
   } = config
 
   const MarkdownComponent: React.FC<MarkdownProps> = (props) => {
-    const mergedOptions: Exclude<ParserOptions, 'plugins'> = {
+    const mergedOptions: Omit<ParserOptions, 'plugins'> = {
       ...parseOptions,
       ...props.options,
     }

--- a/packages/comark-svelte/src/types.ts
+++ b/packages/comark-svelte/src/types.ts
@@ -37,7 +37,7 @@ export interface MarkdownDocumentProps {
 export interface MarkdownProps {
   /** The markdown content to parse and render, or a pre-parsed MarkdownDocument */
   value?: string | MarkdownDocument
-  options?: Exclude<ParserOptions, 'plugins'>
+  options?: Omit<ParserOptions, 'plugins'>
   plugins?: ComarkPlugin[]
   /**
    * Strip wrapper tags from the top level of the document — shorthand for

--- a/packages/comark-vue/src/components/Markdown.ts
+++ b/packages/comark-vue/src/components/Markdown.ts
@@ -17,7 +17,7 @@ export interface MarkdownProps {
   /**
    * Parser options (excluding plugins)
    */
-  options?: Exclude<ParserOptions, 'plugins'>
+  options?: Omit<ParserOptions, 'plugins'>
 
   /**
    * Additional plugins to use
@@ -61,9 +61,116 @@ export interface MarkdownProps {
    * Additional data to pass to the renderer
    */
   data?: Record<string, unknown>
+
+  /**
+   * Document key used to subscribe to live updates via `globalThis.comarkContext`
+   */
+  documentKey?: string
 }
 
 type MarkdownComponent = ReturnType<typeof defineComponent<MarkdownProps>>
+
+/**
+ * Runtime prop declarations for `<Markdown>`.
+ *
+ * Exported so `defineMarkdownComponent` can reuse them verbatim instead of
+ * hand-copying the table, which had drifted: `value` was declared `String`
+ * only, and `data` and `documentKey` were missing entirely.
+ */
+export const markdownProps = {
+  /**
+   * The markdown content to parse and render, or a pre-parsed MarkdownDocument
+   */
+  value: {
+    type: [String, Object] as PropType<string | MarkdownDocumentType>,
+    default: undefined,
+  },
+
+  /**
+   * Parser options
+   */
+  options: {
+    type: Object as PropType<Omit<ParserOptions, 'plugins'>>,
+    default: () => ({}),
+  },
+
+  /**
+   * Additional plugins to use
+   */
+  plugins: {
+    type: Array as PropType<ParserOptions['plugins']>,
+    default: () => [],
+  },
+
+  /**
+   * Strip wrapper tags from the top level of the document — shorthand for
+   * `options.unwrap`. `true` unwraps `<p>`; a space-separated string or array
+   * unwraps the listed tags.
+   */
+  unwrap: {
+    type: [Boolean, String, Array] as PropType<boolean | string | string[]>,
+    default: false,
+  },
+
+  /**
+   * Custom component mappings for element tags
+   * Key: tag name (e.g., 'h1', 'p', 'MyComponent')
+   * Value: Vue component
+   */
+  components: {
+    type: Object as PropType<Record<string, any>>,
+    default: () => ({}),
+  },
+
+  /**
+   * Dynamic component resolver function
+   * Used to resolve components that aren't in the components map
+   */
+  componentsManifest: {
+    type: Function as PropType<ComponentManifest>,
+    default: undefined,
+  },
+
+  /**
+   * Enable streaming mode with stream-specific components
+   */
+  streaming: {
+    type: Boolean as PropType<boolean>,
+    default: false,
+  },
+
+  /**
+   * If document has a <!-- more --> comment, only render the content before the comment
+   */
+  summary: {
+    type: Boolean as PropType<boolean>,
+    default: false,
+  },
+
+  /**
+   * If caret is true, a caret will be appended to the document's last text node
+   */
+  caret: {
+    type: [Boolean, Object] as PropType<boolean | { class: string }>,
+    default: false,
+  },
+
+  /**
+   * Additional data to pass to the renderer
+   */
+  data: {
+    type: Object as PropType<Record<string, unknown>>,
+    default: () => ({}),
+  },
+
+  /**
+   * Document key used to subscribe to live updates via `globalThis.comarkContext`
+   */
+  documentKey: {
+    type: String as PropType<string>,
+    default: undefined,
+  },
+} as const
 
 /**
  * Markdown component
@@ -100,92 +207,7 @@ type MarkdownComponent = ReturnType<typeof defineComponent<MarkdownProps>>
 export const Markdown: MarkdownComponent = defineComponent({
   name: 'Markdown',
 
-  props: {
-    /**
-     * The markdown content to parse and render, or a pre-parsed MarkdownDocument
-     */
-    value: {
-      type: [String, Object] as PropType<string | MarkdownDocumentType>,
-      default: undefined,
-    },
-
-    /**
-     * Parser options
-     */
-    options: {
-      type: Object as PropType<Exclude<ParserOptions, 'plugins'>>,
-      default: () => ({}),
-    },
-
-    /**
-     * Additional plugins to use
-     */
-    plugins: {
-      type: Array as PropType<ParserOptions['plugins']>,
-      default: () => [],
-    },
-
-    /**
-     * Strip wrapper tags from the top level of the document — shorthand for
-     * `options.unwrap`. `true` unwraps `<p>`; a space-separated string or array
-     * unwraps the listed tags.
-     */
-    unwrap: {
-      type: [Boolean, String, Array] as PropType<boolean | string | string[]>,
-      default: false,
-    },
-
-    /**
-     * Custom component mappings for element tags
-     * Key: tag name (e.g., 'h1', 'p', 'MyComponent')
-     * Value: Vue component
-     */
-    components: {
-      type: Object as PropType<Record<string, any>>,
-      default: () => ({}),
-    },
-
-    /**
-     * Dynamic component resolver function
-     * Used to resolve components that aren't in the components map
-     */
-    componentsManifest: {
-      type: Function as PropType<ComponentManifest>,
-      default: undefined,
-    },
-
-    /**
-     * Enable streaming mode with stream-specific components
-     */
-    streaming: {
-      type: Boolean as PropType<boolean>,
-      default: false,
-    },
-
-    /**
-     * If document has a <!-- more --> comment, only render the content before the comment
-     */
-    summary: {
-      type: Boolean as PropType<boolean>,
-      default: false,
-    },
-
-    /**
-     * If caret is true, a caret will be appended to the document's last text node
-     */
-    caret: {
-      type: [Boolean, Object] as PropType<boolean | { class: string }>,
-      default: false,
-    },
-
-    /**
-     * Additional data to pass to the renderer
-     */
-    data: {
-      type: Object as PropType<Record<string, unknown>>,
-      default: () => ({}),
-    },
-  },
+  props: markdownProps,
 
   async setup(props, ctx) {
     const markdown = computed(() => {
@@ -234,6 +256,7 @@ export const Markdown: MarkdownComponent = defineComponent({
           class: props.streaming ? 'comark-stream' : '',
           caret: props.caret,
           data: props.data,
+          documentKey: props.documentKey,
         })
       }
 
@@ -246,6 +269,7 @@ export const Markdown: MarkdownComponent = defineComponent({
         class: props.streaming ? 'comark-stream' : '',
         caret: props.caret,
         data: props.data,
+        documentKey: props.documentKey,
       })
     }
   },

--- a/packages/comark-vue/src/components/MarkdownDocument.ts
+++ b/packages/comark-vue/src/components/MarkdownDocument.ts
@@ -281,6 +281,75 @@ export interface MarkdownDocumentProps {
 type MarkdownDocumentComponent = ReturnType<typeof defineComponent<MarkdownDocumentProps>>
 
 /**
+ * Runtime prop declarations for `<MarkdownDocument>`.
+ *
+ * Exported so `defineMarkdownDocumentComponent` can reuse them verbatim
+ * instead of hand-copying the table, which was missing `data` and
+ * `documentKey`.
+ */
+export const markdownDocumentProps = {
+  /**
+   * The parsed Markdown document to render
+   */
+  value: {
+    type: Object as PropType<MarkdownDocumentType | { nodes: MarkdownDocumentType['nodes'] }>,
+    default: undefined,
+  },
+
+  /**
+   * Custom component mappings for element tags
+   * Key: tag name (e.g., 'h1', 'p', 'MyComponent')
+   * Value: Vue component
+   */
+  components: {
+    type: Object as PropType<Record<string, any>>,
+    default: () => ({}),
+  },
+
+  /**
+   * Dynamic component resolver function
+   * Used to resolve components that aren't in the components map
+   */
+  componentsManifest: {
+    type: Function as PropType<ComponentManifest>,
+    default: undefined,
+  },
+
+  /**
+   * Enable streaming mode with stream-specific components
+   */
+  streaming: {
+    type: Boolean as PropType<boolean>,
+    default: false,
+  },
+
+  /**
+   * If caret is true, a caret will be appended to the document's last text node
+   * If caret is an object, it will be appended with the given class
+   */
+  caret: {
+    type: [Boolean, Object] as PropType<boolean | { class: string }>,
+    default: false,
+  },
+
+  /**
+   * Additional data to pass to the renderer
+   */
+  data: {
+    type: Object as PropType<Record<string, unknown>>,
+    default: () => ({}),
+  },
+
+  /**
+   * Document key used to subscribe to live updates via `globalThis.comarkContext`
+   */
+  documentKey: {
+    type: String as PropType<string>,
+    default: undefined,
+  },
+} as const
+
+/**
  * MarkdownDocument component
  *
  * Renders an already-parsed Markdown document to Vue components/HTML — no parser
@@ -308,67 +377,7 @@ type MarkdownDocumentComponent = ReturnType<typeof defineComponent<MarkdownDocum
 export const MarkdownDocument: MarkdownDocumentComponent = defineComponent({
   name: 'MarkdownDocument',
 
-  props: {
-    /**
-     * The parsed Markdown document to render
-     */
-    value: {
-      type: Object as PropType<MarkdownDocumentType | { nodes: MarkdownDocumentType['nodes'] }>,
-      default: undefined,
-    },
-
-    /**
-     * Custom component mappings for element tags
-     * Key: tag name (e.g., 'h1', 'p', 'MyComponent')
-     * Value: Vue component
-     */
-    components: {
-      type: Object as PropType<Record<string, any>>,
-      default: () => ({}),
-    },
-
-    /**
-     * Dynamic component resolver function
-     * Used to resolve components that aren't in the components map
-     */
-    componentsManifest: {
-      type: Function as PropType<ComponentManifest>,
-      default: undefined,
-    },
-
-    /**
-     * Enable streaming mode with stream-specific components
-     */
-    streaming: {
-      type: Boolean as PropType<boolean>,
-      default: false,
-    },
-
-    /**
-     * If caret is true, a caret will be appended to the document's last text node
-     * If caret is an object, it will be appended with the given class
-     */
-    caret: {
-      type: [Boolean, Object] as PropType<boolean | { class: string }>,
-      default: false,
-    },
-
-    /**
-     * Additional data to pass to the renderer
-     */
-    data: {
-      type: Object as PropType<Record<string, unknown>>,
-      default: () => ({}),
-    },
-
-    /**
-     * Document key used to subscribe to live updates via `globalThis.comarkContext`
-     */
-    documentKey: {
-      type: String as PropType<string>,
-      default: undefined,
-    },
-  },
+  props: markdownDocumentProps,
 
   async setup(props) {
     const inputDocument = computed(

--- a/packages/comark-vue/src/index.ts
+++ b/packages/comark-vue/src/index.ts
@@ -1,7 +1,6 @@
-import type { PropType } from 'vue'
 import { computed, defineComponent, h } from 'vue'
 import { Markdown, markdownProps } from './components/Markdown.ts'
-import type { MarkdownDocument as MarkdownDocumentType, ComponentManifest, ParserOptions } from 'comark'
+import type { ParserOptions } from 'comark'
 import { MarkdownDocument, markdownDocumentProps } from './components/MarkdownDocument.ts'
 
 export { Markdown } from './components/Markdown.ts'

--- a/packages/comark-vue/src/index.ts
+++ b/packages/comark-vue/src/index.ts
@@ -1,8 +1,8 @@
 import type { PropType } from 'vue'
 import { computed, defineComponent, h } from 'vue'
-import { Markdown } from './components/Markdown.ts'
+import { Markdown, markdownProps } from './components/Markdown.ts'
 import type { MarkdownDocument as MarkdownDocumentType, ComponentManifest, ParserOptions } from 'comark'
-import { MarkdownDocument } from './components/MarkdownDocument.ts'
+import { MarkdownDocument, markdownDocumentProps } from './components/MarkdownDocument.ts'
 
 export { Markdown } from './components/Markdown.ts'
 export type { MarkdownProps } from './components/Markdown.ts'
@@ -36,84 +36,7 @@ export function defineMarkdownComponent(config: DefineMarkdownComponentOptions =
 
   return defineComponent({
     name: name ?? 'MarkdownComponent',
-    props: {
-      /**
-       * The markdown content to parse and render
-       */
-      value: {
-        type: String as PropType<string>,
-        default: undefined,
-      },
-
-      /**
-       * Parser options
-       */
-      options: {
-        type: Object as PropType<Exclude<ParserOptions, 'plugins'>>,
-        default: () => ({}),
-      },
-
-      /**
-       * Additional plugins to use
-       */
-      plugins: {
-        type: Array as PropType<ParserOptions['plugins']>,
-        default: () => [],
-      },
-
-      /**
-       * Strip wrapper tags from the top level of the document — shorthand for
-       * `options.unwrap`. `true` unwraps `<p>`; a space-separated string or
-       * array unwraps the listed tags.
-       */
-      unwrap: {
-        type: [Boolean, String, Array] as PropType<boolean | string | string[]>,
-        default: false,
-      },
-
-      /**
-       * Custom component mappings for element tags
-       * Key: tag name (e.g., 'h1', 'p', 'MyComponent')
-       * Value: Vue component
-       */
-      components: {
-        type: Object as PropType<Record<string, any>>,
-        default: () => ({}),
-      },
-
-      /**
-       * Dynamic component resolver function
-       * Used to resolve components that aren't in the components map
-       */
-      componentsManifest: {
-        type: Function as PropType<ComponentManifest>,
-        default: undefined,
-      },
-
-      /**
-       * Enable streaming mode with stream-specific components
-       */
-      streaming: {
-        type: Boolean as PropType<boolean>,
-        default: false,
-      },
-
-      /**
-       * If document has a <!-- more --> comment, only render the content before the comment
-       */
-      summary: {
-        type: Boolean as PropType<boolean>,
-        default: false,
-      },
-
-      /**
-       * If caret is true, a caret will be appended to the document's last text node
-       */
-      caret: {
-        type: [Boolean, Object] as PropType<boolean | { class: string }>,
-        default: false,
-      },
-    },
+    props: markdownProps,
     setup(props, { slots }) {
       const options = computed(() => ({
         ...parseOptions,
@@ -129,18 +52,15 @@ export function defineMarkdownComponent(config: DefineMarkdownComponentOptions =
 
       return () => {
         const component = config.extends || Markdown
+        // Spread rather than list every prop: the hand-written list had drifted
+        // from `<Markdown>` three times, dropping `data` and `documentKey`.
         return h(
           component,
           {
-            value: props.value,
+            ...props,
             options: options.value,
             plugins: plugins.value,
-            unwrap: props.unwrap,
             components: components.value,
-            componentsManifest: props.componentsManifest,
-            streaming: props.streaming,
-            summary: props.summary,
-            caret: props.caret,
             class: config.class,
           },
           {
@@ -155,50 +75,7 @@ export function defineMarkdownComponent(config: DefineMarkdownComponentOptions =
 export function defineMarkdownDocumentComponent(config: DefineMarkdownDocumentOptions = {}): typeof MarkdownDocument {
   return defineComponent({
     name: config.name ?? 'MarkdownDocumentComponent',
-    props: {
-      /**
-       * The parsed Markdown document to render
-       */
-      value: {
-        type: Object as PropType<MarkdownDocumentType>,
-        default: undefined,
-      },
-
-      /**
-       * Custom component mappings for element tags
-       * Key: tag name (e.g., 'h1', 'p', 'MyComponent')
-       * Value: Vue component
-       */
-      components: {
-        type: Object as PropType<Record<string, any>>,
-        default: () => ({}),
-      },
-
-      /**
-       * Dynamic component resolver function
-       * Used to resolve components that aren't in the components map
-       */
-      componentsManifest: {
-        type: Function as PropType<ComponentManifest>,
-        default: undefined,
-      },
-
-      /**
-       * Enable streaming mode with stream-specific components
-       */
-      streaming: {
-        type: Boolean as PropType<boolean>,
-        default: false,
-      },
-
-      /**
-       * If caret is true, a caret will be appended to the document's last text node
-       */
-      caret: {
-        type: [Boolean, Object] as PropType<boolean | { class: string }>,
-        default: false,
-      },
-    },
+    props: markdownDocumentProps,
     setup(props, { slots }) {
       const components = computed(() => ({
         ...config.components,
@@ -210,11 +87,8 @@ export function defineMarkdownDocumentComponent(config: DefineMarkdownDocumentOp
         return h(
           component,
           {
-            value: props.value,
+            ...props,
             components: components.value,
-            componentsManifest: props.componentsManifest,
-            streaming: props.streaming,
-            caret: props.caret,
             class: config.class,
           },
           {

--- a/packages/comark-vue/test/define-component-props.test.ts
+++ b/packages/comark-vue/test/define-component-props.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { parseMarkdown } from 'comark'
+import { defineMarkdownComponent, defineMarkdownDocumentComponent } from '../src/index'
+
+async function render(component: any, props: Record<string, any> = {}) {
+  const app = createSSRApp({
+    setup() {
+      return () => h(component, props)
+    },
+  })
+  return renderToString(app as any)
+}
+
+describe('defineMarkdownComponent props', () => {
+  it('accepts a pre-parsed document without a type warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const Custom = defineMarkdownComponent({ name: 'Custom' })
+    const document = await parseMarkdown('Hello **world**')
+
+    const html = await render(Custom, { value: document })
+
+    expect(html).toContain('<strong>world</strong>')
+    const typeWarnings = warn.mock.calls.filter((call) => String(call[0]).includes('type check failed'))
+    expect(typeWarnings).toEqual([])
+    warn.mockRestore()
+  })
+
+  it('still renders a string value', async () => {
+    const Custom = defineMarkdownComponent({ name: 'Custom' })
+    expect(await render(Custom, { value: 'Hello **world**' })).toContain('<strong>world</strong>')
+  })
+
+  it('forwards data to the renderer', async () => {
+    const Custom = defineMarkdownComponent({ name: 'Custom' })
+    const html = await render(Custom, {
+      value: 'Value is :span{:text="data.answer"}',
+      data: { answer: '42' },
+    })
+    expect(html).toContain('42')
+  })
+
+  it('forwards documentKey through to MarkdownDocument', async () => {
+    const Custom = defineMarkdownComponent({ name: 'Custom' })
+    // The prop must be declared, otherwise it silently falls through as an attr.
+    expect(Object.keys((Custom as any).props)).toContain('documentKey')
+    expect(await render(Custom, { value: 'Hi', documentKey: 'doc-1' })).toContain('Hi')
+  })
+
+  it('keeps config options and per-instance options merged', async () => {
+    const Custom = defineMarkdownComponent({ name: 'Custom', unwrap: 'p' })
+    const html = await render(Custom, { value: 'Hello **world**' })
+    expect(html).not.toContain('<p>')
+    expect(html).toContain('<strong>world</strong>')
+  })
+})
+
+describe('defineMarkdownDocumentComponent props', () => {
+  it('forwards data and documentKey', async () => {
+    const Custom = defineMarkdownDocumentComponent({ name: 'CustomDocument' })
+    expect(Object.keys((Custom as any).props)).toContain('data')
+    expect(Object.keys((Custom as any).props)).toContain('documentKey')
+
+    const document = await parseMarkdown('Value is :span{:text="data.answer"}')
+    const html = await render(Custom, { value: document, data: { answer: '42' } })
+    expect(html).toContain('42')
+  })
+})

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -64,9 +64,9 @@ describe('package bundle size', { timeout: 60_000 }, () => {
         "@comark/ansi": "36.6k (98 files)",
         "@comark/html": "15.7k (58 files)",
         "@comark/nuxt": "11.8k (58 files)",
-        "@comark/react": "36.9k (74 files)",
+        "@comark/react": "36.8k (74 files)",
         "@comark/svelte": "43.9k (82 files)",
-        "@comark/vue": "51.7k (78 files)",
+        "@comark/vue": "54.7k (78 files)",
         "comark": "364k (158 files)",
       }
     `)


### PR DESCRIPTION
### What

`defineMarkdownComponent` and `defineMarkdownDocumentComponent` now reuse the prop tables exported by `<Markdown>` and `<MarkdownDocument>` instead of hand-copying them. That fixes the reported `Invalid prop: type check failed` warning when passing an already parsed document, plus two forwarding gaps, and makes the drift structurally impossible.

### Why

Reported from ui.nuxt.com: `<Markdown>` accepts `value: [String, Object]` and short-circuits on `isMarkdownDocument`, but the component `defineMarkdownComponent` returns declared `value: { type: String }`, so passing a parsed document warned even though it rendered correctly. The underlying cause is that the wrapper carried its own copy of the prop table, and the two had drifted three times. Fixing just `value` would leave the next drift to be found the same way.

### Walkthrough

#### One prop table

`markdownProps` and `markdownDocumentProps` are exported from the components and the wrappers use them directly. The render calls spread `props` rather than listing each one.

A React-style spread alone would not have been enough here: in Vue, spreading `props` only spreads *declared* props, so `data` and `documentKey` would still have been missed. Sharing the declaration is what actually fixes it.

#### The three gaps this closes

- `value` inherits `[String, Object]`, so a parsed document no longer warns.
- `data` is declared rather than relying on attribute fallthrough.
- `documentKey` is declared on `<Markdown>` and forwarded to `<MarkdownDocument>`, which has been waiting for it. It is what the `globalThis.comarkContext` live-update subscription reads, and it previously needed two fallthrough hops through a component that sets `class` explicitly.

Worth noting for review: `data` did already arrive via fallthrough, so only the `value` warning and `documentKey` were visibly broken. I verified that by reverting the change and watching exactly those two tests fail. `data` is pinned anyway, since fallthrough is not something to depend on.

#### `Exclude` was a no-op

`Exclude<ParserOptions, 'plugins'>` appeared in six places. `Exclude` filters union members, so on an object type it resolves to plain `ParserOptions`. `Omit` is what was meant, and it surfaces a real bug: `:options="{ plugins: [x] }"` type-checked and was then silently discarded, because the component passes `plugins: props.plugins` separately.

This is a type-level breaking change for anyone who was relying on the accident, but it only rejects code that never worked at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Vue components now support `documentKey` for live document updates.
  - Vue wrappers forward additional rendering data and document configuration consistently.

- **Bug Fixes**
  - Corrected option type handling across Angular, React, Svelte, and Vue integrations, ensuring unsupported plugin configuration is properly excluded.
  - Improved Vue rendering for pre-parsed documents and string content while preserving merged configuration options.

- **Tests**
  - Added coverage for Vue prop forwarding, document updates, and server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->